### PR TITLE
Implement Entity API endpoints for players, teams, and games (#44)

### DIFF
--- a/src/nhl_api/viewer/routers/entities.py
+++ b/src/nhl_api/viewer/routers/entities.py
@@ -1,19 +1,415 @@
-"""Entity exploration endpoints.
+"""Entity exploration endpoints for players, teams, and games.
 
-Future implementation will provide:
-- Player lookups
-- Team information
-- Game data exploration
+Provides paginated, searchable, and filterable access to NHL entity data
+using materialized views for optimal query performance.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from datetime import date
+from typing import Annotated, Literal
 
-router = APIRouter(prefix="/entities", tags=["entities"])
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from nhl_api.services.db import DatabaseService
+from nhl_api.viewer.dependencies import get_db
+from nhl_api.viewer.schemas.entities import (
+    DivisionTeams,
+    GameDetail,
+    GameListResponse,
+    GameSummary,
+    PaginationMeta,
+    PlayerDetail,
+    PlayerListResponse,
+    PlayerSummary,
+    TeamDetail,
+    TeamListResponse,
+    TeamSummary,
+    TeamWithRoster,
+)
+
+# Type alias for dependency injection
+DbDep = Annotated[DatabaseService, Depends(get_db)]
+
+router = APIRouter(tags=["entities"])
 
 
-@router.get("/")
-async def list_entity_types() -> dict[str, str]:
-    """List available entity types (not yet implemented)."""
-    return {"message": "Entity endpoints coming soon"}
+# =============================================================================
+# Players
+# =============================================================================
+
+
+@router.get(
+    "/players",
+    response_model=PlayerListResponse,
+    summary="List Players",
+    description="Get paginated list of players with search and position filter",
+)
+async def list_players(
+    db: DbDep,
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 25,
+    search: Annotated[str | None, Query(description="Search by player name")] = None,
+    position: Annotated[
+        Literal["C", "LW", "RW", "D", "G"] | None,
+        Query(description="Filter by primary position"),
+    ] = None,
+    team_id: Annotated[int | None, Query(description="Filter by team ID")] = None,
+    active_only: Annotated[bool, Query(description="Only show active players")] = True,
+) -> PlayerListResponse:
+    """Get a paginated list of players.
+
+    Supports full-text search on player names and filtering by position/team.
+    """
+    # Build WHERE clauses
+    conditions: list[str] = []
+    params: list[object] = []
+    param_idx = 1
+
+    if active_only:
+        conditions.append("active = TRUE")
+
+    if search:
+        conditions.append(
+            f"(full_name ILIKE ${param_idx} OR "
+            f"to_tsvector('english', full_name) @@ plainto_tsquery('english', ${param_idx + 1}))"
+        )
+        params.extend([f"%{search}%", search])
+        param_idx += 2
+
+    if position:
+        conditions.append(f"primary_position = ${param_idx}")
+        params.append(position)
+        param_idx += 1
+
+    if team_id:
+        conditions.append(f"current_team_id = ${param_idx}")
+        params.append(team_id)
+        param_idx += 1
+
+    where_clause = " AND ".join(conditions) if conditions else "TRUE"
+
+    # Get total count
+    count_query = f"SELECT COUNT(*) FROM mv_player_summary WHERE {where_clause}"
+    total_items = await db.fetchval(count_query, *params)
+
+    # Calculate pagination
+    total_pages = (total_items + per_page - 1) // per_page if total_items > 0 else 0
+    offset = (page - 1) * per_page
+
+    # Get players
+    query = f"""
+        SELECT
+            player_id, first_name, last_name, full_name, age,
+            primary_position, position_type, current_team_id,
+            team_name, team_abbreviation, sweater_number,
+            headshot_url, active
+        FROM mv_player_summary
+        WHERE {where_clause}
+        ORDER BY last_name, first_name
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+    """
+    params.extend([per_page, offset])
+
+    rows = await db.fetch(query, *params)
+
+    players = [PlayerSummary(**dict(row)) for row in rows]
+
+    return PlayerListResponse(
+        players=players,
+        pagination=PaginationMeta(
+            page=page,
+            per_page=per_page,
+            total_items=total_items,
+            total_pages=total_pages,
+        ),
+    )
+
+
+@router.get(
+    "/players/{player_id}",
+    response_model=PlayerDetail,
+    summary="Get Player",
+    description="Get detailed player information by ID",
+)
+async def get_player(
+    db: DbDep,
+    player_id: int,
+) -> PlayerDetail:
+    """Get detailed information for a specific player."""
+    query = """
+        SELECT
+            player_id, first_name, last_name, full_name,
+            birth_date, age, birth_country, nationality,
+            height_inches, height_display, weight_lbs,
+            shoots_catches, primary_position, position_type,
+            roster_status, current_team_id, team_name,
+            team_abbreviation, division_name, conference_name,
+            captain, alternate_captain, rookie, nhl_experience,
+            sweater_number, headshot_url, active, updated_at
+        FROM mv_player_summary
+        WHERE player_id = $1
+    """
+    row = await db.fetchrow(query, player_id)
+
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Player with ID {player_id} not found",
+        )
+
+    return PlayerDetail(**dict(row))
+
+
+# =============================================================================
+# Teams
+# =============================================================================
+
+
+@router.get(
+    "/teams",
+    response_model=TeamListResponse,
+    summary="List Teams",
+    description="Get all teams grouped by division",
+)
+async def list_teams(
+    db: DbDep,
+    active_only: Annotated[bool, Query(description="Only show active teams")] = True,
+) -> TeamListResponse:
+    """Get all teams grouped by division and conference."""
+    where_clause = "t.active = TRUE" if active_only else "TRUE"
+
+    query = f"""
+        SELECT
+            t.team_id, t.name, t.abbreviation, t.team_name,
+            t.location_name, t.division_id, d.name AS division_name,
+            t.conference_id, c.name AS conference_name, t.active
+        FROM teams t
+        LEFT JOIN divisions d ON t.division_id = d.division_id
+        LEFT JOIN conferences c ON t.conference_id = c.conference_id
+        WHERE {where_clause}
+        ORDER BY c.name, d.name, t.name
+    """
+    rows = await db.fetch(query)
+
+    # Group by division
+    divisions_map: dict[int, DivisionTeams] = {}
+    for row in rows:
+        div_id = row["division_id"]
+        if div_id is None:
+            continue
+
+        if div_id not in divisions_map:
+            divisions_map[div_id] = DivisionTeams(
+                division_id=div_id,
+                division_name=row["division_name"] or "Unknown",
+                conference_name=row["conference_name"],
+                teams=[],
+            )
+        divisions_map[div_id].teams.append(TeamSummary(**dict(row)))
+
+    return TeamListResponse(
+        divisions=list(divisions_map.values()),
+        total_teams=len(rows),
+    )
+
+
+@router.get(
+    "/teams/{team_id}",
+    response_model=TeamWithRoster,
+    summary="Get Team",
+    description="Get team details with current roster",
+)
+async def get_team(
+    db: DbDep,
+    team_id: int,
+) -> TeamWithRoster:
+    """Get detailed team information with current roster."""
+    # Get team details
+    team_query = """
+        SELECT
+            t.team_id, t.franchise_id, t.name, t.abbreviation,
+            t.team_name, t.location_name, t.division_id,
+            d.name AS division_name, t.conference_id,
+            c.name AS conference_name, t.venue_id,
+            v.name AS venue_name, t.first_year_of_play,
+            t.official_site_url, t.active, t.updated_at
+        FROM teams t
+        LEFT JOIN divisions d ON t.division_id = d.division_id
+        LEFT JOIN conferences c ON t.conference_id = c.conference_id
+        LEFT JOIN venues v ON t.venue_id = v.venue_id
+        WHERE t.team_id = $1
+    """
+    team_row = await db.fetchrow(team_query, team_id)
+
+    if not team_row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Team with ID {team_id} not found",
+        )
+
+    team = TeamDetail(**dict(team_row))
+
+    # Get roster
+    roster_query = """
+        SELECT
+            player_id, first_name, last_name, full_name, age,
+            primary_position, position_type, current_team_id,
+            team_name, team_abbreviation, sweater_number,
+            headshot_url, active
+        FROM mv_player_summary
+        WHERE current_team_id = $1 AND active = TRUE
+        ORDER BY
+            CASE position_type
+                WHEN 'G' THEN 1
+                WHEN 'D' THEN 2
+                WHEN 'F' THEN 3
+                ELSE 4
+            END,
+            last_name, first_name
+    """
+    roster_rows = await db.fetch(roster_query, team_id)
+    roster = [PlayerSummary(**dict(row)) for row in roster_rows]
+
+    return TeamWithRoster(team=team, roster=roster)
+
+
+# =============================================================================
+# Games
+# =============================================================================
+
+
+@router.get(
+    "/games",
+    response_model=GameListResponse,
+    summary="List Games",
+    description="Get paginated list of games with date and team filters",
+)
+async def list_games(
+    db: DbDep,
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 25,
+    season: Annotated[
+        str | None, Query(description="Filter by season (e.g., '20242025')")
+    ] = None,
+    team_id: Annotated[
+        int | None, Query(description="Filter by team (home or away)")
+    ] = None,
+    start_date: Annotated[
+        date | None, Query(description="Start date (inclusive)")
+    ] = None,
+    end_date: Annotated[date | None, Query(description="End date (inclusive)")] = None,
+    game_type: Annotated[
+        Literal["PR", "R", "P", "A"] | None,
+        Query(description="Game type: PR=Preseason, R=Regular, P=Playoffs, A=All-Star"),
+    ] = None,
+) -> GameListResponse:
+    """Get a paginated list of games.
+
+    Supports filtering by season, team, date range, and game type.
+    """
+    # Build WHERE clauses
+    conditions: list[str] = []
+    params: list[object] = []
+    param_idx = 1
+
+    if season:
+        conditions.append(f"season_name = ${param_idx}")
+        params.append(season)
+        param_idx += 1
+
+    if team_id:
+        conditions.append(
+            f"(home_team_id = ${param_idx} OR away_team_id = ${param_idx})"
+        )
+        params.append(team_id)
+        param_idx += 1
+
+    if start_date:
+        conditions.append(f"game_date >= ${param_idx}")
+        params.append(start_date)
+        param_idx += 1
+
+    if end_date:
+        conditions.append(f"game_date <= ${param_idx}")
+        params.append(end_date)
+        param_idx += 1
+
+    if game_type:
+        conditions.append(f"game_type = ${param_idx}")
+        params.append(game_type)
+        param_idx += 1
+
+    where_clause = " AND ".join(conditions) if conditions else "TRUE"
+
+    # Get total count
+    count_query = f"SELECT COUNT(*) FROM mv_game_summary WHERE {where_clause}"
+    total_items = await db.fetchval(count_query, *params)
+
+    # Calculate pagination
+    total_pages = (total_items + per_page - 1) // per_page if total_items > 0 else 0
+    offset = (page - 1) * per_page
+
+    # Get games
+    query = f"""
+        SELECT
+            game_id, season_id, season_name, game_type, game_type_name,
+            game_date, game_time, venue_name, home_team_id,
+            home_team_name, home_team_abbr, home_score,
+            away_team_id, away_team_name, away_team_abbr, away_score,
+            game_state, is_overtime, is_shootout, winner_abbr
+        FROM mv_game_summary
+        WHERE {where_clause}
+        ORDER BY game_date DESC, game_time DESC NULLS LAST
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+    """
+    params.extend([per_page, offset])
+
+    rows = await db.fetch(query, *params)
+
+    games = [GameSummary(**dict(row)) for row in rows]
+
+    return GameListResponse(
+        games=games,
+        pagination=PaginationMeta(
+            page=page,
+            per_page=per_page,
+            total_items=total_items,
+            total_pages=total_pages,
+        ),
+    )
+
+
+@router.get(
+    "/games/{game_id}",
+    response_model=GameDetail,
+    summary="Get Game",
+    description="Get detailed game information by ID",
+)
+async def get_game(
+    db: DbDep,
+    game_id: int,
+) -> GameDetail:
+    """Get detailed information for a specific game."""
+    query = """
+        SELECT
+            game_id, season_id, season_name, game_type, game_type_name,
+            game_date, game_time, venue_id, venue_name, venue_city,
+            home_team_id, home_team_name, home_team_abbr, home_score,
+            away_team_id, away_team_name, away_team_abbr, away_score,
+            final_period, game_state, is_overtime, is_shootout,
+            game_outcome, winner_team_id, winner_abbr,
+            goal_differential, attendance, game_duration_minutes,
+            updated_at
+        FROM mv_game_summary
+        WHERE game_id = $1
+    """
+    row = await db.fetchrow(query, game_id)
+
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Game with ID {game_id} not found",
+        )
+
+    return GameDetail(**dict(row))

--- a/src/nhl_api/viewer/schemas/__init__.py
+++ b/src/nhl_api/viewer/schemas/__init__.py
@@ -1,0 +1,31 @@
+"""Pydantic schemas for viewer API responses."""
+
+from nhl_api.viewer.schemas.entities import (
+    DivisionTeams,
+    GameDetail,
+    GameListResponse,
+    GameSummary,
+    PaginationMeta,
+    PlayerDetail,
+    PlayerListResponse,
+    PlayerSummary,
+    TeamDetail,
+    TeamListResponse,
+    TeamSummary,
+    TeamWithRoster,
+)
+
+__all__ = [
+    "DivisionTeams",
+    "GameDetail",
+    "GameListResponse",
+    "GameSummary",
+    "PaginationMeta",
+    "PlayerDetail",
+    "PlayerListResponse",
+    "PlayerSummary",
+    "TeamDetail",
+    "TeamListResponse",
+    "TeamSummary",
+    "TeamWithRoster",
+]

--- a/src/nhl_api/viewer/schemas/entities.py
+++ b/src/nhl_api/viewer/schemas/entities.py
@@ -1,0 +1,222 @@
+"""Pydantic schemas for entity API endpoints.
+
+Defines request/response models for players, teams, and games.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+
+class PaginationMeta(BaseModel):
+    """Pagination metadata for list responses."""
+
+    page: int = Field(ge=1, description="Current page number")
+    per_page: int = Field(ge=1, le=100, description="Items per page")
+    total_items: int = Field(ge=0, description="Total number of items")
+    total_pages: int = Field(ge=0, description="Total number of pages")
+
+
+# =============================================================================
+# Players
+# =============================================================================
+
+
+class PlayerSummary(BaseModel):
+    """Player summary for list views."""
+
+    player_id: int
+    first_name: str
+    last_name: str
+    full_name: str
+    age: int | None = None
+    primary_position: str | None = None
+    position_type: Literal["F", "D", "G"] | None = None
+    current_team_id: int | None = None
+    team_name: str | None = None
+    team_abbreviation: str | None = None
+    sweater_number: int | None = None
+    headshot_url: str | None = None
+    active: bool = True
+
+
+class PlayerDetail(BaseModel):
+    """Detailed player information."""
+
+    player_id: int
+    first_name: str
+    last_name: str
+    full_name: str
+    birth_date: date | None = None
+    age: int | None = None
+    birth_country: str | None = None
+    nationality: str | None = None
+    height_inches: int | None = None
+    height_display: str | None = None
+    weight_lbs: int | None = None
+    shoots_catches: str | None = None
+    primary_position: str | None = None
+    position_type: Literal["F", "D", "G"] | None = None
+    roster_status: str | None = None
+    current_team_id: int | None = None
+    team_name: str | None = None
+    team_abbreviation: str | None = None
+    division_name: str | None = None
+    conference_name: str | None = None
+    captain: bool = False
+    alternate_captain: bool = False
+    rookie: bool = False
+    nhl_experience: int | None = None
+    sweater_number: int | None = None
+    headshot_url: str | None = None
+    active: bool = True
+    updated_at: datetime | None = None
+
+
+class PlayerListResponse(BaseModel):
+    """Response for player list endpoint."""
+
+    players: list[PlayerSummary]
+    pagination: PaginationMeta
+
+
+# =============================================================================
+# Teams
+# =============================================================================
+
+
+class TeamSummary(BaseModel):
+    """Team summary for list views."""
+
+    team_id: int
+    name: str
+    abbreviation: str
+    team_name: str | None = None
+    location_name: str | None = None
+    division_id: int | None = None
+    division_name: str | None = None
+    conference_id: int | None = None
+    conference_name: str | None = None
+    active: bool = True
+
+
+class TeamDetail(BaseModel):
+    """Detailed team information."""
+
+    team_id: int
+    franchise_id: int | None = None
+    name: str
+    abbreviation: str
+    team_name: str | None = None
+    location_name: str | None = None
+    division_id: int | None = None
+    division_name: str | None = None
+    conference_id: int | None = None
+    conference_name: str | None = None
+    venue_id: int | None = None
+    venue_name: str | None = None
+    first_year_of_play: int | None = None
+    official_site_url: str | None = None
+    active: bool = True
+    updated_at: datetime | None = None
+
+
+class TeamWithRoster(BaseModel):
+    """Team with roster players."""
+
+    team: TeamDetail
+    roster: list[PlayerSummary]
+
+
+class DivisionTeams(BaseModel):
+    """Teams grouped by division."""
+
+    division_id: int
+    division_name: str
+    conference_name: str | None = None
+    teams: list[TeamSummary]
+
+
+class TeamListResponse(BaseModel):
+    """Response for team list endpoint with division grouping."""
+
+    divisions: list[DivisionTeams]
+    total_teams: int
+
+
+# =============================================================================
+# Games
+# =============================================================================
+
+
+class GameSummary(BaseModel):
+    """Game summary for list views."""
+
+    game_id: int
+    season_id: int
+    season_name: str | None = None
+    game_type: str
+    game_type_name: str | None = None
+    game_date: date
+    game_time: str | None = None
+    venue_name: str | None = None
+    home_team_id: int
+    home_team_name: str
+    home_team_abbr: str
+    home_score: int | None = None
+    away_team_id: int
+    away_team_name: str
+    away_team_abbr: str
+    away_score: int | None = None
+    game_state: str | None = None
+    is_overtime: bool = False
+    is_shootout: bool = False
+    winner_abbr: str | None = None
+
+
+class GameDetail(BaseModel):
+    """Detailed game information."""
+
+    game_id: int
+    season_id: int
+    season_name: str | None = None
+    game_type: str
+    game_type_name: str | None = None
+    game_date: date
+    game_time: str | None = None
+    venue_id: int | None = None
+    venue_name: str | None = None
+    venue_city: str | None = None
+    home_team_id: int
+    home_team_name: str
+    home_team_abbr: str
+    home_score: int | None = None
+    away_team_id: int
+    away_team_name: str
+    away_team_abbr: str
+    away_score: int | None = None
+    final_period: int | None = None
+    game_state: str | None = None
+    is_overtime: bool = False
+    is_shootout: bool = False
+    game_outcome: str | None = None
+    winner_team_id: int | None = None
+    winner_abbr: str | None = None
+    goal_differential: int | None = None
+    attendance: int | None = None
+    game_duration_minutes: int | None = None
+    updated_at: datetime | None = None
+
+
+class GameListResponse(BaseModel):
+    """Response for game list endpoint."""
+
+    games: list[GameSummary]
+    pagination: PaginationMeta

--- a/tests/unit/viewer/test_api_info.py
+++ b/tests/unit/viewer/test_api_info.py
@@ -40,15 +40,6 @@ class TestStubEndpoints:
         assert "message" in data
         assert "coming soon" in data["message"].lower()
 
-    def test_entities_list_returns_coming_soon(self, test_client: TestClient) -> None:
-        """Test entities list stub returns coming soon message."""
-        response = test_client.get("/api/v1/entities/")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert "message" in data
-        assert "coming soon" in data["message"].lower()
-
     def test_validation_status_returns_coming_soon(
         self, test_client: TestClient
     ) -> None:

--- a/tests/unit/viewer/test_entities.py
+++ b/tests/unit/viewer/test_entities.py
@@ -1,0 +1,652 @@
+"""Tests for entity API endpoints."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+# =============================================================================
+# Player Tests
+# =============================================================================
+
+
+class TestListPlayers:
+    """Tests for GET /api/v1/players endpoint."""
+
+    def test_list_players_returns_paginated_results(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test player list returns paginated response."""
+        mock_db_service.fetchval = AsyncMock(return_value=100)
+        mock_db_service.fetch = AsyncMock(
+            return_value=[
+                {
+                    "player_id": 8478402,
+                    "first_name": "Connor",
+                    "last_name": "McDavid",
+                    "full_name": "Connor McDavid",
+                    "age": 27,
+                    "primary_position": "C",
+                    "position_type": "F",
+                    "current_team_id": 22,
+                    "team_name": "Edmonton Oilers",
+                    "team_abbreviation": "EDM",
+                    "sweater_number": 97,
+                    "headshot_url": "https://example.com/mcdavid.jpg",
+                    "active": True,
+                }
+            ]
+        )
+
+        response = test_client.get("/api/v1/players")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "players" in data
+        assert "pagination" in data
+        assert len(data["players"]) == 1
+        assert data["players"][0]["player_id"] == 8478402
+        assert data["players"][0]["full_name"] == "Connor McDavid"
+        assert data["pagination"]["total_items"] == 100
+        assert data["pagination"]["page"] == 1
+        assert data["pagination"]["per_page"] == 25
+
+    def test_list_players_with_search(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test player list with search filter."""
+        mock_db_service.fetchval = AsyncMock(return_value=1)
+        mock_db_service.fetch = AsyncMock(
+            return_value=[
+                {
+                    "player_id": 8478402,
+                    "first_name": "Connor",
+                    "last_name": "McDavid",
+                    "full_name": "Connor McDavid",
+                    "age": 27,
+                    "primary_position": "C",
+                    "position_type": "F",
+                    "current_team_id": 22,
+                    "team_name": "Edmonton Oilers",
+                    "team_abbreviation": "EDM",
+                    "sweater_number": 97,
+                    "headshot_url": None,
+                    "active": True,
+                }
+            ]
+        )
+
+        response = test_client.get("/api/v1/players?search=McDavid")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["players"]) == 1
+        assert data["players"][0]["last_name"] == "McDavid"
+
+    def test_list_players_with_position_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test player list with position filter."""
+        mock_db_service.fetchval = AsyncMock(return_value=50)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/players?position=G")
+
+        assert response.status_code == 200
+        # Verify query was called with position filter
+        mock_db_service.fetch.assert_called_once()
+
+    def test_list_players_with_team_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test player list filtered by team."""
+        mock_db_service.fetchval = AsyncMock(return_value=25)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/players?team_id=22")
+
+        assert response.status_code == 200
+        mock_db_service.fetch.assert_called_once()
+
+    def test_list_players_pagination(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test player list pagination parameters."""
+        mock_db_service.fetchval = AsyncMock(return_value=200)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/players?page=3&per_page=50")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["page"] == 3
+        assert data["pagination"]["per_page"] == 50
+        assert data["pagination"]["total_pages"] == 4
+
+    def test_list_players_empty_results(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test player list with no results."""
+        mock_db_service.fetchval = AsyncMock(return_value=0)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/players?search=nonexistent")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["players"] == []
+        assert data["pagination"]["total_items"] == 0
+        assert data["pagination"]["total_pages"] == 0
+
+
+class TestGetPlayer:
+    """Tests for GET /api/v1/players/{player_id} endpoint."""
+
+    def test_get_player_returns_detail(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test get player returns detailed information."""
+        mock_db_service.fetchrow = AsyncMock(
+            return_value={
+                "player_id": 8478402,
+                "first_name": "Connor",
+                "last_name": "McDavid",
+                "full_name": "Connor McDavid",
+                "birth_date": date(1997, 1, 13),
+                "age": 27,
+                "birth_country": "CAN",
+                "nationality": "CAN",
+                "height_inches": 73,
+                "height_display": "6'1\"",
+                "weight_lbs": 193,
+                "shoots_catches": "L",
+                "primary_position": "C",
+                "position_type": "F",
+                "roster_status": "Y",
+                "current_team_id": 22,
+                "team_name": "Edmonton Oilers",
+                "team_abbreviation": "EDM",
+                "division_name": "Pacific",
+                "conference_name": "Western",
+                "captain": True,
+                "alternate_captain": False,
+                "rookie": False,
+                "nhl_experience": 9,
+                "sweater_number": 97,
+                "headshot_url": "https://example.com/mcdavid.jpg",
+                "active": True,
+                "updated_at": datetime(2024, 12, 20, 12, 0, 0),
+            }
+        )
+
+        response = test_client.get("/api/v1/players/8478402")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["player_id"] == 8478402
+        assert data["full_name"] == "Connor McDavid"
+        assert data["captain"] is True
+        assert data["height_display"] == "6'1\""
+        assert data["nhl_experience"] == 9
+
+    def test_get_player_not_found(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test get player returns 404 for non-existent player."""
+        mock_db_service.fetchrow = AsyncMock(return_value=None)
+
+        response = test_client.get("/api/v1/players/9999999")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+
+# =============================================================================
+# Team Tests
+# =============================================================================
+
+
+class TestListTeams:
+    """Tests for GET /api/v1/teams endpoint."""
+
+    def test_list_teams_returns_grouped_by_division(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test teams are grouped by division."""
+        mock_db_service.fetch = AsyncMock(
+            return_value=[
+                {
+                    "team_id": 22,
+                    "name": "Edmonton Oilers",
+                    "abbreviation": "EDM",
+                    "team_name": "Oilers",
+                    "location_name": "Edmonton",
+                    "division_id": 15,
+                    "division_name": "Pacific",
+                    "conference_id": 5,
+                    "conference_name": "Western",
+                    "active": True,
+                },
+                {
+                    "team_id": 26,
+                    "name": "Los Angeles Kings",
+                    "abbreviation": "LAK",
+                    "team_name": "Kings",
+                    "location_name": "Los Angeles",
+                    "division_id": 15,
+                    "division_name": "Pacific",
+                    "conference_id": 5,
+                    "conference_name": "Western",
+                    "active": True,
+                },
+                {
+                    "team_id": 6,
+                    "name": "Boston Bruins",
+                    "abbreviation": "BOS",
+                    "team_name": "Bruins",
+                    "location_name": "Boston",
+                    "division_id": 17,
+                    "division_name": "Atlantic",
+                    "conference_id": 6,
+                    "conference_name": "Eastern",
+                    "active": True,
+                },
+            ]
+        )
+
+        response = test_client.get("/api/v1/teams")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "divisions" in data
+        assert "total_teams" in data
+        assert data["total_teams"] == 3
+        # Should be grouped into 2 divisions
+        assert len(data["divisions"]) == 2
+
+    def test_list_teams_includes_division_info(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test teams include division and conference info."""
+        mock_db_service.fetch = AsyncMock(
+            return_value=[
+                {
+                    "team_id": 22,
+                    "name": "Edmonton Oilers",
+                    "abbreviation": "EDM",
+                    "team_name": "Oilers",
+                    "location_name": "Edmonton",
+                    "division_id": 15,
+                    "division_name": "Pacific",
+                    "conference_id": 5,
+                    "conference_name": "Western",
+                    "active": True,
+                }
+            ]
+        )
+
+        response = test_client.get("/api/v1/teams")
+
+        assert response.status_code == 200
+        data = response.json()
+        division = data["divisions"][0]
+        assert division["division_name"] == "Pacific"
+        assert division["conference_name"] == "Western"
+        assert len(division["teams"]) == 1
+
+    def test_list_teams_empty(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test teams list with no results."""
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/teams")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["divisions"] == []
+        assert data["total_teams"] == 0
+
+    def test_list_teams_skips_teams_without_division(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test teams without division_id are skipped in grouping."""
+        mock_db_service.fetch = AsyncMock(
+            return_value=[
+                {
+                    "team_id": 22,
+                    "name": "Edmonton Oilers",
+                    "abbreviation": "EDM",
+                    "team_name": "Oilers",
+                    "location_name": "Edmonton",
+                    "division_id": 15,
+                    "division_name": "Pacific",
+                    "conference_id": 5,
+                    "conference_name": "Western",
+                    "active": True,
+                },
+                {
+                    "team_id": 99,
+                    "name": "Test Team No Division",
+                    "abbreviation": "TND",
+                    "team_name": "No Division",
+                    "location_name": "Nowhere",
+                    "division_id": None,  # No division
+                    "division_name": None,
+                    "conference_id": None,
+                    "conference_name": None,
+                    "active": True,
+                },
+            ]
+        )
+
+        response = test_client.get("/api/v1/teams")
+
+        assert response.status_code == 200
+        data = response.json()
+        # Total teams includes the one without division in count
+        assert data["total_teams"] == 2
+        # But divisions only has the one with a division
+        assert len(data["divisions"]) == 1
+        assert data["divisions"][0]["division_id"] == 15
+        assert len(data["divisions"][0]["teams"]) == 1
+
+
+class TestGetTeam:
+    """Tests for GET /api/v1/teams/{team_id} endpoint."""
+
+    def test_get_team_returns_detail_with_roster(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test get team returns details with roster."""
+        # First call: team details
+        team_row = {
+            "team_id": 22,
+            "franchise_id": 25,
+            "name": "Edmonton Oilers",
+            "abbreviation": "EDM",
+            "team_name": "Oilers",
+            "location_name": "Edmonton",
+            "division_id": 15,
+            "division_name": "Pacific",
+            "conference_id": 5,
+            "conference_name": "Western",
+            "venue_id": 5100,
+            "venue_name": "Rogers Place",
+            "first_year_of_play": 1979,
+            "official_site_url": "https://www.nhl.com/oilers",
+            "active": True,
+            "updated_at": datetime(2024, 12, 20, 12, 0, 0),
+        }
+
+        # Second call: roster
+        roster_rows = [
+            {
+                "player_id": 8478402,
+                "first_name": "Connor",
+                "last_name": "McDavid",
+                "full_name": "Connor McDavid",
+                "age": 27,
+                "primary_position": "C",
+                "position_type": "F",
+                "current_team_id": 22,
+                "team_name": "Edmonton Oilers",
+                "team_abbreviation": "EDM",
+                "sweater_number": 97,
+                "headshot_url": None,
+                "active": True,
+            }
+        ]
+
+        mock_db_service.fetchrow = AsyncMock(return_value=team_row)
+        mock_db_service.fetch = AsyncMock(return_value=roster_rows)
+
+        response = test_client.get("/api/v1/teams/22")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "team" in data
+        assert "roster" in data
+        assert data["team"]["team_id"] == 22
+        assert data["team"]["name"] == "Edmonton Oilers"
+        assert data["team"]["venue_name"] == "Rogers Place"
+        assert len(data["roster"]) == 1
+        assert data["roster"][0]["full_name"] == "Connor McDavid"
+
+    def test_get_team_not_found(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test get team returns 404 for non-existent team."""
+        mock_db_service.fetchrow = AsyncMock(return_value=None)
+
+        response = test_client.get("/api/v1/teams/9999")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+
+# =============================================================================
+# Game Tests
+# =============================================================================
+
+
+class TestListGames:
+    """Tests for GET /api/v1/games endpoint."""
+
+    def test_list_games_returns_paginated_results(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test games list returns paginated response."""
+        mock_db_service.fetchval = AsyncMock(return_value=1312)
+        mock_db_service.fetch = AsyncMock(
+            return_value=[
+                {
+                    "game_id": 2024020500,
+                    "season_id": 20242025,
+                    "season_name": "20242025",
+                    "game_type": "R",
+                    "game_type_name": "Regular Season",
+                    "game_date": date(2024, 12, 20),
+                    "game_time": "19:00:00",
+                    "venue_name": "Rogers Place",
+                    "home_team_id": 22,
+                    "home_team_name": "Edmonton Oilers",
+                    "home_team_abbr": "EDM",
+                    "home_score": 4,
+                    "away_team_id": 20,
+                    "away_team_name": "Calgary Flames",
+                    "away_team_abbr": "CGY",
+                    "away_score": 2,
+                    "game_state": "Final",
+                    "is_overtime": False,
+                    "is_shootout": False,
+                    "winner_abbr": "EDM",
+                }
+            ]
+        )
+
+        response = test_client.get("/api/v1/games")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "games" in data
+        assert "pagination" in data
+        assert len(data["games"]) == 1
+        assert data["games"][0]["game_id"] == 2024020500
+        assert data["games"][0]["home_team_abbr"] == "EDM"
+        assert data["games"][0]["winner_abbr"] == "EDM"
+
+    def test_list_games_with_season_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test games list filtered by season."""
+        mock_db_service.fetchval = AsyncMock(return_value=82)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/games?season=20242025")
+
+        assert response.status_code == 200
+        mock_db_service.fetch.assert_called_once()
+
+    def test_list_games_with_team_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test games list filtered by team."""
+        mock_db_service.fetchval = AsyncMock(return_value=82)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/games?team_id=22")
+
+        assert response.status_code == 200
+        mock_db_service.fetch.assert_called_once()
+
+    def test_list_games_with_date_range(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test games list filtered by date range."""
+        mock_db_service.fetchval = AsyncMock(return_value=10)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get(
+            "/api/v1/games?start_date=2024-12-01&end_date=2024-12-31"
+        )
+
+        assert response.status_code == 200
+        mock_db_service.fetch.assert_called_once()
+
+    def test_list_games_with_game_type_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test games list filtered by game type."""
+        mock_db_service.fetchval = AsyncMock(return_value=16)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/games?game_type=P")
+
+        assert response.status_code == 200
+        mock_db_service.fetch.assert_called_once()
+
+    def test_list_games_empty(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test games list with no results."""
+        mock_db_service.fetchval = AsyncMock(return_value=0)
+        mock_db_service.fetch = AsyncMock(return_value=[])
+
+        response = test_client.get("/api/v1/games?team_id=9999")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["games"] == []
+        assert data["pagination"]["total_items"] == 0
+
+
+class TestGetGame:
+    """Tests for GET /api/v1/games/{game_id} endpoint."""
+
+    def test_get_game_returns_detail(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test get game returns detailed information."""
+        mock_db_service.fetchrow = AsyncMock(
+            return_value={
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "season_name": "20242025",
+                "game_type": "R",
+                "game_type_name": "Regular Season",
+                "game_date": date(2024, 12, 20),
+                "game_time": "19:00:00",
+                "venue_id": 5100,
+                "venue_name": "Rogers Place",
+                "venue_city": "Edmonton",
+                "home_team_id": 22,
+                "home_team_name": "Edmonton Oilers",
+                "home_team_abbr": "EDM",
+                "home_score": 4,
+                "away_team_id": 20,
+                "away_team_name": "Calgary Flames",
+                "away_team_abbr": "CGY",
+                "away_score": 2,
+                "final_period": 3,
+                "game_state": "Final",
+                "is_overtime": False,
+                "is_shootout": False,
+                "game_outcome": "REG",
+                "winner_team_id": 22,
+                "winner_abbr": "EDM",
+                "goal_differential": 2,
+                "attendance": 18347,
+                "game_duration_minutes": 150,
+                "updated_at": datetime(2024, 12, 20, 22, 30, 0),
+            }
+        )
+
+        response = test_client.get("/api/v1/games/2024020500")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["game_id"] == 2024020500
+        assert data["home_score"] == 4
+        assert data["away_score"] == 2
+        assert data["winner_team_id"] == 22
+        assert data["attendance"] == 18347
+        assert data["venue_city"] == "Edmonton"
+
+    def test_get_game_overtime(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test get game with overtime result."""
+        mock_db_service.fetchrow = AsyncMock(
+            return_value={
+                "game_id": 2024020501,
+                "season_id": 20242025,
+                "season_name": "20242025",
+                "game_type": "R",
+                "game_type_name": "Regular Season",
+                "game_date": date(2024, 12, 21),
+                "game_time": "20:00:00",
+                "venue_id": 5100,
+                "venue_name": "Rogers Place",
+                "venue_city": "Edmonton",
+                "home_team_id": 22,
+                "home_team_name": "Edmonton Oilers",
+                "home_team_abbr": "EDM",
+                "home_score": 3,
+                "away_team_id": 25,
+                "away_team_name": "Dallas Stars",
+                "away_team_abbr": "DAL",
+                "away_score": 2,
+                "final_period": 4,
+                "game_state": "Final",
+                "is_overtime": True,
+                "is_shootout": False,
+                "game_outcome": "OT",
+                "winner_team_id": 22,
+                "winner_abbr": "EDM",
+                "goal_differential": 1,
+                "attendance": 18347,
+                "game_duration_minutes": 165,
+                "updated_at": datetime(2024, 12, 21, 23, 0, 0),
+            }
+        )
+
+        response = test_client.get("/api/v1/games/2024020501")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_overtime"] is True
+        assert data["final_period"] == 4
+
+    def test_get_game_not_found(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Test get game returns 404 for non-existent game."""
+        mock_db_service.fetchrow = AsyncMock(return_value=None)
+
+        response = test_client.get("/api/v1/games/9999999999")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- Implement 6 Entity API endpoints for browsing NHL data (players, teams, games)
- Add Pydantic schemas for request/response validation with full type safety
- Create 23 comprehensive unit tests achieving 100% coverage on entities module

## Endpoints Added

### Players
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/players` | Paginated list with search, position, team filters |
| GET | `/api/v1/players/{player_id}` | Detailed player information |

### Teams
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/teams` | All teams grouped by division/conference |
| GET | `/api/v1/teams/{team_id}` | Team details with current roster |

### Games
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/games` | Paginated with season, team, date range filters |
| GET | `/api/v1/games/{game_id}` | Detailed game information |

## Features
- Full-text search support for player names (ILIKE + tsvector)
- Pagination with configurable page size (1-100, default 25)
- Position filtering (C, LW, RW, D, G)
- Date range filtering for games
- Teams grouped by division with conference info

## Files Changed
- `src/nhl_api/viewer/routers/entities.py` - Main endpoint implementations
- `src/nhl_api/viewer/schemas/entities.py` - Pydantic models (new)
- `src/nhl_api/viewer/schemas/__init__.py` - Schema exports (new)
- `tests/unit/viewer/test_entities.py` - 23 unit tests (new)
- `tests/unit/viewer/test_api_info.py` - Remove outdated stub test

## Test plan
- [x] All 339 unit tests pass
- [x] 95.64% overall coverage (above 80% threshold)
- [x] 100% coverage on entities router and schemas
- [x] Pre-commit hooks pass (ruff, mypy, pytest)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)