### PR TITLE
Implement Roster Downloader (#67)

### DIFF
--- a/src/nhl_api/downloaders/sources/nhl_json/__init__.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/__init__.py
@@ -13,15 +13,27 @@ from nhl_api.downloaders.sources.nhl_json.play_by_play import (
     PlayByPlayDownloaderConfig,
     create_play_by_play_downloader,
 )
+from nhl_api.downloaders.sources.nhl_json.roster import (
+    NHL_TEAM_ABBREVS,
+    ParsedRoster,
+    PlayerInfo,
+    RosterDownloader,
+    create_roster_downloader,
+)
 from nhl_api.downloaders.sources.nhl_json.schedule import ScheduleDownloader
 
 __all__ = [
     "BoxscoreDownloader",
     "EventPlayer",
     "GameEvent",
+    "NHL_TEAM_ABBREVS",
     "ParsedPlayByPlay",
+    "ParsedRoster",
     "PlayByPlayDownloader",
     "PlayByPlayDownloaderConfig",
+    "PlayerInfo",
+    "RosterDownloader",
     "ScheduleDownloader",
     "create_play_by_play_downloader",
+    "create_roster_downloader",
 ]

--- a/src/nhl_api/downloaders/sources/nhl_json/roster.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/roster.py
@@ -1,0 +1,496 @@
+"""NHL Roster Downloader.
+
+Downloads team rosters from the NHL JSON API (api-web.nhle.com/v1/).
+Provides methods to fetch current rosters, historical rosters by season,
+and available seasons for each team.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+from typing import TYPE_CHECKING, Any
+
+from nhl_api.downloaders.base.base_downloader import (
+    BaseDownloader,
+    DownloaderConfig,
+)
+from nhl_api.downloaders.base.protocol import DownloadError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Sequence
+
+logger = logging.getLogger(__name__)
+
+# NHL JSON API base URL
+NHL_API_BASE_URL = "https://api-web.nhle.com/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class PlayerInfo:
+    """Parsed player information from roster response.
+
+    Contains all biographical and roster information for a player.
+    """
+
+    player_id: int
+    first_name: str
+    last_name: str
+    sweater_number: int | None
+    position_code: str  # L, R, C, D, G
+    shoots_catches: str  # L or R
+    height_inches: int
+    weight_pounds: int
+    height_cm: int
+    weight_kg: int
+    birth_date: date | None
+    birth_city: str | None
+    birth_country: str | None
+    birth_state_province: str | None
+    headshot_url: str | None
+    team_abbrev: str  # Team this player is on
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedRoster:
+    """Complete roster for a team.
+
+    Contains lists of forwards, defensemen, and goalies.
+    """
+
+    team_abbrev: str
+    season_id: int | None  # None for current roster
+    forwards: tuple[PlayerInfo, ...]
+    defensemen: tuple[PlayerInfo, ...]
+    goalies: tuple[PlayerInfo, ...]
+
+    @property
+    def all_players(self) -> tuple[PlayerInfo, ...]:
+        """Return all players on the roster."""
+        return self.forwards + self.defensemen + self.goalies
+
+    @property
+    def player_count(self) -> int:
+        """Return total number of players on roster."""
+        return len(self.forwards) + len(self.defensemen) + len(self.goalies)
+
+
+def _parse_localized_name(name_obj: dict[str, Any] | None) -> str:
+    """Parse a localized name object, returning the default value.
+
+    Args:
+        name_obj: Object with 'default' and potentially other locale keys
+
+    Returns:
+        The default name or empty string if not available
+    """
+    if not name_obj:
+        return ""
+    result = name_obj.get("default", "")
+    return str(result) if result else ""
+
+
+def _parse_birth_date(date_str: str | None) -> date | None:
+    """Parse a birth date string to date object.
+
+    Args:
+        date_str: ISO format date string (YYYY-MM-DD)
+
+    Returns:
+        Parsed date or None if parsing fails
+    """
+    if not date_str:
+        return None
+    try:
+        return date.fromisoformat(date_str)
+    except ValueError:
+        logger.warning("Failed to parse birth date: %s", date_str)
+        return None
+
+
+def _parse_player(player_data: dict[str, Any], team_abbrev: str) -> PlayerInfo:
+    """Parse a single player from the roster response.
+
+    Args:
+        player_data: Raw player data from API
+        team_abbrev: Team abbreviation for this roster
+
+    Returns:
+        Parsed PlayerInfo object
+    """
+    return PlayerInfo(
+        player_id=player_data["id"],
+        first_name=_parse_localized_name(player_data.get("firstName")),
+        last_name=_parse_localized_name(player_data.get("lastName")),
+        sweater_number=player_data.get("sweaterNumber"),
+        position_code=player_data.get("positionCode", ""),
+        shoots_catches=player_data.get("shootsCatches", ""),
+        height_inches=player_data.get("heightInInches", 0),
+        weight_pounds=player_data.get("weightInPounds", 0),
+        height_cm=player_data.get("heightInCentimeters", 0),
+        weight_kg=player_data.get("weightInKilograms", 0),
+        birth_date=_parse_birth_date(player_data.get("birthDate")),
+        birth_city=_parse_localized_name(player_data.get("birthCity")),
+        birth_country=player_data.get("birthCountry"),
+        birth_state_province=_parse_localized_name(
+            player_data.get("birthStateProvince")
+        ),
+        headshot_url=player_data.get("headshot"),
+        team_abbrev=team_abbrev,
+    )
+
+
+def _parse_roster(
+    data: dict[str, Any], team_abbrev: str, season_id: int | None = None
+) -> ParsedRoster:
+    """Parse a complete roster response.
+
+    Args:
+        data: Raw roster data from API
+        team_abbrev: Team abbreviation
+        season_id: Season ID if historical roster, None for current
+
+    Returns:
+        Parsed roster object
+    """
+    forwards = tuple(_parse_player(p, team_abbrev) for p in data.get("forwards", []))
+    defensemen = tuple(
+        _parse_player(p, team_abbrev) for p in data.get("defensemen", [])
+    )
+    goalies = tuple(_parse_player(p, team_abbrev) for p in data.get("goalies", []))
+
+    return ParsedRoster(
+        team_abbrev=team_abbrev,
+        season_id=season_id,
+        forwards=forwards,
+        defensemen=defensemen,
+        goalies=goalies,
+    )
+
+
+# All 32 NHL team abbreviations
+NHL_TEAM_ABBREVS: tuple[str, ...] = (
+    "ANA",  # Anaheim Ducks
+    "ARI",  # Arizona Coyotes (relocated to UTA 2024)
+    "BOS",  # Boston Bruins
+    "BUF",  # Buffalo Sabres
+    "CAR",  # Carolina Hurricanes
+    "CBJ",  # Columbus Blue Jackets
+    "CGY",  # Calgary Flames
+    "CHI",  # Chicago Blackhawks
+    "COL",  # Colorado Avalanche
+    "DAL",  # Dallas Stars
+    "DET",  # Detroit Red Wings
+    "EDM",  # Edmonton Oilers
+    "FLA",  # Florida Panthers
+    "LAK",  # Los Angeles Kings
+    "MIN",  # Minnesota Wild
+    "MTL",  # Montreal Canadiens
+    "NJD",  # New Jersey Devils
+    "NSH",  # Nashville Predators
+    "NYI",  # New York Islanders
+    "NYR",  # New York Rangers
+    "OTT",  # Ottawa Senators
+    "PHI",  # Philadelphia Flyers
+    "PIT",  # Pittsburgh Penguins
+    "SEA",  # Seattle Kraken
+    "SJS",  # San Jose Sharks
+    "STL",  # St. Louis Blues
+    "TBL",  # Tampa Bay Lightning
+    "TOR",  # Toronto Maple Leafs
+    "UTA",  # Utah Hockey Club (formerly ARI)
+    "VAN",  # Vancouver Canucks
+    "VGK",  # Vegas Golden Knights
+    "WPG",  # Winnipeg Jets
+    "WSH",  # Washington Capitals
+)
+
+
+class RosterDownloader(BaseDownloader):
+    """Downloads NHL team rosters.
+
+    Supports multiple access patterns:
+    - Current roster: get_current_roster()
+    - Historical roster: get_roster_for_season()
+    - All teams: download_all_current_rosters()
+    - Available seasons: get_available_seasons()
+
+    Example:
+        config = DownloaderConfig(base_url=NHL_API_BASE_URL)
+        async with RosterDownloader(config) as downloader:
+            # Get current Boston roster
+            roster = await downloader.get_current_roster("BOS")
+
+            # Get historical roster
+            roster = await downloader.get_roster_for_season("BOS", 20232024)
+
+            # Download all current rosters
+            async for roster in downloader.download_all_current_rosters():
+                print(f"{roster.team_abbrev}: {roster.player_count} players")
+    """
+
+    @property
+    def source_name(self) -> str:
+        """Return unique identifier for this source."""
+        return "nhl_json_roster"
+
+    async def _fetch_game(self, game_id: int) -> dict[str, Any]:
+        """Not used for roster downloads.
+
+        Roster downloads are team-based, not game-based.
+        """
+        # This method is required by BaseDownloader but not applicable
+        # for roster downloads which are team-centric
+        return {"_note": "Roster downloads are team-based, not game-based"}
+
+    async def _fetch_season_games(self, season_id: int) -> AsyncGenerator[int, None]:
+        """Not used for roster downloads.
+
+        Roster downloads are team-based, not game-based.
+        Use download_all_current_rosters() or download_rosters_for_season()
+        instead.
+
+        Args:
+            season_id: NHL season ID (not used)
+
+        Yields:
+            Nothing - this method is not applicable for roster downloads
+        """
+        # This method is required by BaseDownloader but not applicable
+        # for roster downloads which are team-centric
+        return
+        yield  # Make this a generator (never reached)
+
+    async def get_current_roster(self, team_abbrev: str) -> ParsedRoster:
+        """Get the current roster for a team.
+
+        Args:
+            team_abbrev: Team abbreviation (e.g., "BOS", "NYR")
+
+        Returns:
+            ParsedRoster with all current players
+
+        Raises:
+            DownloadError: If the roster cannot be fetched
+        """
+        logger.debug("Fetching current roster for %s", team_abbrev)
+
+        response = await self._get(f"roster/{team_abbrev}/current")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch roster for {team_abbrev}: HTTP {response.status}",
+                source=self.source_name,
+            )
+
+        data = response.json()
+        roster = _parse_roster(data, team_abbrev)
+
+        logger.info(
+            "Fetched %d players for %s (F:%d D:%d G:%d)",
+            roster.player_count,
+            team_abbrev,
+            len(roster.forwards),
+            len(roster.defensemen),
+            len(roster.goalies),
+        )
+
+        return roster
+
+    async def get_roster_for_season(
+        self, team_abbrev: str, season_id: int
+    ) -> ParsedRoster:
+        """Get the roster for a team in a specific season.
+
+        Args:
+            team_abbrev: Team abbreviation (e.g., "BOS", "NYR")
+            season_id: Season ID (e.g., 20232024)
+
+        Returns:
+            ParsedRoster for the specified season
+
+        Raises:
+            DownloadError: If the roster cannot be fetched
+        """
+        logger.debug("Fetching roster for %s season %d", team_abbrev, season_id)
+
+        response = await self._get(f"roster/{team_abbrev}/{season_id}")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch roster for {team_abbrev} "
+                f"season {season_id}: HTTP {response.status}",
+                source=self.source_name,
+            )
+
+        data = response.json()
+        roster = _parse_roster(data, team_abbrev, season_id)
+
+        logger.info(
+            "Fetched %d players for %s season %d",
+            roster.player_count,
+            team_abbrev,
+            season_id,
+        )
+
+        return roster
+
+    async def get_available_seasons(self, team_abbrev: str) -> list[int]:
+        """Get all seasons with roster data available for a team.
+
+        Args:
+            team_abbrev: Team abbreviation (e.g., "BOS", "NYR")
+
+        Returns:
+            List of season IDs (e.g., [20232024, 20222023, ...])
+
+        Raises:
+            DownloadError: If the seasons cannot be fetched
+        """
+        logger.debug("Fetching available seasons for %s", team_abbrev)
+
+        response = await self._get(f"roster-season/{team_abbrev}")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch seasons for {team_abbrev}: HTTP {response.status}",
+                source=self.source_name,
+            )
+
+        data = response.json()
+        # API returns list of season strings like "20232024"
+        seasons = [int(s) for s in data if s.isdigit()]
+
+        logger.info("Found %d seasons for %s", len(seasons), team_abbrev)
+
+        return sorted(seasons, reverse=True)
+
+    async def download_all_current_rosters(
+        self, team_abbrevs: Sequence[str] | None = None
+    ) -> list[ParsedRoster]:
+        """Download current rosters for multiple teams.
+
+        Args:
+            team_abbrevs: List of team abbreviations to download.
+                         If None, downloads all 32 NHL teams.
+
+        Returns:
+            List of ParsedRoster objects
+
+        Raises:
+            DownloadError: If any roster cannot be fetched
+        """
+        teams = team_abbrevs if team_abbrevs is not None else NHL_TEAM_ABBREVS
+        self.set_total_items(len(teams))
+
+        logger.info("Downloading rosters for %d teams", len(teams))
+
+        rosters: list[ParsedRoster] = []
+        for team in teams:
+            try:
+                roster = await self.get_current_roster(team)
+                rosters.append(roster)
+            except DownloadError as e:
+                logger.warning("Failed to download roster for %s: %s", team, e)
+                # Continue with other teams
+
+        logger.info(
+            "Downloaded %d rosters with %d total players",
+            len(rosters),
+            sum(r.player_count for r in rosters),
+        )
+
+        return rosters
+
+    async def download_rosters_for_season(
+        self,
+        season_id: int,
+        team_abbrevs: Sequence[str] | None = None,
+    ) -> list[ParsedRoster]:
+        """Download rosters for multiple teams for a specific season.
+
+        Args:
+            season_id: Season ID (e.g., 20232024)
+            team_abbrevs: List of team abbreviations to download.
+                         If None, downloads all 32 NHL teams.
+
+        Returns:
+            List of ParsedRoster objects
+
+        Raises:
+            DownloadError: If any roster cannot be fetched
+        """
+        teams = team_abbrevs if team_abbrevs is not None else NHL_TEAM_ABBREVS
+        self.set_total_items(len(teams))
+
+        logger.info("Downloading rosters for %d teams season %d", len(teams), season_id)
+
+        rosters: list[ParsedRoster] = []
+        for team in teams:
+            try:
+                roster = await self.get_roster_for_season(team, season_id)
+                rosters.append(roster)
+            except DownloadError as e:
+                # Some teams may not have existed in older seasons
+                logger.debug("No roster for %s season %d: %s", team, season_id, e)
+
+        logger.info(
+            "Downloaded %d rosters for season %d with %d total players",
+            len(rosters),
+            season_id,
+            sum(r.player_count for r in rosters),
+        )
+
+        return rosters
+
+    async def get_player_by_id(
+        self, player_id: int, team_abbrevs: Sequence[str] | None = None
+    ) -> PlayerInfo | None:
+        """Find a player by ID across team rosters.
+
+        This searches current rosters to find a player. For more complete
+        player info, use the Player Landing downloader.
+
+        Args:
+            player_id: NHL player ID
+            team_abbrevs: Teams to search. If None, searches all teams.
+
+        Returns:
+            PlayerInfo if found, None otherwise
+        """
+        teams = team_abbrevs if team_abbrevs is not None else NHL_TEAM_ABBREVS
+
+        for team in teams:
+            try:
+                roster = await self.get_current_roster(team)
+                for player in roster.all_players:
+                    if player.player_id == player_id:
+                        return player
+            except DownloadError:
+                continue
+
+        return None
+
+
+def create_roster_downloader(
+    *,
+    requests_per_second: float = 5.0,
+    max_retries: int = 3,
+) -> RosterDownloader:
+    """Factory function to create a configured RosterDownloader.
+
+    Args:
+        requests_per_second: Rate limit for API calls
+        max_retries: Maximum retry attempts
+
+    Returns:
+        Configured RosterDownloader instance
+    """
+    config = DownloaderConfig(
+        base_url=NHL_API_BASE_URL,
+        requests_per_second=requests_per_second,
+        max_retries=max_retries,
+        health_check_url="roster/BOS/current",
+    )
+    return RosterDownloader(config)

--- a/tests/unit/downloaders/sources/nhl_json/test_roster.py
+++ b/tests/unit/downloaders/sources/nhl_json/test_roster.py
@@ -1,0 +1,681 @@
+"""Tests for Roster Downloader."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nhl_api.downloaders.base.base_downloader import DownloaderConfig
+from nhl_api.downloaders.base.protocol import DownloadError
+from nhl_api.downloaders.sources.nhl_json.roster import (
+    NHL_TEAM_ABBREVS,
+    ParsedRoster,
+    PlayerInfo,
+    RosterDownloader,
+    _parse_birth_date,
+    _parse_localized_name,
+    _parse_player,
+    _parse_roster,
+    create_roster_downloader,
+)
+
+# Sample player data for testing
+SAMPLE_FORWARD = {
+    "id": 8478402,
+    "headshot": "https://assets.nhle.com/mugs/nhl/20242025/BOS/8478402.png",
+    "firstName": {"default": "David"},
+    "lastName": {"default": "Pastrnak"},
+    "sweaterNumber": 88,
+    "positionCode": "R",
+    "shootsCatches": "R",
+    "heightInInches": 72,
+    "weightInPounds": 194,
+    "heightInCentimeters": 183,
+    "weightInKilograms": 88,
+    "birthDate": "1996-05-25",
+    "birthCity": {"default": "Havirov"},
+    "birthCountry": "CZE",
+}
+
+SAMPLE_DEFENSEMAN = {
+    "id": 8479325,
+    "headshot": "https://assets.nhle.com/mugs/nhl/20242025/BOS/8479325.png",
+    "firstName": {"default": "Charlie"},
+    "lastName": {"default": "McAvoy"},
+    "sweaterNumber": 73,
+    "positionCode": "D",
+    "shootsCatches": "R",
+    "heightInInches": 72,
+    "weightInPounds": 209,
+    "heightInCentimeters": 183,
+    "weightInKilograms": 95,
+    "birthDate": "1997-12-21",
+    "birthCity": {"default": "Long Beach"},
+    "birthCountry": "USA",
+    "birthStateProvince": {"default": "NY"},
+}
+
+SAMPLE_GOALIE = {
+    "id": 8480280,
+    "headshot": "https://assets.nhle.com/mugs/nhl/20242025/BOS/8480280.png",
+    "firstName": {"default": "Jeremy"},
+    "lastName": {"default": "Swayman"},
+    "sweaterNumber": 1,
+    "positionCode": "G",
+    "shootsCatches": "L",
+    "heightInInches": 74,
+    "weightInPounds": 195,
+    "heightInCentimeters": 188,
+    "weightInKilograms": 88,
+    "birthDate": "1998-11-24",
+    "birthCity": {"default": "Anchorage"},
+    "birthCountry": "USA",
+    "birthStateProvince": {"default": "AK"},
+}
+
+
+@pytest.mark.unit
+class TestParseLocalizedName:
+    """Tests for _parse_localized_name function."""
+
+    def test_parse_default_name(self) -> None:
+        """Test parsing a name with default key."""
+        name_obj = {"default": "David"}
+        assert _parse_localized_name(name_obj) == "David"
+
+    def test_parse_name_with_multiple_locales(self) -> None:
+        """Test parsing a name with multiple locales."""
+        name_obj = {"default": "David", "cs": "David", "fi": "David"}
+        assert _parse_localized_name(name_obj) == "David"
+
+    def test_parse_none_returns_empty_string(self) -> None:
+        """Test that None returns empty string."""
+        assert _parse_localized_name(None) == ""
+
+    def test_parse_empty_dict_returns_empty_string(self) -> None:
+        """Test that empty dict returns empty string."""
+        assert _parse_localized_name({}) == ""
+
+
+@pytest.mark.unit
+class TestParseBirthDate:
+    """Tests for _parse_birth_date function."""
+
+    def test_parse_valid_date(self) -> None:
+        """Test parsing a valid ISO date string."""
+        result = _parse_birth_date("1996-05-25")
+        assert result == date(1996, 5, 25)
+
+    def test_parse_none_returns_none(self) -> None:
+        """Test that None returns None."""
+        assert _parse_birth_date(None) is None
+
+    def test_parse_invalid_date_returns_none(self) -> None:
+        """Test that invalid date returns None."""
+        assert _parse_birth_date("invalid-date") is None
+
+    def test_parse_empty_string_returns_none(self) -> None:
+        """Test that empty string returns None."""
+        assert _parse_birth_date("") is None
+
+
+@pytest.mark.unit
+class TestParsePlayer:
+    """Tests for _parse_player function."""
+
+    def test_parse_forward(self) -> None:
+        """Test parsing a forward player."""
+        player = _parse_player(SAMPLE_FORWARD, "BOS")
+
+        assert player.player_id == 8478402
+        assert player.first_name == "David"
+        assert player.last_name == "Pastrnak"
+        assert player.sweater_number == 88
+        assert player.position_code == "R"
+        assert player.shoots_catches == "R"
+        assert player.height_inches == 72
+        assert player.weight_pounds == 194
+        assert player.height_cm == 183
+        assert player.weight_kg == 88
+        assert player.birth_date == date(1996, 5, 25)
+        assert player.birth_city == "Havirov"
+        assert player.birth_country == "CZE"
+        assert player.birth_state_province is None or player.birth_state_province == ""
+        assert player.headshot_url is not None
+        assert player.team_abbrev == "BOS"
+
+    def test_parse_defenseman_with_state(self) -> None:
+        """Test parsing a defenseman with birth state."""
+        player = _parse_player(SAMPLE_DEFENSEMAN, "BOS")
+
+        assert player.player_id == 8479325
+        assert player.first_name == "Charlie"
+        assert player.last_name == "McAvoy"
+        assert player.position_code == "D"
+        assert player.birth_country == "USA"
+        assert player.birth_state_province == "NY"
+
+    def test_parse_goalie(self) -> None:
+        """Test parsing a goalie."""
+        player = _parse_player(SAMPLE_GOALIE, "BOS")
+
+        assert player.player_id == 8480280
+        assert player.first_name == "Jeremy"
+        assert player.last_name == "Swayman"
+        assert player.position_code == "G"
+        assert player.shoots_catches == "L"
+
+    def test_parse_player_with_missing_fields(self) -> None:
+        """Test parsing a player with minimal data."""
+        minimal_data = {
+            "id": 12345,
+        }
+        player = _parse_player(minimal_data, "NYR")
+
+        assert player.player_id == 12345
+        assert player.first_name == ""
+        assert player.last_name == ""
+        assert player.sweater_number is None
+        assert player.position_code == ""
+        assert player.height_inches == 0
+        assert player.weight_pounds == 0
+        assert player.birth_date is None
+        assert player.team_abbrev == "NYR"
+
+
+@pytest.mark.unit
+class TestParseRoster:
+    """Tests for _parse_roster function."""
+
+    def test_parse_complete_roster(self) -> None:
+        """Test parsing a complete roster with all positions."""
+        roster_data = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [SAMPLE_DEFENSEMAN],
+            "goalies": [SAMPLE_GOALIE],
+        }
+
+        roster = _parse_roster(roster_data, "BOS")
+
+        assert roster.team_abbrev == "BOS"
+        assert roster.season_id is None
+        assert len(roster.forwards) == 1
+        assert len(roster.defensemen) == 1
+        assert len(roster.goalies) == 1
+        assert roster.player_count == 3
+
+    def test_parse_roster_with_season(self) -> None:
+        """Test parsing a historical roster with season ID."""
+        roster_data = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [],
+            "goalies": [],
+        }
+
+        roster = _parse_roster(roster_data, "BOS", 20232024)
+
+        assert roster.season_id == 20232024
+
+    def test_parse_empty_roster(self) -> None:
+        """Test parsing an empty roster."""
+        roster_data: dict[str, Any] = {}
+
+        roster = _parse_roster(roster_data, "BOS")
+
+        assert len(roster.forwards) == 0
+        assert len(roster.defensemen) == 0
+        assert len(roster.goalies) == 0
+        assert roster.player_count == 0
+
+    def test_all_players_property(self) -> None:
+        """Test the all_players property."""
+        roster_data = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [SAMPLE_DEFENSEMAN],
+            "goalies": [SAMPLE_GOALIE],
+        }
+
+        roster = _parse_roster(roster_data, "BOS")
+        all_players = roster.all_players
+
+        assert len(all_players) == 3
+        assert all_players[0].position_code == "R"  # Forward first
+        assert all_players[1].position_code == "D"  # Then defenseman
+        assert all_players[2].position_code == "G"  # Then goalie
+
+
+@pytest.mark.unit
+class TestParsedRoster:
+    """Tests for ParsedRoster dataclass."""
+
+    def test_parsed_roster_is_frozen(self) -> None:
+        """Test that ParsedRoster is immutable."""
+        roster = ParsedRoster(
+            team_abbrev="BOS",
+            season_id=None,
+            forwards=(),
+            defensemen=(),
+            goalies=(),
+        )
+
+        with pytest.raises(AttributeError):
+            roster.team_abbrev = "NYR"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestPlayerInfo:
+    """Tests for PlayerInfo dataclass."""
+
+    def test_player_info_is_frozen(self) -> None:
+        """Test that PlayerInfo is immutable."""
+        player = PlayerInfo(
+            player_id=1,
+            first_name="Test",
+            last_name="Player",
+            sweater_number=1,
+            position_code="C",
+            shoots_catches="L",
+            height_inches=72,
+            weight_pounds=200,
+            height_cm=183,
+            weight_kg=91,
+            birth_date=None,
+            birth_city=None,
+            birth_country=None,
+            birth_state_province=None,
+            headshot_url=None,
+            team_abbrev="BOS",
+        )
+
+        with pytest.raises(AttributeError):
+            player.first_name = "Changed"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestNHLTeamAbbrevs:
+    """Tests for NHL_TEAM_ABBREVS constant."""
+
+    def test_all_32_teams_present(self) -> None:
+        """Test that all 32 NHL teams are present."""
+        # 32 teams, but ARI relocated to UTA so we have 33 total
+        assert len(NHL_TEAM_ABBREVS) == 33
+
+    def test_common_teams_present(self) -> None:
+        """Test that common teams are in the list."""
+        assert "BOS" in NHL_TEAM_ABBREVS
+        assert "NYR" in NHL_TEAM_ABBREVS
+        assert "MTL" in NHL_TEAM_ABBREVS
+        assert "TOR" in NHL_TEAM_ABBREVS
+        assert "CHI" in NHL_TEAM_ABBREVS
+
+    def test_expansion_teams_present(self) -> None:
+        """Test that expansion teams are in the list."""
+        assert "SEA" in NHL_TEAM_ABBREVS  # Seattle Kraken (2021)
+        assert "VGK" in NHL_TEAM_ABBREVS  # Vegas Golden Knights (2017)
+        assert "UTA" in NHL_TEAM_ABBREVS  # Utah Hockey Club (2024)
+
+
+@pytest.mark.unit
+class TestRosterDownloader:
+    """Tests for RosterDownloader class."""
+
+    @pytest.fixture
+    def mock_http_client(self) -> MagicMock:
+        """Create a mock HTTP client."""
+        client = MagicMock()
+        client.get = AsyncMock()
+        client.close = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mock_rate_limiter(self) -> MagicMock:
+        """Create a mock rate limiter."""
+        limiter = MagicMock()
+        limiter.wait = AsyncMock()
+        return limiter
+
+    @pytest.fixture
+    def config(self) -> DownloaderConfig:
+        """Create a test configuration."""
+        return DownloaderConfig(
+            base_url="https://api-web.nhle.com/v1",
+            requests_per_second=10.0,
+        )
+
+    @pytest.fixture
+    def downloader(
+        self,
+        config: DownloaderConfig,
+        mock_http_client: MagicMock,
+        mock_rate_limiter: MagicMock,
+    ) -> RosterDownloader:
+        """Create a RosterDownloader with mock HTTP client."""
+        dl = RosterDownloader(
+            config,
+            http_client=mock_http_client,
+            rate_limiter=mock_rate_limiter,
+        )
+        dl._owns_http_client = False  # Don't close the mock
+        return dl
+
+    def test_source_name(self, downloader: RosterDownloader) -> None:
+        """Test that source_name returns correct identifier."""
+        assert downloader.source_name == "nhl_json_roster"
+
+    @pytest.mark.asyncio
+    async def test_get_current_roster_success(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test successful current roster download."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [SAMPLE_DEFENSEMAN],
+            "goalies": [SAMPLE_GOALIE],
+        }
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        roster = await downloader.get_current_roster("BOS")
+
+        assert roster.team_abbrev == "BOS"
+        assert roster.player_count == 3
+        mock_http_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_current_roster_failure(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test handling of failed roster download."""
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 404
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(DownloadError) as exc_info:
+            await downloader.get_current_roster("INVALID")
+
+        assert "Failed to fetch roster" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_roster_for_season_success(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test successful historical roster download."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [],
+            "goalies": [],
+        }
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        roster = await downloader.get_roster_for_season("BOS", 20232024)
+
+        assert roster.team_abbrev == "BOS"
+        assert roster.season_id == 20232024
+        mock_http_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_roster_for_season_failure(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test handling of failed historical roster download."""
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 404
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(DownloadError) as exc_info:
+            await downloader.get_roster_for_season("BOS", 19001901)
+
+        assert "Failed to fetch roster" in str(exc_info.value)
+        assert "season 19001901" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_available_seasons_success(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test successful seasons list download."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = ["20232024", "20222023", "20212022"]
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        seasons = await downloader.get_available_seasons("BOS")
+
+        assert seasons == [20232024, 20222023, 20212022]
+        mock_http_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_available_seasons_failure(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test handling of failed seasons download."""
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 404
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(DownloadError) as exc_info:
+            await downloader.get_available_seasons("INVALID")
+
+        assert "Failed to fetch seasons" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_download_all_current_rosters_success(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test downloading multiple team rosters."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [],
+            "goalies": [],
+        }
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        rosters = await downloader.download_all_current_rosters(["BOS", "NYR"])
+
+        assert len(rosters) == 2
+        assert rosters[0].team_abbrev == "BOS"
+
+    @pytest.mark.asyncio
+    async def test_download_all_current_rosters_partial_failure(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test that download continues when one team fails."""
+        success_response = MagicMock()
+        success_response.is_success = True
+        success_response.is_rate_limited = False
+        success_response.is_server_error = False
+        success_response.status = 200
+        success_response.retry_after = None
+        success_response.json.return_value = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [],
+            "goalies": [],
+        }
+
+        fail_response = MagicMock()
+        fail_response.is_success = False
+        fail_response.is_rate_limited = False
+        fail_response.is_server_error = False
+        fail_response.status = 404
+
+        # First call fails, second succeeds
+        mock_http_client.get = AsyncMock(side_effect=[fail_response, success_response])
+
+        rosters = await downloader.download_all_current_rosters(["INVALID", "BOS"])
+
+        # Should still get the successful one
+        assert len(rosters) == 1
+        assert rosters[0].team_abbrev == "BOS"
+
+    @pytest.mark.asyncio
+    async def test_download_rosters_for_season_success(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test downloading historical rosters for multiple teams."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [],
+            "goalies": [],
+        }
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        rosters = await downloader.download_rosters_for_season(20232024, ["BOS", "NYR"])
+
+        assert len(rosters) == 2
+        assert all(r.season_id == 20232024 for r in rosters)
+
+    @pytest.mark.asyncio
+    async def test_get_player_by_id_found(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test finding a player by ID."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "forwards": [SAMPLE_FORWARD],
+            "defensemen": [],
+            "goalies": [],
+        }
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        player = await downloader.get_player_by_id(8478402, ["BOS"])
+
+        assert player is not None
+        assert player.player_id == 8478402
+        assert player.last_name == "Pastrnak"
+
+    @pytest.mark.asyncio
+    async def test_get_player_by_id_not_found(
+        self,
+        downloader: RosterDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test when player is not found."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "forwards": [],
+            "defensemen": [],
+            "goalies": [],
+        }
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        player = await downloader.get_player_by_id(9999999, ["BOS"])
+
+        assert player is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_game_not_applicable(
+        self, downloader: RosterDownloader
+    ) -> None:
+        """Test that _fetch_game returns placeholder for roster downloads."""
+        result = await downloader._fetch_game(12345)
+
+        assert "_note" in result
+        assert "team-based" in result["_note"]
+
+
+@pytest.mark.unit
+class TestCreateRosterDownloader:
+    """Tests for create_roster_downloader factory function."""
+
+    def test_create_with_defaults(self) -> None:
+        """Test creating downloader with default parameters."""
+        downloader = create_roster_downloader()
+
+        assert downloader.source_name == "nhl_json_roster"
+        assert downloader.config.base_url == "https://api-web.nhle.com/v1"
+        assert downloader.config.requests_per_second == 5.0
+        assert downloader.config.max_retries == 3
+
+    def test_create_with_custom_params(self) -> None:
+        """Test creating downloader with custom parameters."""
+        downloader = create_roster_downloader(
+            requests_per_second=10.0,
+            max_retries=5,
+        )
+
+        assert downloader.config.requests_per_second == 10.0
+        assert downloader.config.max_retries == 5
+
+    def test_health_check_url_set(self) -> None:
+        """Test that health check URL is configured."""
+        downloader = create_roster_downloader()
+
+        assert downloader.config.health_check_url == "roster/BOS/current"


### PR DESCRIPTION
## Summary
- Add RosterDownloader for downloading team rosters from NHL JSON API
- Support for current rosters and historical rosters by season
- Get available seasons per team
- Download rosters for multiple teams at once
- Search for player by ID across team rosters

## Changes
- `src/nhl_api/downloaders/sources/nhl_json/roster.py` - New RosterDownloader class
- `tests/unit/downloaders/sources/nhl_json/test_roster.py` - 37 unit tests

## API Endpoints Used
- `GET /roster/{team}/current` - Current roster
- `GET /roster/{team}/{season}` - Historical roster
- `GET /roster-season/{team}` - Available seasons

## Test plan
- [x] All 37 unit tests pass
- [x] 96% code coverage on roster module
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] Pre-commit hooks pass

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)