### PR TITLE
Add pre-commit hooks (#7)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# Pre-commit hooks for NHL API
+# See https://pre-commit.com for more information
+
+repos:
+  # Ruff - linting and formatting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # Local hooks
+  - repo: local
+    hooks:
+      # mypy type checking
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        pass_filenames: false
+        args: ["."]
+
+      # pytest unit tests (blocks commit if tests fail)
+      - id: pytest-unit
+        name: pytest unit tests
+        entry: pytest -m unit --no-cov
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Thank you for your interest in contributing to the NHL API project. This guide c
    ```bash
    pre-commit install
    ```
-   > **Note:** Pre-commit configuration is coming soon (see [Issue #7](https://github.com/cooneycw/nhl-api/issues/7)).
+   This installs hooks for ruff (linting/formatting), mypy (type checking), and pytest (unit tests).
 
 ## Git Worktree Workflow
 
@@ -84,7 +84,12 @@ Examples:
 
 ### Pre-Commit Requirements
 
-All unit tests must pass before committing. This is enforced by pre-commit hooks (coming soon in [Issue #7](https://github.com/cooneycw/nhl-api/issues/7)).
+All unit tests must pass before committing. This is enforced by pre-commit hooks that run automatically on each commit:
+
+- **ruff**: Linting and auto-fixing
+- **ruff-format**: Code formatting
+- **mypy**: Type checking
+- **pytest**: Unit tests (commit blocked if tests fail)
 
 ## Code Quality Requirements
 


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with hooks for ruff, ruff-format, mypy, and pytest
- Update `CONTRIBUTING.md` to document the pre-commit hooks
- **Key feature:** Commits are blocked if unit tests fail

## Hooks Configured
| Hook | Purpose |
|------|---------|
| ruff | Linting with auto-fix |
| ruff-format | Code formatting |
| mypy | Type checking |
| pytest-unit | Unit tests (blocks commit) |

## Test plan
- [x] Verified `pre-commit install` works
- [x] Verified `pre-commit run --all-files` passes
- [x] Commit successfully triggered pre-commit hooks

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)