### PR TITLE
Implement Progress Tracker for resumable downloads (#34)

### DIFF
--- a/src/nhl_api/downloaders/progress/__init__.py
+++ b/src/nhl_api/downloaders/progress/__init__.py
@@ -1,0 +1,38 @@
+"""Progress tracking for NHL data downloads.
+
+This module provides in-memory progress tracking with database persistence
+for resumable downloads.
+
+Example usage:
+    from nhl_api.downloaders.progress import ProgressTracker, ProgressState
+    from nhl_api.services.db import DatabaseService, ProgressRepository
+
+    async with DatabaseService() as db:
+        repo = ProgressRepository(db)
+        tracker = ProgressTracker(repo, source_id=1, season_id=20242025)
+
+        # Resume from last successful point
+        await tracker.load_state()
+
+        # Track progress
+        for game_id in games:
+            await tracker.start_item(str(game_id))
+            # ... download logic ...
+            await tracker.complete_item(str(game_id))
+"""
+
+from nhl_api.downloaders.progress.tracker import (
+    ProgressCallback,
+    ProgressEvent,
+    ProgressState,
+    ProgressStats,
+    ProgressTracker,
+)
+
+__all__ = [
+    "ProgressCallback",
+    "ProgressEvent",
+    "ProgressState",
+    "ProgressStats",
+    "ProgressTracker",
+]

--- a/src/nhl_api/downloaders/progress/tracker.py
+++ b/src/nhl_api/downloaders/progress/tracker.py
@@ -1,0 +1,642 @@
+"""Progress tracker for resumable downloads.
+
+This module provides in-memory progress tracking with database persistence,
+enabling resumable downloads and real-time progress updates.
+
+The tracker maintains per-item state (games, players, etc.) and synchronizes
+with the database via ProgressRepository. It supports:
+- Loading existing progress state from DB for resume
+- Real-time callbacks for UI updates
+- Aggregated statistics for monitoring
+- Batch operations for efficient tracking
+
+Example usage:
+    from nhl_api.downloaders.progress import ProgressTracker
+    from nhl_api.services.db import DatabaseService, ProgressRepository
+
+    async with DatabaseService() as db:
+        repo = ProgressRepository(db)
+        tracker = ProgressTracker(
+            repo,
+            source_id=1,
+            season_id=20242025,
+            on_progress=lambda event: print(f"Progress: {event}"),
+        )
+
+        # Resume from last checkpoint
+        await tracker.load_state()
+
+        # Track downloads
+        for game_id in games:
+            if tracker.should_download(str(game_id)):
+                await tracker.start_item(str(game_id))
+                try:
+                    # ... download logic ...
+                    await tracker.complete_item(str(game_id))
+                except Exception as e:
+                    await tracker.fail_item(str(game_id), str(e))
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from nhl_api.services.db.progress_repo import ProgressRepository
+
+logger = logging.getLogger(__name__)
+
+
+class ProgressState(Enum):
+    """State of a download item."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    SUCCESS = "success"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressEvent:
+    """Event emitted when progress changes.
+
+    Attributes:
+        source_id: Data source identifier.
+        season_id: Season identifier (optional).
+        item_key: Item being tracked (game_id, player_id, etc.).
+        state: Current state of the item.
+        stats: Aggregated progress statistics.
+        message: Optional status message.
+        timestamp: When the event occurred.
+    """
+
+    source_id: int
+    item_key: str
+    state: ProgressState
+    stats: ProgressStats
+    season_id: int | None = None
+    message: str | None = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass
+class ProgressStats:
+    """Aggregated progress statistics.
+
+    Attributes:
+        total: Total items to process (None if unknown).
+        pending: Items waiting to be processed.
+        in_progress: Items currently being processed.
+        success: Successfully completed items.
+        failed: Failed items.
+        skipped: Skipped items.
+        started_at: When tracking started.
+        last_update: Last state change time.
+    """
+
+    total: int | None = None
+    pending: int = 0
+    in_progress: int = 0
+    success: int = 0
+    failed: int = 0
+    skipped: int = 0
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    last_update: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def completed(self) -> int:
+        """Total completed items (success + failed + skipped)."""
+        return self.success + self.failed + self.skipped
+
+    @property
+    def processed(self) -> int:
+        """Total processed items (completed + in_progress)."""
+        return self.completed + self.in_progress
+
+    @property
+    def success_rate(self) -> float:
+        """Success rate as percentage (0-100)."""
+        if self.completed == 0:
+            return 0.0
+        return (self.success / self.completed) * 100
+
+    @property
+    def progress_percent(self) -> float:
+        """Overall progress as percentage (0-100)."""
+        if self.total is None or self.total == 0:
+            return 0.0
+        return (self.completed / self.total) * 100
+
+    @property
+    def is_complete(self) -> bool:
+        """Check if all items are processed."""
+        if self.total is None:
+            return False
+        return self.completed >= self.total
+
+
+class ProgressCallback(Protocol):
+    """Protocol for progress callback functions."""
+
+    def __call__(self, event: ProgressEvent) -> None:
+        """Called when progress changes.
+
+        Args:
+            event: The progress event with current state and stats.
+        """
+        ...
+
+
+@dataclass
+class _ItemState:
+    """Internal state for a tracked item."""
+
+    key: str
+    state: ProgressState
+    progress_id: int | None = None
+    attempts: int = 0
+    error_message: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
+class ProgressTracker:
+    """Track download progress with in-memory state and DB persistence.
+
+    This class provides:
+    - In-memory state for fast access during downloads
+    - Database persistence via ProgressRepository for resume
+    - Real-time callbacks for UI updates
+    - Aggregated statistics for monitoring
+
+    The tracker is designed to work with the download framework:
+    1. Load existing state before starting (for resume)
+    2. Register items to be downloaded
+    3. Track item state transitions (start -> success/fail)
+    4. Query which items need downloading
+
+    Example:
+        >>> tracker = ProgressTracker(repo, source_id=1, season_id=20242025)
+        >>> await tracker.load_state()  # Resume from DB
+        >>> for game_id in games:
+        ...     if tracker.should_download(str(game_id)):
+        ...         await tracker.start_item(str(game_id))
+        ...         # ... download ...
+        ...         await tracker.complete_item(str(game_id))
+    """
+
+    def __init__(
+        self,
+        repository: ProgressRepository,
+        source_id: int,
+        *,
+        season_id: int | None = None,
+        batch_id: int | None = None,
+        on_progress: ProgressCallback | Callable[[ProgressEvent], None] | None = None,
+    ) -> None:
+        """Initialize the progress tracker.
+
+        Args:
+            repository: Database repository for persistence.
+            source_id: Data source identifier.
+            season_id: Season identifier (optional).
+            batch_id: Batch identifier for grouping (optional).
+            on_progress: Callback for progress updates.
+        """
+        self._repo = repository
+        self._source_id = source_id
+        self._season_id = season_id
+        self._batch_id = batch_id
+        self._on_progress = on_progress
+
+        # In-memory state
+        self._items: dict[str, _ItemState] = {}
+        self._stats = ProgressStats()
+        self._started = False
+
+        logger.debug(
+            "Initialized ProgressTracker: source_id=%d, season_id=%s",
+            source_id,
+            season_id,
+        )
+
+    @property
+    def source_id(self) -> int:
+        """Data source identifier."""
+        return self._source_id
+
+    @property
+    def season_id(self) -> int | None:
+        """Season identifier."""
+        return self._season_id
+
+    @property
+    def stats(self) -> ProgressStats:
+        """Current progress statistics."""
+        return self._stats
+
+    @property
+    def is_complete(self) -> bool:
+        """Check if all registered items are processed."""
+        return self._stats.is_complete
+
+    async def load_state(self) -> int:
+        """Load existing progress state from database.
+
+        This method should be called before starting downloads to enable
+        resume functionality. It loads all existing progress entries and
+        populates the in-memory state.
+
+        Returns:
+            Number of entries loaded from database.
+        """
+        # Load incomplete items (pending + failed)
+        entries = await self._repo.get_incomplete(self._source_id, self._season_id)
+
+        for entry in entries:
+            state = ProgressState.PENDING
+            if entry.status == "failed":
+                state = ProgressState.FAILED
+
+            self._items[entry.item_key] = _ItemState(
+                key=entry.item_key,
+                state=state,
+                progress_id=entry.progress_id,
+                attempts=entry.attempts,
+                error_message=entry.error_message,
+            )
+
+        # Update stats based on loaded state
+        self._stats.pending = sum(
+            1 for item in self._items.values() if item.state == ProgressState.PENDING
+        )
+        self._stats.failed = sum(
+            1 for item in self._items.values() if item.state == ProgressState.FAILED
+        )
+
+        self._started = True
+        logger.info(
+            "Loaded %d incomplete items (pending=%d, failed=%d) for source_id=%d, season_id=%s",
+            len(entries),
+            self._stats.pending,
+            self._stats.failed,
+            self._source_id,
+            self._season_id,
+        )
+
+        return len(entries)
+
+    def set_total(self, total: int) -> None:
+        """Set the total number of items to process.
+
+        Args:
+            total: Total item count.
+        """
+        self._stats.total = total
+        logger.debug("Set total items to %d", total)
+
+    async def register_item(self, item_key: str) -> int:
+        """Register an item for tracking.
+
+        Creates a pending entry in the database if it doesn't exist.
+
+        Args:
+            item_key: Unique identifier for the item.
+
+        Returns:
+            The progress_id from the database.
+        """
+        if item_key in self._items:
+            item = self._items[item_key]
+            if item.progress_id is not None:
+                return item.progress_id
+
+        # Create or update in database
+        progress_id = await self._repo.upsert_progress(
+            source_id=self._source_id,
+            item_key=item_key,
+            season_id=self._season_id,
+            batch_id=self._batch_id,
+            status="pending",
+        )
+
+        # Update in-memory state
+        if item_key not in self._items:
+            self._items[item_key] = _ItemState(
+                key=item_key,
+                state=ProgressState.PENDING,
+                progress_id=progress_id,
+            )
+            self._stats.pending += 1
+        else:
+            self._items[item_key].progress_id = progress_id
+
+        return progress_id
+
+    async def register_items(self, item_keys: list[str]) -> None:
+        """Register multiple items for tracking.
+
+        More efficient than calling register_item individually.
+
+        Args:
+            item_keys: List of unique identifiers.
+        """
+        for item_key in item_keys:
+            await self.register_item(item_key)
+
+        if self._stats.total is None:
+            self._stats.total = len(self._items)
+
+        logger.debug("Registered %d items for tracking", len(item_keys))
+
+    def should_download(self, item_key: str) -> bool:
+        """Check if an item should be downloaded.
+
+        Returns True if the item is pending or failed (for retry).
+        Returns False if already completed or in progress.
+
+        Args:
+            item_key: Item identifier.
+
+        Returns:
+            True if the item needs to be downloaded.
+        """
+        if item_key not in self._items:
+            return True  # Unknown items should be downloaded
+
+        item = self._items[item_key]
+        return item.state in (ProgressState.PENDING, ProgressState.FAILED)
+
+    def get_pending_items(self) -> list[str]:
+        """Get all pending item keys.
+
+        Returns:
+            List of item keys that need to be downloaded.
+        """
+        return [
+            key
+            for key, item in self._items.items()
+            if item.state == ProgressState.PENDING
+        ]
+
+    def get_failed_items(self) -> list[str]:
+        """Get all failed item keys.
+
+        Returns:
+            List of item keys that failed and may be retried.
+        """
+        return [
+            key
+            for key, item in self._items.items()
+            if item.state == ProgressState.FAILED
+        ]
+
+    async def start_item(self, item_key: str) -> None:
+        """Mark an item as in progress.
+
+        Args:
+            item_key: Item identifier.
+        """
+        # Ensure item is registered
+        if item_key not in self._items:
+            await self.register_item(item_key)
+
+        item = self._items[item_key]
+        old_state = item.state
+
+        # Update in-memory state
+        item.state = ProgressState.IN_PROGRESS
+        item.started_at = datetime.now(UTC)
+        item.attempts += 1
+
+        # Update stats
+        if old_state == ProgressState.PENDING:
+            self._stats.pending -= 1
+        elif old_state == ProgressState.FAILED:
+            self._stats.failed -= 1
+        self._stats.in_progress += 1
+        self._stats.last_update = datetime.now(UTC)
+
+        # Update database
+        if item.progress_id is not None:
+            await self._repo.increment_attempts(item.progress_id)
+
+        # Notify callback
+        self._notify(item_key, ProgressState.IN_PROGRESS)
+
+        logger.debug("Started item %s (attempt %d)", item_key, item.attempts)
+
+    async def complete_item(
+        self,
+        item_key: str,
+        *,
+        response_size_bytes: int | None = None,
+        response_time_ms: int | None = None,
+    ) -> None:
+        """Mark an item as successfully completed.
+
+        Args:
+            item_key: Item identifier.
+            response_size_bytes: Size of downloaded data (optional).
+            response_time_ms: Download time in milliseconds (optional).
+        """
+        if item_key not in self._items:
+            logger.warning("Completing unknown item: %s", item_key)
+            return
+
+        item = self._items[item_key]
+
+        # Update in-memory state
+        item.state = ProgressState.SUCCESS
+        item.completed_at = datetime.now(UTC)
+        item.error_message = None
+
+        # Update stats
+        if self._stats.in_progress > 0:
+            self._stats.in_progress -= 1
+        self._stats.success += 1
+        self._stats.last_update = datetime.now(UTC)
+
+        # Update database
+        if item.progress_id is not None:
+            await self._repo.mark_success(
+                item.progress_id,
+                response_size_bytes=response_size_bytes,
+                response_time_ms=response_time_ms,
+            )
+
+        # Notify callback
+        self._notify(item_key, ProgressState.SUCCESS)
+
+        logger.debug("Completed item %s", item_key)
+
+    async def fail_item(self, item_key: str, error_message: str) -> None:
+        """Mark an item as failed.
+
+        Args:
+            item_key: Item identifier.
+            error_message: Description of the failure.
+        """
+        if item_key not in self._items:
+            logger.warning("Failing unknown item: %s", item_key)
+            return
+
+        item = self._items[item_key]
+
+        # Update in-memory state
+        item.state = ProgressState.FAILED
+        item.error_message = error_message
+
+        # Update stats
+        if self._stats.in_progress > 0:
+            self._stats.in_progress -= 1
+        self._stats.failed += 1
+        self._stats.last_update = datetime.now(UTC)
+
+        # Update database
+        if item.progress_id is not None:
+            await self._repo.mark_failed(item.progress_id, error_message)
+
+        # Notify callback
+        self._notify(item_key, ProgressState.FAILED, message=error_message)
+
+        logger.debug("Failed item %s: %s", item_key, error_message)
+
+    async def skip_item(self, item_key: str, reason: str | None = None) -> None:
+        """Mark an item as skipped.
+
+        Args:
+            item_key: Item identifier.
+            reason: Reason for skipping (optional).
+        """
+        if item_key not in self._items:
+            await self.register_item(item_key)
+
+        item = self._items[item_key]
+        old_state = item.state
+
+        # Update in-memory state
+        item.state = ProgressState.SKIPPED
+        item.completed_at = datetime.now(UTC)
+
+        # Update stats
+        if old_state == ProgressState.PENDING:
+            self._stats.pending -= 1
+        elif old_state == ProgressState.IN_PROGRESS:
+            self._stats.in_progress -= 1
+        elif old_state == ProgressState.FAILED:
+            self._stats.failed -= 1
+        self._stats.skipped += 1
+        self._stats.last_update = datetime.now(UTC)
+
+        # Update database
+        if item.progress_id is not None:
+            await self._repo.mark_skipped(item.progress_id, reason)
+
+        # Notify callback
+        self._notify(item_key, ProgressState.SKIPPED, message=reason)
+
+        logger.debug("Skipped item %s: %s", item_key, reason)
+
+    async def reset_failed(self) -> int:
+        """Reset all failed items to pending status.
+
+        Returns:
+            Number of items reset.
+        """
+        # Reset in database
+        count = await self._repo.reset_failed(self._source_id, self._season_id)
+
+        # Reset in-memory state
+        for item in self._items.values():
+            if item.state == ProgressState.FAILED:
+                item.state = ProgressState.PENDING
+                item.error_message = None
+
+        # Update stats
+        self._stats.pending += self._stats.failed
+        self._stats.failed = 0
+        self._stats.last_update = datetime.now(UTC)
+
+        logger.info("Reset %d failed items to pending", count)
+        return count
+
+    def get_item_state(self, item_key: str) -> ProgressState | None:
+        """Get the current state of an item.
+
+        Args:
+            item_key: Item identifier.
+
+        Returns:
+            Current state or None if item not tracked.
+        """
+        item = self._items.get(item_key)
+        return item.state if item else None
+
+    def get_item_attempts(self, item_key: str) -> int:
+        """Get the number of attempts for an item.
+
+        Args:
+            item_key: Item identifier.
+
+        Returns:
+            Number of attempts (0 if not tracked).
+        """
+        item = self._items.get(item_key)
+        return item.attempts if item else 0
+
+    def _notify(
+        self,
+        item_key: str,
+        state: ProgressState,
+        *,
+        message: str | None = None,
+    ) -> None:
+        """Send progress event to callback.
+
+        Args:
+            item_key: Item identifier.
+            state: New state.
+            message: Optional message.
+        """
+        if self._on_progress is None:
+            return
+
+        event = ProgressEvent(
+            source_id=self._source_id,
+            season_id=self._season_id,
+            item_key=item_key,
+            state=state,
+            stats=ProgressStats(
+                total=self._stats.total,
+                pending=self._stats.pending,
+                in_progress=self._stats.in_progress,
+                success=self._stats.success,
+                failed=self._stats.failed,
+                skipped=self._stats.skipped,
+                started_at=self._stats.started_at,
+                last_update=self._stats.last_update,
+            ),
+            message=message,
+        )
+
+        try:
+            self._on_progress(event)
+        except Exception:
+            logger.exception("Error in progress callback")
+
+    def __repr__(self) -> str:
+        return (
+            f"ProgressTracker("
+            f"source_id={self._source_id}, "
+            f"season_id={self._season_id}, "
+            f"items={len(self._items)}, "
+            f"stats={self._stats})"
+        )

--- a/tests/unit/test_progress_tracker.py
+++ b/tests/unit/test_progress_tracker.py
@@ -1,0 +1,777 @@
+"""Unit tests for ProgressTracker."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nhl_api.downloaders.progress.tracker import (
+    ProgressEvent,
+    ProgressState,
+    ProgressStats,
+    ProgressTracker,
+)
+from nhl_api.services.db.progress_repo import ProgressEntry, ProgressRepository
+
+
+def create_mock_repo() -> MagicMock:
+    """Create a mock ProgressRepository."""
+    repo = MagicMock(spec=ProgressRepository)
+    repo.upsert_progress = AsyncMock(return_value=1)
+    repo.get_incomplete = AsyncMock(return_value=[])
+    repo.increment_attempts = AsyncMock(return_value=1)
+    repo.mark_success = AsyncMock()
+    repo.mark_failed = AsyncMock()
+    repo.mark_skipped = AsyncMock()
+    repo.reset_failed = AsyncMock(return_value=0)
+    return repo
+
+
+def create_mock_entry(
+    progress_id: int = 1,
+    source_id: int = 1,
+    season_id: int | None = 20242025,
+    item_key: str = "2024020001",
+    status: str = "pending",
+    attempts: int = 0,
+    error_message: str | None = None,
+) -> ProgressEntry:
+    """Create a mock ProgressEntry."""
+    return ProgressEntry(
+        progress_id=progress_id,
+        source_id=source_id,
+        season_id=season_id,
+        item_key=item_key,
+        status=status,
+        attempts=attempts,
+        error_message=error_message,
+    )
+
+
+class TestProgressState:
+    """Tests for ProgressState enum."""
+
+    def test_has_expected_values(self) -> None:
+        """Test that all expected states exist."""
+        assert ProgressState.PENDING.value == "pending"
+        assert ProgressState.IN_PROGRESS.value == "in_progress"
+        assert ProgressState.SUCCESS.value == "success"
+        assert ProgressState.FAILED.value == "failed"
+        assert ProgressState.SKIPPED.value == "skipped"
+
+
+class TestProgressStats:
+    """Tests for ProgressStats dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default values are correct."""
+        stats = ProgressStats()
+        assert stats.total is None
+        assert stats.pending == 0
+        assert stats.in_progress == 0
+        assert stats.success == 0
+        assert stats.failed == 0
+        assert stats.skipped == 0
+
+    def test_completed_property(self) -> None:
+        """Test completed property calculation."""
+        stats = ProgressStats(success=10, failed=2, skipped=3)
+        assert stats.completed == 15
+
+    def test_processed_property(self) -> None:
+        """Test processed property calculation."""
+        stats = ProgressStats(success=10, failed=2, skipped=3, in_progress=5)
+        assert stats.processed == 20
+
+    def test_success_rate_with_completions(self) -> None:
+        """Test success rate calculation."""
+        stats = ProgressStats(success=8, failed=2)
+        assert stats.success_rate == 80.0
+
+    def test_success_rate_with_no_completions(self) -> None:
+        """Test success rate is 0 with no completions."""
+        stats = ProgressStats()
+        assert stats.success_rate == 0.0
+
+    def test_progress_percent_with_total(self) -> None:
+        """Test progress percentage calculation."""
+        stats = ProgressStats(total=100, success=25, failed=5, skipped=10)
+        assert stats.progress_percent == 40.0
+
+    def test_progress_percent_without_total(self) -> None:
+        """Test progress percentage is 0 without total."""
+        stats = ProgressStats(success=25)
+        assert stats.progress_percent == 0.0
+
+    def test_is_complete_when_done(self) -> None:
+        """Test is_complete when all items processed."""
+        stats = ProgressStats(total=10, success=8, failed=2)
+        assert stats.is_complete is True
+
+    def test_is_complete_when_not_done(self) -> None:
+        """Test is_complete when items remain."""
+        stats = ProgressStats(total=10, success=5)
+        assert stats.is_complete is False
+
+    def test_is_complete_without_total(self) -> None:
+        """Test is_complete is False without total."""
+        stats = ProgressStats(success=100)
+        assert stats.is_complete is False
+
+
+class TestProgressEvent:
+    """Tests for ProgressEvent dataclass."""
+
+    def test_creates_with_required_fields(self) -> None:
+        """Test creating event with required fields."""
+        stats = ProgressStats()
+        event = ProgressEvent(
+            source_id=1,
+            item_key="game_123",
+            state=ProgressState.IN_PROGRESS,
+            stats=stats,
+        )
+        assert event.source_id == 1
+        assert event.item_key == "game_123"
+        assert event.state == ProgressState.IN_PROGRESS
+        assert event.stats is stats
+
+    def test_optional_fields(self) -> None:
+        """Test optional fields."""
+        stats = ProgressStats()
+        event = ProgressEvent(
+            source_id=1,
+            item_key="game_123",
+            state=ProgressState.FAILED,
+            stats=stats,
+            season_id=20242025,
+            message="Connection failed",
+        )
+        assert event.season_id == 20242025
+        assert event.message == "Connection failed"
+
+    def test_is_frozen(self) -> None:
+        """Test that event is immutable."""
+        stats = ProgressStats()
+        event = ProgressEvent(
+            source_id=1,
+            item_key="game_123",
+            state=ProgressState.PENDING,
+            stats=stats,
+        )
+        with pytest.raises(AttributeError):
+            event.state = ProgressState.SUCCESS  # type: ignore[misc]
+
+
+class TestProgressTrackerInit:
+    """Tests for ProgressTracker initialization."""
+
+    def test_stores_config(self) -> None:
+        """Test that tracker stores configuration."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1, season_id=20242025, batch_id=5)
+        assert tracker.source_id == 1
+        assert tracker.season_id == 20242025
+
+    def test_initializes_empty_state(self) -> None:
+        """Test that tracker starts with empty state."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        assert tracker.stats.pending == 0
+        assert tracker.stats.success == 0
+        assert tracker.stats.total is None
+
+    def test_repr(self) -> None:
+        """Test string representation."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1, season_id=20242025)
+        repr_str = repr(tracker)
+        assert "source_id=1" in repr_str
+        assert "season_id=20242025" in repr_str
+
+
+class TestLoadState:
+    """Tests for load_state method."""
+
+    @pytest.mark.asyncio
+    async def test_loads_incomplete_entries(self) -> None:
+        """Test loading incomplete entries from database."""
+        repo = create_mock_repo()
+        repo.get_incomplete.return_value = [
+            create_mock_entry(progress_id=1, item_key="game_1", status="pending"),
+            create_mock_entry(progress_id=2, item_key="game_2", status="failed"),
+        ]
+
+        tracker = ProgressTracker(repo, source_id=1, season_id=20242025)
+        count = await tracker.load_state()
+
+        assert count == 2
+        assert tracker.stats.pending == 1
+        assert tracker.stats.failed == 1
+        repo.get_incomplete.assert_called_once_with(1, 20242025)
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_empty_db(self) -> None:
+        """Test returns zero when no entries in database."""
+        repo = create_mock_repo()
+        repo.get_incomplete.return_value = []
+
+        tracker = ProgressTracker(repo, source_id=1)
+        count = await tracker.load_state()
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_preserves_progress_ids(self) -> None:
+        """Test that progress IDs from DB are preserved."""
+        repo = create_mock_repo()
+        repo.get_incomplete.return_value = [
+            create_mock_entry(progress_id=42, item_key="game_1", status="pending"),
+        ]
+
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.load_state()
+
+        # Start item should use existing progress_id
+        await tracker.start_item("game_1")
+        repo.increment_attempts.assert_called_once_with(42)
+
+
+class TestSetTotal:
+    """Tests for set_total method."""
+
+    def test_sets_total(self) -> None:
+        """Test setting total items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        tracker.set_total(100)
+        assert tracker.stats.total == 100
+
+    def test_updates_is_complete(self) -> None:
+        """Test that is_complete reflects total."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        assert tracker.is_complete is False
+        tracker.set_total(0)
+        # With 0 total and 0 completed, is_complete is True (nothing to do)
+        assert tracker.is_complete is True
+
+
+class TestRegisterItem:
+    """Tests for register_item method."""
+
+    @pytest.mark.asyncio
+    async def test_creates_db_entry(self) -> None:
+        """Test that register_item creates database entry."""
+        repo = create_mock_repo()
+        repo.upsert_progress.return_value = 42
+
+        tracker = ProgressTracker(repo, source_id=1, season_id=20242025, batch_id=5)
+        progress_id = await tracker.register_item("game_123")
+
+        assert progress_id == 42
+        repo.upsert_progress.assert_called_once_with(
+            source_id=1,
+            item_key="game_123",
+            season_id=20242025,
+            batch_id=5,
+            status="pending",
+        )
+
+    @pytest.mark.asyncio
+    async def test_updates_stats(self) -> None:
+        """Test that register_item updates pending count."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+
+        await tracker.register_item("game_1")
+        await tracker.register_item("game_2")
+
+        assert tracker.stats.pending == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_progress_id(self) -> None:
+        """Test that re-registering returns existing progress_id."""
+        repo = create_mock_repo()
+        repo.upsert_progress.return_value = 42
+
+        tracker = ProgressTracker(repo, source_id=1)
+        id1 = await tracker.register_item("game_1")
+        id2 = await tracker.register_item("game_1")
+
+        assert id1 == 42
+        assert id2 == 42
+        # Should only create once
+        assert repo.upsert_progress.call_count == 1
+
+
+class TestRegisterItems:
+    """Tests for register_items method."""
+
+    @pytest.mark.asyncio
+    async def test_registers_multiple(self) -> None:
+        """Test registering multiple items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+
+        await tracker.register_items(["game_1", "game_2", "game_3"])
+
+        assert tracker.stats.pending == 3
+        assert repo.upsert_progress.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_sets_total_if_not_set(self) -> None:
+        """Test that total is set from item count."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+
+        await tracker.register_items(["game_1", "game_2"])
+
+        assert tracker.stats.total == 2
+
+
+class TestShouldDownload:
+    """Tests for should_download method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_unknown(self) -> None:
+        """Test returns True for unknown items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        assert tracker.should_download("unknown_game") is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_pending(self) -> None:
+        """Test returns True for pending items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        assert tracker.should_download("game_1") is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_failed(self) -> None:
+        """Test returns True for failed items (retry)."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.fail_item("game_1", "Error")
+        assert tracker.should_download("game_1") is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_success(self) -> None:
+        """Test returns False for successful items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.complete_item("game_1")
+        assert tracker.should_download("game_1") is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_in_progress(self) -> None:
+        """Test returns False for in-progress items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        assert tracker.should_download("game_1") is False
+
+
+class TestGetPendingItems:
+    """Tests for get_pending_items method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_pending_keys(self) -> None:
+        """Test returning pending item keys."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.register_item("game_2")
+        await tracker.start_item("game_2")
+
+        pending = tracker.get_pending_items()
+
+        assert pending == ["game_1"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_none_pending(self) -> None:
+        """Test returns empty list when no pending items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        assert tracker.get_pending_items() == []
+
+
+class TestGetFailedItems:
+    """Tests for get_failed_items method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_failed_keys(self) -> None:
+        """Test returning failed item keys."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.register_item("game_2")
+        await tracker.start_item("game_1")
+        await tracker.fail_item("game_1", "Error")
+
+        failed = tracker.get_failed_items()
+
+        assert failed == ["game_1"]
+
+
+class TestStartItem:
+    """Tests for start_item method."""
+
+    @pytest.mark.asyncio
+    async def test_updates_state(self) -> None:
+        """Test that start_item updates state to in_progress."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+
+        assert tracker.get_item_state("game_1") == ProgressState.IN_PROGRESS
+        assert tracker.stats.pending == 0
+        assert tracker.stats.in_progress == 1
+
+    @pytest.mark.asyncio
+    async def test_increments_attempts_in_db(self) -> None:
+        """Test that attempts are incremented in database."""
+        repo = create_mock_repo()
+        repo.upsert_progress.return_value = 42
+
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+
+        repo.increment_attempts.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_auto_registers_unknown_item(self) -> None:
+        """Test that unknown items are auto-registered."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.start_item("new_game")
+
+        assert tracker.get_item_state("new_game") == ProgressState.IN_PROGRESS
+        repo.upsert_progress.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_failed_to_in_progress(self) -> None:
+        """Test starting a failed item (retry)."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.fail_item("game_1", "Error")
+
+        assert tracker.stats.failed == 1
+
+        await tracker.start_item("game_1")
+
+        assert tracker.stats.failed == 0
+        assert tracker.stats.in_progress == 1
+
+
+class TestCompleteItem:
+    """Tests for complete_item method."""
+
+    @pytest.mark.asyncio
+    async def test_updates_state(self) -> None:
+        """Test that complete_item updates state to success."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.complete_item("game_1")
+
+        assert tracker.get_item_state("game_1") == ProgressState.SUCCESS
+        assert tracker.stats.in_progress == 0
+        assert tracker.stats.success == 1
+
+    @pytest.mark.asyncio
+    async def test_marks_success_in_db(self) -> None:
+        """Test that success is recorded in database."""
+        repo = create_mock_repo()
+        repo.upsert_progress.return_value = 42
+
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.complete_item(
+            "game_1", response_size_bytes=1024, response_time_ms=150
+        )
+
+        repo.mark_success.assert_called_once_with(
+            42, response_size_bytes=1024, response_time_ms=150
+        )
+
+    @pytest.mark.asyncio
+    async def test_handles_unknown_item(self) -> None:
+        """Test completing unknown item logs warning but doesn't crash."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.complete_item("unknown")  # Should not raise
+
+
+class TestFailItem:
+    """Tests for fail_item method."""
+
+    @pytest.mark.asyncio
+    async def test_updates_state(self) -> None:
+        """Test that fail_item updates state to failed."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.fail_item("game_1", "Connection timeout")
+
+        assert tracker.get_item_state("game_1") == ProgressState.FAILED
+        assert tracker.stats.in_progress == 0
+        assert tracker.stats.failed == 1
+
+    @pytest.mark.asyncio
+    async def test_marks_failed_in_db(self) -> None:
+        """Test that failure is recorded in database."""
+        repo = create_mock_repo()
+        repo.upsert_progress.return_value = 42
+
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.fail_item("game_1", "Server error")
+
+        repo.mark_failed.assert_called_once_with(42, "Server error")
+
+
+class TestSkipItem:
+    """Tests for skip_item method."""
+
+    @pytest.mark.asyncio
+    async def test_updates_state(self) -> None:
+        """Test that skip_item updates state to skipped."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.skip_item("game_1", "Already exists")
+
+        assert tracker.get_item_state("game_1") == ProgressState.SKIPPED
+        assert tracker.stats.pending == 0
+        assert tracker.stats.skipped == 1
+
+    @pytest.mark.asyncio
+    async def test_marks_skipped_in_db(self) -> None:
+        """Test that skip is recorded in database."""
+        repo = create_mock_repo()
+        repo.upsert_progress.return_value = 42
+
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.skip_item("game_1", "Already exists")
+
+        repo.mark_skipped.assert_called_once_with(42, "Already exists")
+
+    @pytest.mark.asyncio
+    async def test_auto_registers_unknown_item(self) -> None:
+        """Test that unknown items are auto-registered when skipping."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.skip_item("new_game", "Not needed")
+
+        assert tracker.get_item_state("new_game") == ProgressState.SKIPPED
+
+
+class TestResetFailed:
+    """Tests for reset_failed method."""
+
+    @pytest.mark.asyncio
+    async def test_resets_in_memory_state(self) -> None:
+        """Test that failed items are reset to pending in memory."""
+        repo = create_mock_repo()
+        repo.reset_failed.return_value = 1
+
+        tracker = ProgressTracker(repo, source_id=1, season_id=20242025)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.fail_item("game_1", "Error")
+
+        assert tracker.stats.failed == 1
+
+        count = await tracker.reset_failed()
+
+        assert count == 1
+        assert tracker.stats.failed == 0
+        assert tracker.stats.pending == 1
+        assert tracker.get_item_state("game_1") == ProgressState.PENDING
+
+    @pytest.mark.asyncio
+    async def test_calls_db_reset(self) -> None:
+        """Test that database reset is called."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1, season_id=20242025)
+
+        await tracker.reset_failed()
+
+        repo.reset_failed.assert_called_once_with(1, 20242025)
+
+
+class TestGetItemState:
+    """Tests for get_item_state method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_state(self) -> None:
+        """Test returning item state."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+
+        assert tracker.get_item_state("game_1") == ProgressState.PENDING
+
+    def test_returns_none_for_unknown(self) -> None:
+        """Test returning None for unknown items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        assert tracker.get_item_state("unknown") is None
+
+
+class TestGetItemAttempts:
+    """Tests for get_item_attempts method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_attempt_count(self) -> None:
+        """Test returning attempt count."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.fail_item("game_1", "Error")
+        await tracker.start_item("game_1")
+
+        assert tracker.get_item_attempts("game_1") == 2
+
+    def test_returns_zero_for_unknown(self) -> None:
+        """Test returning 0 for unknown items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        assert tracker.get_item_attempts("unknown") == 0
+
+
+class TestProgressCallback:
+    """Tests for progress callbacks."""
+
+    @pytest.mark.asyncio
+    async def test_calls_callback_on_start(self) -> None:
+        """Test that callback is called when item starts."""
+        repo = create_mock_repo()
+        events: list[ProgressEvent] = []
+
+        def callback(event: ProgressEvent) -> None:
+            events.append(event)
+
+        tracker = ProgressTracker(repo, source_id=1, on_progress=callback)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+
+        assert len(events) == 1
+        assert events[0].item_key == "game_1"
+        assert events[0].state == ProgressState.IN_PROGRESS
+
+    @pytest.mark.asyncio
+    async def test_calls_callback_on_complete(self) -> None:
+        """Test that callback is called when item completes."""
+        repo = create_mock_repo()
+        events: list[ProgressEvent] = []
+
+        def callback(event: ProgressEvent) -> None:
+            events.append(event)
+
+        tracker = ProgressTracker(repo, source_id=1, on_progress=callback)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.complete_item("game_1")
+
+        assert len(events) == 2
+        assert events[1].state == ProgressState.SUCCESS
+
+    @pytest.mark.asyncio
+    async def test_calls_callback_on_fail(self) -> None:
+        """Test that callback is called with error message."""
+        repo = create_mock_repo()
+        events: list[ProgressEvent] = []
+
+        def callback(event: ProgressEvent) -> None:
+            events.append(event)
+
+        tracker = ProgressTracker(repo, source_id=1, on_progress=callback)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+        await tracker.fail_item("game_1", "Connection failed")
+
+        assert len(events) == 2
+        assert events[1].state == ProgressState.FAILED
+        assert events[1].message == "Connection failed"
+
+    @pytest.mark.asyncio
+    async def test_includes_stats_in_callback(self) -> None:
+        """Test that callback includes current stats."""
+        repo = create_mock_repo()
+        events: list[ProgressEvent] = []
+
+        def callback(event: ProgressEvent) -> None:
+            events.append(event)
+
+        tracker = ProgressTracker(repo, source_id=1, on_progress=callback)
+        tracker.set_total(10)
+        await tracker.register_item("game_1")
+        await tracker.start_item("game_1")
+
+        assert events[0].stats.total == 10
+        assert events[0].stats.in_progress == 1
+
+    @pytest.mark.asyncio
+    async def test_handles_callback_exception(self) -> None:
+        """Test that callback exceptions don't crash tracker."""
+        repo = create_mock_repo()
+
+        def bad_callback(event: ProgressEvent) -> None:
+            raise ValueError("Callback error")
+
+        tracker = ProgressTracker(repo, source_id=1, on_progress=bad_callback)
+        await tracker.register_item("game_1")
+        # Should not raise
+        await tracker.start_item("game_1")
+        await tracker.complete_item("game_1")
+
+
+class TestIsComplete:
+    """Tests for is_complete property."""
+
+    @pytest.mark.asyncio
+    async def test_is_complete_when_all_done(self) -> None:
+        """Test is_complete returns True when all items processed."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        tracker.set_total(2)
+        await tracker.register_item("game_1")
+        await tracker.register_item("game_2")
+        await tracker.start_item("game_1")
+        await tracker.complete_item("game_1")
+        await tracker.start_item("game_2")
+        await tracker.complete_item("game_2")
+
+        assert tracker.is_complete is True
+
+    @pytest.mark.asyncio
+    async def test_is_not_complete_with_pending(self) -> None:
+        """Test is_complete returns False with pending items."""
+        repo = create_mock_repo()
+        tracker = ProgressTracker(repo, source_id=1)
+        tracker.set_total(2)
+        await tracker.register_item("game_1")
+        await tracker.register_item("game_2")
+        await tracker.start_item("game_1")
+        await tracker.complete_item("game_1")
+
+        assert tracker.is_complete is False


### PR DESCRIPTION
## Summary

- Implement in-memory progress tracking with database persistence for resumable downloads
- Add `ProgressTracker` class that bridges `BaseDownloader` with `ProgressRepository`
- Support for per-item state tracking (pending, in_progress, success, failed, skipped)
- Real-time progress callbacks for UI updates
- Aggregated statistics via `ProgressStats` dataclass

## Features

- **Resume Support**: Load existing state from DB via `load_state()` before starting downloads
- **Progress Callbacks**: Register callbacks to receive `ProgressEvent` updates in real-time
- **State Queries**: `should_download()`, `get_pending_items()`, `get_failed_items()`
- **Statistics**: Track total, pending, in_progress, success, failed, skipped counts
- **Retry Tracking**: Automatic attempt counting per item
- **Batch Reset**: `reset_failed()` to retry all failed items

## Files Changed

- `src/nhl_api/downloaders/progress/__init__.py` - Module exports
- `src/nhl_api/downloaders/progress/tracker.py` - Main tracker implementation
- `tests/unit/test_progress_tracker.py` - 60 unit tests

## Test plan

- [x] All 60 unit tests pass
- [x] ruff check passes
- [x] ruff format passes
- [x] mypy passes
- [x] Pre-commit hooks pass

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)