### PR TITLE
Implement Retry Handler with exponential backoff

### DIFF
--- a/src/nhl_api/downloaders/base/__init__.py
+++ b/src/nhl_api/downloaders/base/__init__.py
@@ -5,6 +5,7 @@ This module provides the foundational components for all downloaders:
 - DownloadResult dataclass
 - DownloadStatus enum
 - RateLimiter for API request throttling
+- RetryHandler with exponential backoff
 """
 
 from nhl_api.downloaders.base.protocol import (
@@ -18,13 +19,25 @@ from nhl_api.downloaders.base.rate_limiter import (
     RateLimiter,
     TokenBucket,
 )
+from nhl_api.downloaders.base.retry_handler import (
+    MaxRetriesExceededError,
+    RetryableError,
+    RetryConfig,
+    RetryHandler,
+    RetryResult,
+)
 
 __all__ = [
     "Downloader",
     "DownloadError",
     "DownloadResult",
     "DownloadStatus",
+    "MaxRetriesExceededError",
     "RateLimitError",
     "RateLimiter",
+    "RetryableError",
+    "RetryConfig",
+    "RetryHandler",
+    "RetryResult",
     "TokenBucket",
 ]

--- a/src/nhl_api/downloaders/base/retry_handler.py
+++ b/src/nhl_api/downloaders/base/retry_handler.py
@@ -1,0 +1,327 @@
+"""Retry handler with exponential backoff for failed requests.
+
+This module provides retry logic for HTTP requests, implementing exponential
+backoff with jitter to avoid thundering herd problems when multiple clients
+retry simultaneously.
+
+Example usage:
+    retry_handler = RetryHandler(max_retries=3, base_delay=1.0)
+
+    async with aiohttp.ClientSession() as session:
+        result = await retry_handler.execute(
+            lambda: session.get("https://api.nhle.com/v1/schedule"),
+            operation_name="fetch_schedule"
+        )
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from nhl_api.downloaders.base.protocol import DownloadError, RateLimitError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# HTTP status codes that trigger automatic retry
+RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+
+@dataclass(frozen=True, slots=True)
+class RetryConfig:
+    """Configuration for retry behavior.
+
+    Attributes:
+        max_retries: Maximum number of retry attempts (default: 3)
+        base_delay: Initial delay in seconds before first retry (default: 1.0)
+        max_delay: Maximum delay between retries in seconds (default: 60.0)
+        exponential_base: Base for exponential backoff calculation (default: 2.0)
+        jitter_factor: Random jitter as fraction of delay (default: 0.1)
+        retryable_status_codes: HTTP status codes that trigger retry
+    """
+
+    max_retries: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 60.0
+    exponential_base: float = 2.0
+    jitter_factor: float = 0.1
+    retryable_status_codes: frozenset[int] = field(
+        default_factory=lambda: RETRYABLE_STATUS_CODES
+    )
+
+    def __post_init__(self) -> None:
+        """Validate configuration values."""
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be non-negative")
+        if self.base_delay <= 0:
+            raise ValueError("base_delay must be positive")
+        if self.max_delay < self.base_delay:
+            raise ValueError("max_delay must be >= base_delay")
+        if self.exponential_base <= 1:
+            raise ValueError("exponential_base must be > 1")
+        if not 0 <= self.jitter_factor <= 1:
+            raise ValueError("jitter_factor must be between 0 and 1")
+
+
+@dataclass
+class RetryResult:
+    """Result of a retry operation.
+
+    Attributes:
+        value: The returned value if successful
+        attempts: Total number of attempts made (1 = no retries)
+        total_delay: Total time spent waiting between retries
+        final_error: The error if all retries failed, None if successful
+    """
+
+    value: Any = None
+    attempts: int = 1
+    total_delay: float = 0.0
+    final_error: Exception | None = None
+
+    @property
+    def is_successful(self) -> bool:
+        """Check if the operation succeeded."""
+        return self.final_error is None
+
+
+class RetryableError(DownloadError):
+    """Error that indicates the operation should be retried.
+
+    Raised when an HTTP response has a retryable status code.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int,
+        retry_after: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(message, **kwargs)
+        self.status_code = status_code
+        self.retry_after = retry_after
+
+
+class MaxRetriesExceededError(DownloadError):
+    """Raised when all retry attempts have been exhausted."""
+
+    def __init__(
+        self,
+        message: str,
+        attempts: int,
+        last_error: Exception | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(message, **kwargs)
+        self.attempts = attempts
+        self.last_error = last_error
+
+
+class RetryHandler:
+    """Handles retry logic with exponential backoff and jitter.
+
+    This class wraps async operations and automatically retries them on
+    transient failures, using exponential backoff to avoid overwhelming
+    the server.
+
+    The delay between retries follows this formula:
+        delay = base_delay * (exponential_base ** attempt) + random_jitter
+
+    Example:
+        handler = RetryHandler(RetryConfig(max_retries=3, base_delay=1.0))
+
+        try:
+            result = await handler.execute(fetch_data, operation_name="fetch")
+        except MaxRetriesExceededError as e:
+            logger.error(f"Failed after {e.attempts} attempts")
+    """
+
+    def __init__(self, config: RetryConfig | None = None) -> None:
+        """Initialize the retry handler.
+
+        Args:
+            config: Retry configuration. Uses defaults if not provided.
+        """
+        self.config = config or RetryConfig()
+
+    def calculate_delay(self, attempt: int, retry_after: float | None = None) -> float:
+        """Calculate delay before the next retry attempt.
+
+        Args:
+            attempt: Current attempt number (0-indexed)
+            retry_after: Server-specified delay from Retry-After header
+
+        Returns:
+            Delay in seconds before next retry
+        """
+        if retry_after is not None:
+            # Respect server's Retry-After, but cap at max_delay
+            return min(retry_after, self.config.max_delay)
+
+        # Exponential backoff: base_delay * (base ** attempt)
+        delay = self.config.base_delay * (self.config.exponential_base**attempt)
+
+        # Add jitter to prevent thundering herd
+        jitter = delay * self.config.jitter_factor * random.random()  # noqa: S311
+        delay += jitter
+
+        # Cap at max_delay
+        return min(delay, self.config.max_delay)
+
+    def is_retryable_status(self, status_code: int) -> bool:
+        """Check if an HTTP status code should trigger a retry.
+
+        Args:
+            status_code: HTTP response status code
+
+        Returns:
+            True if the status code is retryable
+        """
+        return status_code in self.config.retryable_status_codes
+
+    async def execute(
+        self,
+        operation: Callable[[], Awaitable[T]],
+        *,
+        operation_name: str = "operation",
+        source: str | None = None,
+    ) -> T:
+        """Execute an async operation with automatic retry on failure.
+
+        Args:
+            operation: Async callable to execute
+            operation_name: Name for logging purposes
+            source: Data source name for error context
+
+        Returns:
+            The result of the operation if successful
+
+        Raises:
+            MaxRetriesExceededError: If all retry attempts fail
+            Exception: Any non-retryable exception from the operation
+        """
+        last_error: Exception | None = None
+        total_delay = 0.0
+
+        for attempt in range(self.config.max_retries + 1):
+            try:
+                result = await operation()
+                if attempt > 0:
+                    logger.info(
+                        f"{operation_name} succeeded after {attempt + 1} attempts "
+                        f"(total delay: {total_delay:.2f}s)"
+                    )
+                return result
+
+            except RetryableError as e:
+                last_error = e
+                if attempt >= self.config.max_retries:
+                    break
+
+                delay = self.calculate_delay(attempt, e.retry_after)
+                total_delay += delay
+
+                logger.warning(
+                    f"{operation_name} failed (attempt {attempt + 1}/"
+                    f"{self.config.max_retries + 1}): {e} "
+                    f"[status={e.status_code}]. Retrying in {delay:.2f}s"
+                )
+                await asyncio.sleep(delay)
+
+            except RateLimitError as e:
+                last_error = e
+                if attempt >= self.config.max_retries:
+                    break
+
+                delay = self.calculate_delay(attempt, e.retry_after)
+                total_delay += delay
+
+                logger.warning(
+                    f"{operation_name} rate limited (attempt {attempt + 1}/"
+                    f"{self.config.max_retries + 1}). Retrying in {delay:.2f}s"
+                )
+                await asyncio.sleep(delay)
+
+            except Exception as e:
+                # Non-retryable error, propagate immediately
+                logger.error(f"{operation_name} failed with non-retryable error: {e}")
+                raise
+
+        # All retries exhausted
+        raise MaxRetriesExceededError(
+            f"{operation_name} failed after {self.config.max_retries + 1} attempts",
+            attempts=self.config.max_retries + 1,
+            last_error=last_error,
+            source=source,
+        )
+
+    async def execute_with_result(
+        self,
+        operation: Callable[[], Awaitable[T]],
+        *,
+        operation_name: str = "operation",
+    ) -> RetryResult:
+        """Execute an operation and return detailed retry statistics.
+
+        Unlike execute(), this method never raises MaxRetriesExceededError.
+        Instead, it returns a RetryResult with the error information.
+
+        Args:
+            operation: Async callable to execute
+            operation_name: Name for logging purposes
+
+        Returns:
+            RetryResult with success/failure status and statistics
+        """
+        total_delay = 0.0
+
+        for attempt in range(self.config.max_retries + 1):
+            try:
+                result = await operation()
+                return RetryResult(
+                    value=result,
+                    attempts=attempt + 1,
+                    total_delay=total_delay,
+                )
+
+            except (RetryableError, RateLimitError) as e:
+                if attempt >= self.config.max_retries:
+                    return RetryResult(
+                        attempts=attempt + 1,
+                        total_delay=total_delay,
+                        final_error=e,
+                    )
+
+                retry_after = getattr(e, "retry_after", None)
+                delay = self.calculate_delay(attempt, retry_after)
+                total_delay += delay
+
+                logger.warning(
+                    f"{operation_name} failed (attempt {attempt + 1}/"
+                    f"{self.config.max_retries + 1}): {e}. Retrying in {delay:.2f}s"
+                )
+                await asyncio.sleep(delay)
+
+            except Exception as e:
+                # Non-retryable error
+                return RetryResult(
+                    attempts=attempt + 1,
+                    total_delay=total_delay,
+                    final_error=e,
+                )
+
+        # Should not reach here, but satisfy type checker
+        return RetryResult(
+            attempts=self.config.max_retries + 1,
+            total_delay=total_delay,
+            final_error=None,
+        )

--- a/tests/unit/test_retry_handler.py
+++ b/tests/unit/test_retry_handler.py
@@ -1,0 +1,474 @@
+"""Tests for the RetryHandler module."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nhl_api.downloaders.base.protocol import RateLimitError
+from nhl_api.downloaders.base.retry_handler import (
+    RETRYABLE_STATUS_CODES,
+    MaxRetriesExceededError,
+    RetryableError,
+    RetryConfig,
+    RetryHandler,
+    RetryResult,
+)
+
+
+class TestRetryConfig:
+    """Tests for RetryConfig dataclass."""
+
+    def test_default_config(self) -> None:
+        """Test default configuration values."""
+        config = RetryConfig()
+
+        assert config.max_retries == 3
+        assert config.base_delay == 1.0
+        assert config.max_delay == 60.0
+        assert config.exponential_base == 2.0
+        assert config.jitter_factor == 0.1
+        assert config.retryable_status_codes == RETRYABLE_STATUS_CODES
+
+    def test_custom_config(self) -> None:
+        """Test custom configuration values."""
+        config = RetryConfig(
+            max_retries=5,
+            base_delay=0.5,
+            max_delay=30.0,
+            exponential_base=3.0,
+            jitter_factor=0.2,
+        )
+
+        assert config.max_retries == 5
+        assert config.base_delay == 0.5
+        assert config.max_delay == 30.0
+        assert config.exponential_base == 3.0
+        assert config.jitter_factor == 0.2
+
+    def test_invalid_max_retries(self) -> None:
+        """Test that negative max_retries raises ValueError."""
+        with pytest.raises(ValueError, match="max_retries must be non-negative"):
+            RetryConfig(max_retries=-1)
+
+    def test_zero_max_retries_valid(self) -> None:
+        """Test that zero max_retries is valid (no retries)."""
+        config = RetryConfig(max_retries=0)
+        assert config.max_retries == 0
+
+    def test_invalid_base_delay(self) -> None:
+        """Test that non-positive base_delay raises ValueError."""
+        with pytest.raises(ValueError, match="base_delay must be positive"):
+            RetryConfig(base_delay=0)
+
+        with pytest.raises(ValueError, match="base_delay must be positive"):
+            RetryConfig(base_delay=-1.0)
+
+    def test_invalid_max_delay(self) -> None:
+        """Test that max_delay < base_delay raises ValueError."""
+        with pytest.raises(ValueError, match="max_delay must be >= base_delay"):
+            RetryConfig(base_delay=10.0, max_delay=5.0)
+
+    def test_invalid_exponential_base(self) -> None:
+        """Test that exponential_base <= 1 raises ValueError."""
+        with pytest.raises(ValueError, match="exponential_base must be > 1"):
+            RetryConfig(exponential_base=1.0)
+
+        with pytest.raises(ValueError, match="exponential_base must be > 1"):
+            RetryConfig(exponential_base=0.5)
+
+    def test_invalid_jitter_factor(self) -> None:
+        """Test that jitter_factor outside [0, 1] raises ValueError."""
+        with pytest.raises(ValueError, match="jitter_factor must be between 0 and 1"):
+            RetryConfig(jitter_factor=-0.1)
+
+        with pytest.raises(ValueError, match="jitter_factor must be between 0 and 1"):
+            RetryConfig(jitter_factor=1.5)
+
+    def test_config_is_frozen(self) -> None:
+        """Test that config is immutable."""
+        config = RetryConfig()
+        with pytest.raises(AttributeError):
+            config.max_retries = 10  # type: ignore[misc]
+
+
+class TestRetryResult:
+    """Tests for RetryResult dataclass."""
+
+    def test_successful_result(self) -> None:
+        """Test a successful retry result."""
+        result = RetryResult(value="success", attempts=1, total_delay=0.0)
+
+        assert result.value == "success"
+        assert result.attempts == 1
+        assert result.total_delay == 0.0
+        assert result.final_error is None
+        assert result.is_successful
+
+    def test_failed_result(self) -> None:
+        """Test a failed retry result."""
+        error = RetryableError("Server error", status_code=500)
+        result = RetryResult(
+            attempts=4,
+            total_delay=7.5,
+            final_error=error,
+        )
+
+        assert result.value is None
+        assert result.attempts == 4
+        assert result.total_delay == 7.5
+        assert result.final_error is error
+        assert not result.is_successful
+
+
+class TestRetryableError:
+    """Tests for RetryableError."""
+
+    def test_basic_error(self) -> None:
+        """Test basic retryable error creation."""
+        error = RetryableError("Server error", status_code=500)
+
+        assert "Server error" in str(error)
+        assert error.status_code == 500
+        assert error.retry_after is None
+
+    def test_error_with_retry_after(self) -> None:
+        """Test retryable error with Retry-After."""
+        error = RetryableError(
+            "Rate limited",
+            status_code=429,
+            retry_after=30.0,
+            source="nhl_api",
+        )
+
+        assert error.status_code == 429
+        assert error.retry_after == 30.0
+        assert error.source == "nhl_api"
+
+    def test_error_inheritance(self) -> None:
+        """Test that RetryableError inherits from DownloadError."""
+        from nhl_api.downloaders.base.protocol import DownloadError
+
+        error = RetryableError("Test", status_code=500)
+        assert isinstance(error, DownloadError)
+
+
+class TestMaxRetriesExceededError:
+    """Tests for MaxRetriesExceededError."""
+
+    def test_basic_error(self) -> None:
+        """Test basic max retries error."""
+        error = MaxRetriesExceededError("Failed", attempts=4)
+
+        assert "Failed" in str(error)
+        assert error.attempts == 4
+        assert error.last_error is None
+
+    def test_error_with_last_error(self) -> None:
+        """Test max retries error with last error."""
+        last = RetryableError("Final failure", status_code=503)
+        error = MaxRetriesExceededError(
+            "All retries failed",
+            attempts=4,
+            last_error=last,
+            source="schedule_downloader",
+        )
+
+        assert error.attempts == 4
+        assert error.last_error is last
+        assert error.source == "schedule_downloader"
+
+
+class TestRetryHandler:
+    """Tests for RetryHandler class."""
+
+    def test_default_config(self) -> None:
+        """Test handler uses default config when none provided."""
+        handler = RetryHandler()
+
+        assert handler.config.max_retries == 3
+        assert handler.config.base_delay == 1.0
+
+    def test_custom_config(self) -> None:
+        """Test handler uses provided config."""
+        config = RetryConfig(max_retries=5, base_delay=0.5)
+        handler = RetryHandler(config)
+
+        assert handler.config.max_retries == 5
+        assert handler.config.base_delay == 0.5
+
+    def test_is_retryable_status(self) -> None:
+        """Test status code retry detection."""
+        handler = RetryHandler()
+
+        # Retryable status codes
+        assert handler.is_retryable_status(429) is True
+        assert handler.is_retryable_status(500) is True
+        assert handler.is_retryable_status(502) is True
+        assert handler.is_retryable_status(503) is True
+        assert handler.is_retryable_status(504) is True
+
+        # Non-retryable status codes
+        assert handler.is_retryable_status(200) is False
+        assert handler.is_retryable_status(400) is False
+        assert handler.is_retryable_status(401) is False
+        assert handler.is_retryable_status(403) is False
+        assert handler.is_retryable_status(404) is False
+
+    def test_calculate_delay_basic(self) -> None:
+        """Test basic delay calculation without jitter."""
+        config = RetryConfig(base_delay=1.0, exponential_base=2.0, jitter_factor=0.0)
+        handler = RetryHandler(config)
+
+        # Without jitter, delay = base_delay * (base ** attempt)
+        assert handler.calculate_delay(0) == 1.0  # 1.0 * 2^0 = 1.0
+        assert handler.calculate_delay(1) == 2.0  # 1.0 * 2^1 = 2.0
+        assert handler.calculate_delay(2) == 4.0  # 1.0 * 2^2 = 4.0
+        assert handler.calculate_delay(3) == 8.0  # 1.0 * 2^3 = 8.0
+
+    def test_calculate_delay_with_jitter(self) -> None:
+        """Test delay calculation includes jitter."""
+        config = RetryConfig(base_delay=1.0, exponential_base=2.0, jitter_factor=0.1)
+        handler = RetryHandler(config)
+
+        # With jitter, delay should be between base and base * 1.1
+        with patch("random.random", return_value=0.5):
+            delay = handler.calculate_delay(0)
+            # delay = 1.0 + (1.0 * 0.1 * 0.5) = 1.05
+            assert delay == pytest.approx(1.05)
+
+    def test_calculate_delay_caps_at_max(self) -> None:
+        """Test delay is capped at max_delay."""
+        config = RetryConfig(
+            base_delay=10.0,
+            max_delay=20.0,
+            exponential_base=2.0,
+            jitter_factor=0.0,
+        )
+        handler = RetryHandler(config)
+
+        # Attempt 2: 10 * 2^2 = 40, but capped at 20
+        assert handler.calculate_delay(2) == 20.0
+
+    def test_calculate_delay_respects_retry_after(self) -> None:
+        """Test delay uses Retry-After header value."""
+        handler = RetryHandler()
+
+        # Server says wait 30 seconds
+        assert handler.calculate_delay(0, retry_after=30.0) == 30.0
+
+        # Server says wait 120 seconds, capped at max_delay (60)
+        assert handler.calculate_delay(0, retry_after=120.0) == 60.0
+
+
+@pytest.mark.asyncio
+class TestRetryHandlerExecute:
+    """Async tests for RetryHandler.execute()."""
+
+    async def test_success_on_first_try(self) -> None:
+        """Test successful operation without retries."""
+        handler = RetryHandler()
+        operation = AsyncMock(return_value="success")
+
+        result = await handler.execute(operation, operation_name="test_op")
+
+        assert result == "success"
+        operation.assert_called_once()
+
+    async def test_success_after_retry(self) -> None:
+        """Test successful operation after retrying."""
+        config = RetryConfig(base_delay=0.01, jitter_factor=0.0)
+        handler = RetryHandler(config)
+
+        # Fail twice, then succeed
+        operation = AsyncMock(
+            side_effect=[
+                RetryableError("Error 1", status_code=500),
+                RetryableError("Error 2", status_code=503),
+                "success",
+            ]
+        )
+
+        result = await handler.execute(operation, operation_name="test_op")
+
+        assert result == "success"
+        assert operation.call_count == 3
+
+    async def test_max_retries_exceeded(self) -> None:
+        """Test MaxRetriesExceededError when all retries fail."""
+        config = RetryConfig(max_retries=2, base_delay=0.01, jitter_factor=0.0)
+        handler = RetryHandler(config)
+
+        operation = AsyncMock(
+            side_effect=RetryableError("Always fails", status_code=500)
+        )
+
+        with pytest.raises(MaxRetriesExceededError) as exc_info:
+            await handler.execute(
+                operation, operation_name="failing_op", source="test_source"
+            )
+
+        assert exc_info.value.attempts == 3  # Initial + 2 retries
+        assert exc_info.value.source == "test_source"
+        assert operation.call_count == 3
+
+    async def test_rate_limit_error_triggers_retry(self) -> None:
+        """Test that RateLimitError triggers retry."""
+        config = RetryConfig(max_retries=2, base_delay=0.01, jitter_factor=0.0)
+        handler = RetryHandler(config)
+
+        operation = AsyncMock(
+            side_effect=[
+                RateLimitError(retry_after=0.01),
+                "success",
+            ]
+        )
+
+        result = await handler.execute(operation)
+
+        assert result == "success"
+        assert operation.call_count == 2
+
+    async def test_non_retryable_error_propagates(self) -> None:
+        """Test that non-retryable errors propagate immediately."""
+        handler = RetryHandler()
+
+        operation = AsyncMock(side_effect=ValueError("Bad input"))
+
+        with pytest.raises(ValueError, match="Bad input"):
+            await handler.execute(operation)
+
+        # Should not retry for non-retryable errors
+        operation.assert_called_once()
+
+    async def test_zero_retries_fails_immediately(self) -> None:
+        """Test that max_retries=0 fails on first error."""
+        config = RetryConfig(max_retries=0, base_delay=0.01)
+        handler = RetryHandler(config)
+
+        operation = AsyncMock(side_effect=RetryableError("Error", status_code=500))
+
+        with pytest.raises(MaxRetriesExceededError) as exc_info:
+            await handler.execute(operation)
+
+        assert exc_info.value.attempts == 1
+        operation.assert_called_once()
+
+    async def test_retry_uses_calculated_delay(self) -> None:
+        """Test that retries wait for calculated delay."""
+        config = RetryConfig(
+            max_retries=1,
+            base_delay=0.1,
+            jitter_factor=0.0,
+        )
+        handler = RetryHandler(config)
+
+        operation = AsyncMock(
+            side_effect=[
+                RetryableError("Error", status_code=500),
+                "success",
+            ]
+        )
+
+        with patch.object(asyncio, "sleep", new_callable=AsyncMock) as mock_sleep:
+            await handler.execute(operation)
+
+            # Should have slept for the calculated delay
+            mock_sleep.assert_called_once()
+            assert mock_sleep.call_args[0][0] == pytest.approx(0.1)
+
+
+@pytest.mark.asyncio
+class TestRetryHandlerExecuteWithResult:
+    """Async tests for RetryHandler.execute_with_result()."""
+
+    async def test_success_returns_result(self) -> None:
+        """Test successful operation returns RetryResult."""
+        handler = RetryHandler()
+        operation = AsyncMock(return_value="success")
+
+        result = await handler.execute_with_result(operation)
+
+        assert result.is_successful
+        assert result.value == "success"
+        assert result.attempts == 1
+        assert result.total_delay == 0.0
+        assert result.final_error is None
+
+    async def test_failure_returns_result_with_error(self) -> None:
+        """Test failed operation returns RetryResult with error."""
+        config = RetryConfig(max_retries=1, base_delay=0.01, jitter_factor=0.0)
+        handler = RetryHandler(config)
+
+        error = RetryableError("Always fails", status_code=500)
+        operation = AsyncMock(side_effect=error)
+
+        result = await handler.execute_with_result(operation)
+
+        assert not result.is_successful
+        assert result.value is None
+        assert result.attempts == 2
+        assert result.final_error is error
+
+    async def test_non_retryable_error_in_result(self) -> None:
+        """Test non-retryable error captured in result."""
+        handler = RetryHandler()
+
+        error = ValueError("Bad input")
+        operation = AsyncMock(side_effect=error)
+
+        result = await handler.execute_with_result(operation)
+
+        assert not result.is_successful
+        assert result.attempts == 1
+        assert result.final_error is error
+
+    async def test_result_tracks_total_delay(self) -> None:
+        """Test that total_delay accumulates across retries."""
+        config = RetryConfig(
+            max_retries=2,
+            base_delay=0.05,
+            jitter_factor=0.0,
+        )
+        handler = RetryHandler(config)
+
+        operation = AsyncMock(
+            side_effect=[
+                RetryableError("Error", status_code=500),
+                RetryableError("Error", status_code=500),
+                "success",
+            ]
+        )
+
+        result = await handler.execute_with_result(operation)
+
+        assert result.is_successful
+        assert result.attempts == 3
+        # Delays: 0.05 * 2^0 + 0.05 * 2^1 = 0.05 + 0.1 = 0.15
+        assert result.total_delay == pytest.approx(0.15)
+
+
+class TestRetryableStatusCodes:
+    """Tests for default retryable status codes."""
+
+    def test_default_retryable_codes(self) -> None:
+        """Test that default retryable codes are correct."""
+        expected = frozenset({429, 500, 502, 503, 504})
+        assert RETRYABLE_STATUS_CODES == expected
+
+    def test_429_is_rate_limit(self) -> None:
+        """Test that 429 Too Many Requests is retryable."""
+        assert 429 in RETRYABLE_STATUS_CODES
+
+    def test_500_server_errors_retryable(self) -> None:
+        """Test that 5xx server errors are retryable."""
+        assert 500 in RETRYABLE_STATUS_CODES  # Internal Server Error
+        assert 502 in RETRYABLE_STATUS_CODES  # Bad Gateway
+        assert 503 in RETRYABLE_STATUS_CODES  # Service Unavailable
+        assert 504 in RETRYABLE_STATUS_CODES  # Gateway Timeout
+
+    def test_501_not_implemented_not_retryable(self) -> None:
+        """Test that 501 Not Implemented is NOT retryable (intentional)."""
+        assert 501 not in RETRYABLE_STATUS_CODES


### PR DESCRIPTION
## Summary

- Implement `RetryHandler` class with exponential backoff and jitter for failed HTTP requests
- Add `RetryConfig` dataclass for configurable retry behavior (max retries, delays, jitter factor)
- Automatic retry on status codes 429, 500, 502, 503, 504
- Support for `Retry-After` header from rate limit responses
- Comprehensive logging for retry attempts and success after retries

## Files Changed

- `src/nhl_api/downloaders/base/retry_handler.py` - New retry handler implementation
- `src/nhl_api/downloaders/base/__init__.py` - Export new classes
- `tests/unit/test_retry_handler.py` - 38 unit tests (98% coverage)

## Test plan

- [x] All 38 unit tests pass
- [x] ruff linting passes
- [x] mypy type checking passes
- [x] Pre-commit hooks pass

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)