### PR TITLE
chore: add comprehensive .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,78 @@
+# Python bytecode and cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+.eggs/
+wheels/
+*.whl
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Conda
+*.conda
+conda-meta/
+
+# Testing
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.nox/
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Ruff
+.ruff_cache/
+
+# IDE / Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.spyderproject
+.spyproject
+.ropeproject
+
+# Jupyter Notebooks
+.ipynb_checkpoints/
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# OS files
+.DS_Store
+.DS_Store?
+._*
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Logs
+*.log
+logs/
+
+# Local development
+.local/
+*.local


### PR DESCRIPTION
## Summary
- Add comprehensive `.gitignore` for Python/conda project
- Cover all standard Python development artifacts
- Include tool-specific caches (mypy, ruff, pytest)

## Acceptance Criteria
- [x] Python bytecode and cache files
- [x] Virtual environment directories
- [x] Conda environment files
- [x] IDE/editor files (.vscode, .idea, etc.)
- [x] Test artifacts (.coverage, htmlcov/, .pytest_cache/)
- [x] Build artifacts (dist/, build/, *.egg-info/)
- [x] Environment files (.env, .env.local)
- [x] OS files (.DS_Store, Thumbs.db)

## Additional Coverage
- mypy cache (`.mypy_cache/`)
- Ruff cache (`.ruff_cache/`)
- Jupyter notebook checkpoints
- Log files

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)