### PR TITLE
feat: configure pytest with markers and sample tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ include = [
     "/tests",
 ]
 
-# Pytest configuration (see issue #5 for full setup)
+# Pytest configuration
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
@@ -70,6 +70,11 @@ addopts = [
     "--cov-fail-under=80",
 ]
 asyncio_mode = "auto"
+markers = [
+    "unit: Unit tests (fast, no external dependencies)",
+    "integration: Integration tests (may require external services)",
+    "data_validation: Data validation tests (verify data integrity)",
+]
 
 # Ruff configuration (see issue #7 for full setup)
 [tool.ruff]

--- a/tests/unit/test_sample.py
+++ b/tests/unit/test_sample.py
@@ -1,0 +1,27 @@
+"""Sample tests to verify pytest configuration."""
+
+import pytest
+
+import nhl_api
+
+
+@pytest.mark.unit
+def test_version_exists() -> None:
+    """Verify that the package version is defined."""
+    assert hasattr(nhl_api, "__version__")
+
+
+@pytest.mark.unit
+def test_version_format() -> None:
+    """Verify that the version follows semantic versioning format."""
+    version = nhl_api.__version__
+    parts = version.split(".")
+    assert len(parts) == 3, "Version should have 3 parts (major.minor.patch)"
+    assert all(part.isdigit() for part in parts), "Version parts should be numeric"
+
+
+@pytest.mark.unit
+def test_package_docstring() -> None:
+    """Verify that the package has a docstring."""
+    assert nhl_api.__doc__ is not None
+    assert len(nhl_api.__doc__) > 0


### PR DESCRIPTION
## Summary
- Add pytest markers (unit, integration, data_validation) to pyproject.toml
- Create sample unit tests to verify pytest configuration works
- All acceptance criteria from Issue #6 met

## Acceptance Criteria Checklist
- [x] Add pytest to dev dependencies in pyproject.toml (already present)
- [x] Add pytest-cov for coverage reporting (already present)
- [x] Configure pytest in pyproject.toml `[tool.pytest.ini_options]` (already present, updated)
- [x] Set testpaths to `tests/` (already present)
- [x] Configure markers: `unit`, `integration`, `data_validation` ✨ NEW
- [x] Set coverage threshold to 80% (already present)
- [x] Create sample test to verify setup ✨ NEW

## Test plan
- [x] Run `pytest tests/unit/test_sample.py -v` - all 3 tests pass
- [x] Run `pytest --markers` - custom markers appear
- [x] Run `pytest -m unit` - filters tests correctly
- [x] Coverage at 100% (exceeds 80% threshold)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)