### PR TITLE
Implement Downloader protocol

### DIFF
--- a/src/nhl_api/downloaders/__init__.py
+++ b/src/nhl_api/downloaders/__init__.py
@@ -1,0 +1,21 @@
+"""NHL API Downloaders package.
+
+This package contains downloaders for various NHL data sources:
+- NHL JSON API (api-web.nhle.com)
+- NHL HTML Reports (GS, ES, PL, FS, FC, RO, SS, TV, TH)
+- NHL Shift Charts API
+- QuantHockey (player stats)
+- DailyFaceoff (line predictions)
+"""
+
+from nhl_api.downloaders.base.protocol import (
+    Downloader,
+    DownloadResult,
+    DownloadStatus,
+)
+
+__all__ = [
+    "Downloader",
+    "DownloadResult",
+    "DownloadStatus",
+]

--- a/src/nhl_api/downloaders/base/__init__.py
+++ b/src/nhl_api/downloaders/base/__init__.py
@@ -1,0 +1,19 @@
+"""Base downloader components.
+
+This module provides the foundational components for all downloaders:
+- Downloader protocol (interface)
+- DownloadResult dataclass
+- DownloadStatus enum
+"""
+
+from nhl_api.downloaders.base.protocol import (
+    Downloader,
+    DownloadResult,
+    DownloadStatus,
+)
+
+__all__ = [
+    "Downloader",
+    "DownloadResult",
+    "DownloadStatus",
+]

--- a/src/nhl_api/downloaders/base/protocol.py
+++ b/src/nhl_api/downloaders/base/protocol.py
@@ -1,0 +1,202 @@
+"""Downloader protocol and data types.
+
+This module defines the interface that all NHL data downloaders must implement.
+Using Python's Protocol (structural subtyping) allows for flexible implementations
+without requiring inheritance.
+
+Example usage:
+    class ScheduleDownloader:
+        @property
+        def source_name(self) -> str:
+            return "nhl_json_schedule"
+
+        async def download_season(self, season_id: int) -> AsyncIterator[DownloadResult]:
+            async for game in self._fetch_games(season_id):
+                yield DownloadResult(
+                    source=self.source_name,
+                    game_id=game["id"],
+                    season_id=season_id,
+                    data=game,
+                    downloaded_at=datetime.now(UTC),
+                )
+
+        async def download_game(self, game_id: int) -> DownloadResult:
+            ...
+
+        async def health_check(self) -> bool:
+            ...
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class DownloadStatus(Enum):
+    """Status of a download operation."""
+
+    PENDING = "pending"
+    DOWNLOADING = "downloading"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"  # For already-downloaded items
+
+
+@dataclass(frozen=True, slots=True)
+class DownloadResult:
+    """Result of a download operation.
+
+    Attributes:
+        source: Name of the data source (e.g., "nhl_json_schedule", "html_gs")
+        game_id: NHL game ID if applicable, None for season-level data
+        season_id: NHL season ID (e.g., 20242025)
+        data: Parsed data as a dictionary
+        downloaded_at: Timestamp when the download completed
+        status: Current status of the download
+        raw_content: Original bytes if preservation is needed (e.g., HTML)
+        error_message: Error details if status is FAILED
+        retry_count: Number of retries attempted
+    """
+
+    source: str
+    season_id: int
+    data: dict[str, Any]
+    downloaded_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    game_id: int | None = None
+    status: DownloadStatus = DownloadStatus.COMPLETED
+    raw_content: bytes | None = None
+    error_message: str | None = None
+    retry_count: int = 0
+
+    def __post_init__(self) -> None:
+        """Validate the download result."""
+        if self.status == DownloadStatus.FAILED and not self.error_message:
+            object.__setattr__(
+                self, "error_message", "Download failed with no error message"
+            )
+
+    @property
+    def is_successful(self) -> bool:
+        """Check if the download was successful."""
+        return self.status == DownloadStatus.COMPLETED
+
+    @property
+    def is_game_level(self) -> bool:
+        """Check if this result is for a specific game."""
+        return self.game_id is not None
+
+
+@runtime_checkable
+class Downloader(Protocol):
+    """Protocol defining the interface for NHL data downloaders.
+
+    All downloaders must implement this protocol to ensure consistent
+    behavior across different data sources (JSON API, HTML reports, etc.).
+
+    The protocol uses structural subtyping, so classes don't need to
+    explicitly inherit from it - they just need to implement the methods.
+    """
+
+    @property
+    def source_name(self) -> str:
+        """Unique identifier for this data source.
+
+        Examples: "nhl_json_schedule", "nhl_json_boxscore", "html_gs", "html_es"
+        """
+        ...
+
+    async def download_season(
+        self, season_id: int, *, force: bool = False
+    ) -> AsyncIterator[DownloadResult]:
+        """Download all data for a season.
+
+        Args:
+            season_id: NHL season ID (e.g., 20242025 for 2024-25 season)
+            force: If True, re-download even if data exists
+
+        Yields:
+            DownloadResult for each downloaded item (game, report, etc.)
+
+        Raises:
+            DownloadError: If a critical error occurs that prevents continuation
+        """
+        ...
+
+    async def download_game(self, game_id: int) -> DownloadResult:
+        """Download data for a specific game.
+
+        Args:
+            game_id: NHL game ID
+
+        Returns:
+            DownloadResult with the game data
+
+        Raises:
+            DownloadError: If the download fails after retries
+        """
+        ...
+
+    async def health_check(self) -> bool:
+        """Check if the data source is accessible.
+
+        Returns:
+            True if the source is healthy and ready for downloads
+        """
+        ...
+
+
+class DownloadError(Exception):
+    """Base exception for download errors."""
+
+    def __init__(
+        self,
+        message: str,
+        source: str | None = None,
+        game_id: int | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        """Initialize the download error.
+
+        Args:
+            message: Human-readable error description
+            source: Data source name where error occurred
+            game_id: Game ID if error is game-specific
+            cause: Original exception that caused this error
+        """
+        super().__init__(message)
+        self.source = source
+        self.game_id = game_id
+        self.cause = cause
+
+    def __str__(self) -> str:
+        parts = [super().__str__()]
+        if self.source:
+            parts.append(f"source={self.source}")
+        if self.game_id:
+            parts.append(f"game_id={self.game_id}")
+        return " ".join(parts)
+
+
+class RateLimitError(DownloadError):
+    """Raised when rate limit is exceeded."""
+
+    def __init__(
+        self,
+        message: str = "Rate limit exceeded",
+        retry_after: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(message, **kwargs)
+        self.retry_after = retry_after
+
+
+class HealthCheckError(DownloadError):
+    """Raised when health check fails."""
+
+    pass

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -1,0 +1,315 @@
+"""Tests for the Downloader protocol and data types."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+
+from nhl_api.downloaders.base.protocol import (
+    Downloader,
+    DownloadError,
+    DownloadResult,
+    DownloadStatus,
+    HealthCheckError,
+    RateLimitError,
+)
+
+
+class TestDownloadStatus:
+    """Tests for DownloadStatus enum."""
+
+    def test_status_values(self) -> None:
+        """Verify all expected status values exist."""
+        assert DownloadStatus.PENDING.value == "pending"
+        assert DownloadStatus.DOWNLOADING.value == "downloading"
+        assert DownloadStatus.COMPLETED.value == "completed"
+        assert DownloadStatus.FAILED.value == "failed"
+        assert DownloadStatus.SKIPPED.value == "skipped"
+
+    def test_status_count(self) -> None:
+        """Verify the expected number of statuses."""
+        assert len(DownloadStatus) == 5
+
+
+class TestDownloadResult:
+    """Tests for DownloadResult dataclass."""
+
+    def test_minimal_result(self) -> None:
+        """Test creating a result with required fields only."""
+        result = DownloadResult(
+            source="test_source",
+            season_id=20242025,
+            data={"key": "value"},
+        )
+
+        assert result.source == "test_source"
+        assert result.season_id == 20242025
+        assert result.data == {"key": "value"}
+        assert result.game_id is None
+        assert result.status == DownloadStatus.COMPLETED
+        assert result.raw_content is None
+        assert result.error_message is None
+        assert result.retry_count == 0
+        assert result.is_successful
+        assert not result.is_game_level
+
+    def test_full_result(self) -> None:
+        """Test creating a result with all fields."""
+        timestamp = datetime.now(UTC)
+        result = DownloadResult(
+            source="nhl_json_boxscore",
+            season_id=20242025,
+            game_id=2024020001,
+            data={"homeTeam": {"score": 3}},
+            downloaded_at=timestamp,
+            status=DownloadStatus.COMPLETED,
+            raw_content=b'{"json": "data"}',
+            retry_count=1,
+        )
+
+        assert result.source == "nhl_json_boxscore"
+        assert result.game_id == 2024020001
+        assert result.downloaded_at == timestamp
+        assert result.raw_content == b'{"json": "data"}'
+        assert result.retry_count == 1
+        assert result.is_successful
+        assert result.is_game_level
+
+    def test_failed_result_gets_default_message(self) -> None:
+        """Test that failed results without message get default."""
+        result = DownloadResult(
+            source="test",
+            season_id=20242025,
+            data={},
+            status=DownloadStatus.FAILED,
+        )
+
+        assert result.error_message == "Download failed with no error message"
+        assert not result.is_successful
+
+    def test_failed_result_keeps_custom_message(self) -> None:
+        """Test that custom error message is preserved."""
+        result = DownloadResult(
+            source="test",
+            season_id=20242025,
+            data={},
+            status=DownloadStatus.FAILED,
+            error_message="Connection timeout",
+        )
+
+        assert result.error_message == "Connection timeout"
+
+    def test_result_is_immutable(self) -> None:
+        """Test that DownloadResult is frozen (immutable)."""
+        result = DownloadResult(
+            source="test",
+            season_id=20242025,
+            data={},
+        )
+
+        with pytest.raises(AttributeError):
+            result.source = "modified"  # type: ignore[misc]
+
+    def test_downloaded_at_defaults_to_now(self) -> None:
+        """Test that downloaded_at defaults to current time."""
+        before = datetime.now(UTC)
+        result = DownloadResult(source="test", season_id=20242025, data={})
+        after = datetime.now(UTC)
+
+        assert before <= result.downloaded_at <= after
+
+
+class TestDownloaderProtocol:
+    """Tests for the Downloader protocol."""
+
+    def test_protocol_is_runtime_checkable(self) -> None:
+        """Test that Downloader protocol can be used with isinstance."""
+
+        # Create a mock implementation
+        class MockDownloader:
+            @property
+            def source_name(self) -> str:
+                return "mock"
+
+            async def download_season(
+                self, season_id: int, *, force: bool = False
+            ) -> AsyncIterator[DownloadResult]:
+                yield DownloadResult(
+                    source=self.source_name,
+                    season_id=season_id,
+                    data={},
+                )
+
+            async def download_game(self, game_id: int) -> DownloadResult:
+                return DownloadResult(
+                    source=self.source_name,
+                    season_id=20242025,
+                    game_id=game_id,
+                    data={},
+                )
+
+            async def health_check(self) -> bool:
+                return True
+
+        downloader = MockDownloader()
+        assert isinstance(downloader, Downloader)
+
+    def test_non_downloader_fails_isinstance(self) -> None:
+        """Test that non-conforming class fails isinstance check."""
+
+        class NotADownloader:
+            pass
+
+        assert not isinstance(NotADownloader(), Downloader)
+
+    def test_partial_implementation_fails(self) -> None:
+        """Test that partial implementation fails isinstance check."""
+
+        class PartialDownloader:
+            @property
+            def source_name(self) -> str:
+                return "partial"
+
+            # Missing other required methods
+
+        assert not isinstance(PartialDownloader(), Downloader)
+
+
+class TestDownloadError:
+    """Tests for DownloadError and subclasses."""
+
+    def test_basic_error(self) -> None:
+        """Test basic error creation."""
+        error = DownloadError("Something went wrong")
+        assert str(error) == "Something went wrong"
+        assert error.source is None
+        assert error.game_id is None
+        assert error.cause is None
+
+    def test_error_with_context(self) -> None:
+        """Test error with full context."""
+        cause = ValueError("Original error")
+        error = DownloadError(
+            "Failed to download",
+            source="nhl_json_boxscore",
+            game_id=2024020001,
+            cause=cause,
+        )
+
+        assert "Failed to download" in str(error)
+        assert "nhl_json_boxscore" in str(error)
+        assert "2024020001" in str(error)
+        assert error.cause is cause
+
+    def test_error_inheritance(self) -> None:
+        """Test that DownloadError is a proper exception."""
+        with pytest.raises(DownloadError):
+            raise DownloadError("Test error")
+
+
+class TestRateLimitError:
+    """Tests for RateLimitError."""
+
+    def test_rate_limit_with_retry_after(self) -> None:
+        """Test rate limit error with retry timing."""
+        error = RateLimitError(retry_after=30.0, source="nhl_api")
+        assert error.retry_after == 30.0
+        assert "Rate limit exceeded" in str(error)
+
+    def test_rate_limit_inheritance(self) -> None:
+        """Test that RateLimitError is a DownloadError."""
+        error = RateLimitError()
+        assert isinstance(error, DownloadError)
+
+
+class TestHealthCheckError:
+    """Tests for HealthCheckError."""
+
+    def test_health_check_error(self) -> None:
+        """Test health check error creation."""
+        error = HealthCheckError("Service unavailable", source="nhl_api")
+        assert "Service unavailable" in str(error)
+        assert error.source == "nhl_api"
+
+    def test_health_check_inheritance(self) -> None:
+        """Test that HealthCheckError is a DownloadError."""
+        error = HealthCheckError("Test")
+        assert isinstance(error, DownloadError)
+
+
+@pytest.mark.asyncio
+class TestDownloaderIntegration:
+    """Integration tests for Downloader implementations."""
+
+    async def test_download_season_yields_results(self) -> None:
+        """Test that download_season properly yields results."""
+
+        class TestDownloader:
+            @property
+            def source_name(self) -> str:
+                return "test"
+
+            async def download_season(
+                self, season_id: int, *, force: bool = False
+            ) -> AsyncIterator[DownloadResult]:
+                for i in range(3):
+                    yield DownloadResult(
+                        source=self.source_name,
+                        season_id=season_id,
+                        game_id=season_id * 1000 + i,
+                        data={"game_number": i},
+                    )
+
+            async def download_game(self, game_id: int) -> DownloadResult:
+                return DownloadResult(
+                    source=self.source_name,
+                    season_id=20242025,
+                    game_id=game_id,
+                    data={},
+                )
+
+            async def health_check(self) -> bool:
+                return True
+
+        downloader = TestDownloader()
+        results = [result async for result in downloader.download_season(20242025)]
+
+        assert len(results) == 3
+        assert all(r.source == "test" for r in results)
+        assert all(r.season_id == 20242025 for r in results)
+        assert [r.data["game_number"] for r in results] == [0, 1, 2]
+
+    async def test_download_game_returns_result(self) -> None:
+        """Test that download_game returns a proper result."""
+
+        class TestDownloader:
+            @property
+            def source_name(self) -> str:
+                return "test"
+
+            async def download_season(
+                self, season_id: int, *, force: bool = False
+            ) -> AsyncIterator[DownloadResult]:
+                yield DownloadResult(
+                    source=self.source_name, season_id=season_id, data={}
+                )
+
+            async def download_game(self, game_id: int) -> DownloadResult:
+                return DownloadResult(
+                    source=self.source_name,
+                    season_id=20242025,
+                    game_id=game_id,
+                    data={"home_score": 3, "away_score": 2},
+                )
+
+            async def health_check(self) -> bool:
+                return True
+
+        downloader = TestDownloader()
+        result = await downloader.download_game(2024020001)
+
+        assert result.game_id == 2024020001
+        assert result.data["home_score"] == 3
+        assert result.is_game_level


### PR DESCRIPTION
## Summary

- Implements the base `Downloader` protocol that all data source downloaders will use
- Adds `DownloadResult` dataclass for uniform return types across downloaders
- Adds `DownloadStatus` enum for tracking download states
- Includes error hierarchy (`DownloadError`, `RateLimitError`, `HealthCheckError`)

## Files Changed

- `src/nhl_api/downloaders/__init__.py` - Package exports
- `src/nhl_api/downloaders/base/__init__.py` - Base module exports
- `src/nhl_api/downloaders/base/protocol.py` - Protocol and data types
- `tests/unit/test_protocol.py` - 20 unit tests

## Test Plan

- [x] All 20 new tests pass
- [x] All 64 total unit tests pass
- [x] mypy passes
- [x] ruff check passes
- [x] ruff format passes
- [x] Pre-commit hooks pass

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)