### PR TITLE
Implement Standings Downloader (#68)

### DIFF
--- a/src/nhl_api/downloaders/sources/nhl_json/__init__.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/__init__.py
@@ -21,6 +21,14 @@ from nhl_api.downloaders.sources.nhl_json.roster import (
     create_roster_downloader,
 )
 from nhl_api.downloaders.sources.nhl_json.schedule import ScheduleDownloader
+from nhl_api.downloaders.sources.nhl_json.standings import (
+    ParsedStandings,
+    RecordSplit,
+    StandingsDownloader,
+    StreakInfo,
+    TeamStandings,
+    create_standings_downloader,
+)
 
 __all__ = [
     "BoxscoreDownloader",
@@ -29,11 +37,17 @@ __all__ = [
     "NHL_TEAM_ABBREVS",
     "ParsedPlayByPlay",
     "ParsedRoster",
+    "ParsedStandings",
     "PlayByPlayDownloader",
     "PlayByPlayDownloaderConfig",
     "PlayerInfo",
+    "RecordSplit",
     "RosterDownloader",
     "ScheduleDownloader",
+    "StandingsDownloader",
+    "StreakInfo",
+    "TeamStandings",
     "create_play_by_play_downloader",
     "create_roster_downloader",
+    "create_standings_downloader",
 ]

--- a/src/nhl_api/downloaders/sources/nhl_json/standings.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/standings.py
@@ -1,0 +1,473 @@
+"""NHL Standings Downloader.
+
+Downloads league standings from the NHL JSON API (api-web.nhle.com/v1/).
+Provides methods to fetch current standings, historical standings by date,
+and available seasons for standings data.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+from typing import TYPE_CHECKING, Any
+
+from nhl_api.downloaders.base.base_downloader import (
+    BaseDownloader,
+    DownloaderConfig,
+)
+from nhl_api.downloaders.base.protocol import DownloadError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+logger = logging.getLogger(__name__)
+
+# NHL JSON API base URL
+NHL_API_BASE_URL = "https://api-web.nhle.com/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class StreakInfo:
+    """Streak information for a team."""
+
+    code: str  # W, L, OT
+    count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecordSplit:
+    """Win-loss record for a specific context (home, road, L10)."""
+
+    wins: int
+    losses: int
+    ot_losses: int
+    points: int
+    goals_for: int
+    goals_against: int
+
+
+@dataclass(frozen=True, slots=True)
+class TeamStandings:
+    """Complete standings entry for a single team.
+
+    Contains all record, ranking, and trend information.
+    """
+
+    # Team identification
+    team_abbrev: str
+    team_name: str
+    team_common_name: str
+    team_logo_url: str | None
+
+    # Division/Conference
+    conference_abbrev: str
+    conference_name: str
+    division_abbrev: str
+    division_name: str
+
+    # Season
+    season_id: int
+
+    # Core record
+    games_played: int
+    wins: int
+    losses: int
+    ot_losses: int
+    points: int
+    point_pctg: float
+
+    # Goals
+    goals_for: int
+    goals_against: int
+    goal_differential: int
+
+    # Win types
+    regulation_wins: int
+    regulation_plus_ot_wins: int
+    shootout_wins: int
+    shootout_losses: int
+
+    # Rankings
+    league_sequence: int
+    conference_sequence: int
+    division_sequence: int
+    wildcard_sequence: int
+
+    # Streak
+    streak: StreakInfo | None
+
+    # Splits
+    home_record: RecordSplit | None
+    road_record: RecordSplit | None
+    last_10_record: RecordSplit | None
+
+    # Playoff status
+    clinch_indicator: str | None  # x=playoff, y=division, z=presidents, e=eliminated
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedStandings:
+    """Complete standings snapshot.
+
+    Contains standings for all teams at a point in time.
+    """
+
+    standings_date: date
+    season_id: int
+    standings: tuple[TeamStandings, ...]
+
+    @property
+    def team_count(self) -> int:
+        """Return number of teams in standings."""
+        return len(self.standings)
+
+    def get_by_conference(self, conference: str) -> tuple[TeamStandings, ...]:
+        """Get teams by conference abbreviation."""
+        return tuple(t for t in self.standings if t.conference_abbrev == conference)
+
+    def get_by_division(self, division: str) -> tuple[TeamStandings, ...]:
+        """Get teams by division abbreviation."""
+        return tuple(t for t in self.standings if t.division_abbrev == division)
+
+    def get_team(self, team_abbrev: str) -> TeamStandings | None:
+        """Get standings for a specific team."""
+        for team in self.standings:
+            if team.team_abbrev == team_abbrev:
+                return team
+        return None
+
+
+def _parse_record_split(data: dict[str, Any] | None) -> RecordSplit | None:
+    """Parse a home/road/L10 record split.
+
+    Args:
+        data: Raw split data from API
+
+    Returns:
+        Parsed RecordSplit or None if no data
+    """
+    if not data:
+        return None
+
+    return RecordSplit(
+        wins=data.get("wins", 0),
+        losses=data.get("losses", 0),
+        ot_losses=data.get("otLosses", 0),
+        points=data.get("points", 0),
+        goals_for=data.get("goalFor", 0),
+        goals_against=data.get("goalAgainst", 0),
+    )
+
+
+def _parse_streak(data: dict[str, Any]) -> StreakInfo | None:
+    """Parse streak information.
+
+    Args:
+        data: Team data containing streak info
+
+    Returns:
+        Parsed StreakInfo or None
+    """
+    streak_code = data.get("streakCode")
+    streak_count = data.get("streakCount")
+
+    if streak_code and streak_count is not None:
+        return StreakInfo(code=streak_code, count=streak_count)
+    return None
+
+
+def _parse_team_standings(data: dict[str, Any]) -> TeamStandings:
+    """Parse standings for a single team.
+
+    Args:
+        data: Raw team standings data from API
+
+    Returns:
+        Parsed TeamStandings object
+    """
+    # Parse team name - handle localized name format
+    team_name_obj = data.get("teamName", {})
+    if isinstance(team_name_obj, dict):
+        team_name = team_name_obj.get("default", "")
+    else:
+        team_name = str(team_name_obj) if team_name_obj else ""
+
+    team_common_name_obj = data.get("teamCommonName", {})
+    if isinstance(team_common_name_obj, dict):
+        team_common_name = team_common_name_obj.get("default", "")
+    else:
+        team_common_name = str(team_common_name_obj) if team_common_name_obj else ""
+
+    return TeamStandings(
+        team_abbrev=data.get("teamAbbrev", {}).get("default", ""),
+        team_name=team_name,
+        team_common_name=team_common_name,
+        team_logo_url=data.get("teamLogo"),
+        conference_abbrev=data.get("conferenceAbbrev", ""),
+        conference_name=data.get("conferenceName", ""),
+        division_abbrev=data.get("divisionAbbrev", ""),
+        division_name=data.get("divisionName", ""),
+        season_id=data.get("seasonId", 0),
+        games_played=data.get("gamesPlayed", 0),
+        wins=data.get("wins", 0),
+        losses=data.get("losses", 0),
+        ot_losses=data.get("otLosses", 0),
+        points=data.get("points", 0),
+        point_pctg=data.get("pointPctg", 0.0),
+        goals_for=data.get("goalFor", 0),
+        goals_against=data.get("goalAgainst", 0),
+        goal_differential=data.get("goalDifferential", 0),
+        regulation_wins=data.get("regulationWins", 0),
+        regulation_plus_ot_wins=data.get("regulationPlusOtWins", 0),
+        shootout_wins=data.get("shootoutWins", 0),
+        shootout_losses=data.get("shootoutLosses", 0),
+        league_sequence=data.get("leagueSequence", 0),
+        conference_sequence=data.get("conferenceSequence", 0),
+        division_sequence=data.get("divisionSequence", 0),
+        wildcard_sequence=data.get("wildcardSequence", 0),
+        streak=_parse_streak(data),
+        home_record=_parse_record_split(data.get("homeRecord")),
+        road_record=_parse_record_split(data.get("roadRecord")),
+        last_10_record=_parse_record_split(data.get("l10Record")),
+        clinch_indicator=data.get("clinchIndicator"),
+    )
+
+
+def _parse_standings(data: dict[str, Any], standings_date: date) -> ParsedStandings:
+    """Parse complete standings response.
+
+    Args:
+        data: Raw standings data from API
+        standings_date: Date of the standings
+
+    Returns:
+        Parsed standings object
+    """
+    standings_list = data.get("standings", [])
+    teams = tuple(_parse_team_standings(team) for team in standings_list)
+
+    # Get season ID from first team if available
+    season_id = teams[0].season_id if teams else 0
+
+    return ParsedStandings(
+        standings_date=standings_date,
+        season_id=season_id,
+        standings=teams,
+    )
+
+
+class StandingsDownloader(BaseDownloader):
+    """Downloads NHL league standings.
+
+    Supports multiple access patterns:
+    - Current standings: get_current_standings()
+    - Historical standings: get_standings_for_date()
+    - Available seasons: get_available_seasons()
+
+    Example:
+        config = DownloaderConfig(base_url=NHL_API_BASE_URL)
+        async with StandingsDownloader(config) as downloader:
+            # Get current standings
+            standings = await downloader.get_current_standings()
+
+            # Get historical standings
+            standings = await downloader.get_standings_for_date(
+                date(2024, 12, 1)
+            )
+
+            # Access team data
+            bruins = standings.get_team("BOS")
+            eastern = standings.get_by_conference("E")
+    """
+
+    @property
+    def source_name(self) -> str:
+        """Return unique identifier for this source."""
+        return "nhl_json_standings"
+
+    async def _fetch_game(self, game_id: int) -> dict[str, Any]:
+        """Not used for standings downloads.
+
+        Standings downloads are date-based, not game-based.
+        """
+        return {"_note": "Standings downloads are date-based, not game-based"}
+
+    async def _fetch_season_games(self, season_id: int) -> AsyncGenerator[int, None]:
+        """Not used for standings downloads.
+
+        Use get_current_standings() or get_standings_for_date() instead.
+
+        Args:
+            season_id: NHL season ID (not used)
+
+        Yields:
+            Nothing - this method is not applicable for standings
+        """
+        return
+        yield  # Make this a generator (never reached)
+
+    async def get_current_standings(self) -> ParsedStandings:
+        """Get current league standings.
+
+        Returns:
+            ParsedStandings with all teams' current standings
+
+        Raises:
+            DownloadError: If standings cannot be fetched
+        """
+        logger.debug("Fetching current standings")
+
+        response = await self._get("standings/now")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch current standings: HTTP {response.status}",
+                source=self.source_name,
+            )
+
+        data = response.json()
+        standings = _parse_standings(data, date.today())
+
+        logger.info(
+            "Fetched standings for %d teams (season %d)",
+            standings.team_count,
+            standings.season_id,
+        )
+
+        return standings
+
+    async def get_standings_for_date(self, standings_date: date) -> ParsedStandings:
+        """Get standings for a specific date.
+
+        Args:
+            standings_date: Date to fetch standings for
+
+        Returns:
+            ParsedStandings for the specified date
+
+        Raises:
+            DownloadError: If standings cannot be fetched
+        """
+        date_str = standings_date.isoformat()
+        logger.debug("Fetching standings for %s", date_str)
+
+        response = await self._get(f"standings/{date_str}")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch standings for {date_str}: HTTP {response.status}",
+                source=self.source_name,
+            )
+
+        data = response.json()
+        standings = _parse_standings(data, standings_date)
+
+        logger.info(
+            "Fetched standings for %d teams on %s",
+            standings.team_count,
+            date_str,
+        )
+
+        return standings
+
+    async def get_available_seasons(self) -> list[dict[str, Any]]:
+        """Get information about all seasons with standings data.
+
+        Returns detailed season information including:
+        - Season ID
+        - Whether conferences/divisions were used
+        - Scoring rules (OT loss points, ties, etc.)
+        - Date ranges for standings
+
+        Returns:
+            List of season info dictionaries
+
+        Raises:
+            DownloadError: If seasons cannot be fetched
+        """
+        logger.debug("Fetching available standings seasons")
+
+        response = await self._get("standings-season")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch standings seasons: HTTP {response.status}",
+                source=self.source_name,
+            )
+
+        data = response.json()
+        seasons: list[dict[str, Any]] = data.get("seasons", [])
+
+        logger.info("Found %d seasons with standings data", len(seasons))
+
+        return seasons
+
+    async def get_standings_range(
+        self,
+        start_date: date,
+        end_date: date,
+        interval_days: int = 7,
+    ) -> list[ParsedStandings]:
+        """Get standings snapshots over a date range.
+
+        Useful for tracking standings progression over time.
+
+        Args:
+            start_date: Start date (inclusive)
+            end_date: End date (inclusive)
+            interval_days: Days between snapshots (default 7 for weekly)
+
+        Returns:
+            List of standings snapshots
+
+        Raises:
+            DownloadError: If any standings fetch fails
+        """
+        from datetime import timedelta
+
+        logger.info(
+            "Fetching standings from %s to %s (every %d days)",
+            start_date,
+            end_date,
+            interval_days,
+        )
+
+        snapshots: list[ParsedStandings] = []
+        current_date = start_date
+
+        while current_date <= end_date:
+            try:
+                standings = await self.get_standings_for_date(current_date)
+                snapshots.append(standings)
+            except DownloadError as e:
+                logger.warning("No standings for %s: %s", current_date, e)
+
+            current_date += timedelta(days=interval_days)
+
+        logger.info("Retrieved %d standings snapshots", len(snapshots))
+
+        return snapshots
+
+
+def create_standings_downloader(
+    *,
+    requests_per_second: float = 5.0,
+    max_retries: int = 3,
+) -> StandingsDownloader:
+    """Factory function to create a configured StandingsDownloader.
+
+    Args:
+        requests_per_second: Rate limit for API calls
+        max_retries: Maximum retry attempts
+
+    Returns:
+        Configured StandingsDownloader instance
+    """
+    config = DownloaderConfig(
+        base_url=NHL_API_BASE_URL,
+        requests_per_second=requests_per_second,
+        max_retries=max_retries,
+        health_check_url="standings/now",
+    )
+    return StandingsDownloader(config)

--- a/tests/unit/downloaders/sources/nhl_json/test_standings.py
+++ b/tests/unit/downloaders/sources/nhl_json/test_standings.py
@@ -1,0 +1,591 @@
+"""Tests for Standings Downloader."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nhl_api.downloaders.base.base_downloader import DownloaderConfig
+from nhl_api.downloaders.base.protocol import DownloadError
+from nhl_api.downloaders.sources.nhl_json.standings import (
+    ParsedStandings,
+    RecordSplit,
+    StandingsDownloader,
+    StreakInfo,
+    _parse_record_split,
+    _parse_standings,
+    _parse_streak,
+    _parse_team_standings,
+    create_standings_downloader,
+)
+
+# Sample team standings data for testing
+SAMPLE_TEAM_STANDINGS = {
+    "teamAbbrev": {"default": "BOS"},
+    "teamName": {"default": "Boston Bruins"},
+    "teamCommonName": {"default": "Bruins"},
+    "teamLogo": "https://assets.nhle.com/logos/nhl/svg/BOS_light.svg",
+    "conferenceAbbrev": "E",
+    "conferenceName": "Eastern",
+    "divisionAbbrev": "A",
+    "divisionName": "Atlantic",
+    "seasonId": 20242025,
+    "gamesPlayed": 35,
+    "wins": 22,
+    "losses": 10,
+    "otLosses": 3,
+    "points": 47,
+    "pointPctg": 0.671,
+    "goalFor": 105,
+    "goalAgainst": 78,
+    "goalDifferential": 27,
+    "regulationWins": 18,
+    "regulationPlusOtWins": 20,
+    "shootoutWins": 2,
+    "shootoutLosses": 1,
+    "leagueSequence": 5,
+    "conferenceSequence": 3,
+    "divisionSequence": 2,
+    "wildcardSequence": 0,
+    "streakCode": "W",
+    "streakCount": 3,
+    "homeRecord": {
+        "wins": 12,
+        "losses": 4,
+        "otLosses": 1,
+        "points": 25,
+        "goalFor": 55,
+        "goalAgainst": 35,
+    },
+    "roadRecord": {
+        "wins": 10,
+        "losses": 6,
+        "otLosses": 2,
+        "points": 22,
+        "goalFor": 50,
+        "goalAgainst": 43,
+    },
+    "l10Record": {
+        "wins": 7,
+        "losses": 2,
+        "otLosses": 1,
+        "points": 15,
+        "goalFor": 28,
+        "goalAgainst": 18,
+    },
+}
+
+SAMPLE_STANDINGS_RESPONSE = {
+    "standings": [SAMPLE_TEAM_STANDINGS],
+}
+
+
+@pytest.mark.unit
+class TestStreakInfo:
+    """Tests for StreakInfo dataclass."""
+
+    def test_streak_info_creation(self) -> None:
+        """Test creating StreakInfo."""
+        streak = StreakInfo(code="W", count=3)
+        assert streak.code == "W"
+        assert streak.count == 3
+
+    def test_streak_info_is_frozen(self) -> None:
+        """Test that StreakInfo is immutable."""
+        streak = StreakInfo(code="L", count=2)
+        with pytest.raises(AttributeError):
+            streak.code = "W"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestRecordSplit:
+    """Tests for RecordSplit dataclass."""
+
+    def test_record_split_creation(self) -> None:
+        """Test creating RecordSplit."""
+        split = RecordSplit(
+            wins=10,
+            losses=5,
+            ot_losses=2,
+            points=22,
+            goals_for=50,
+            goals_against=40,
+        )
+        assert split.wins == 10
+        assert split.losses == 5
+        assert split.ot_losses == 2
+        assert split.points == 22
+
+    def test_record_split_is_frozen(self) -> None:
+        """Test that RecordSplit is immutable."""
+        split = RecordSplit(
+            wins=10, losses=5, ot_losses=2, points=22, goals_for=50, goals_against=40
+        )
+        with pytest.raises(AttributeError):
+            split.wins = 20  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestParseRecordSplit:
+    """Tests for _parse_record_split function."""
+
+    def test_parse_valid_record(self) -> None:
+        """Test parsing valid record split data."""
+        data = {
+            "wins": 12,
+            "losses": 4,
+            "otLosses": 1,
+            "points": 25,
+            "goalFor": 55,
+            "goalAgainst": 35,
+        }
+        result = _parse_record_split(data)
+
+        assert result is not None
+        assert result.wins == 12
+        assert result.losses == 4
+        assert result.ot_losses == 1
+        assert result.points == 25
+        assert result.goals_for == 55
+        assert result.goals_against == 35
+
+    def test_parse_none_returns_none(self) -> None:
+        """Test that None returns None."""
+        assert _parse_record_split(None) is None
+
+    def test_parse_empty_dict_returns_none(self) -> None:
+        """Test parsing empty dict returns None (empty dict is falsy)."""
+        # Empty dict is falsy in Python, so `if not data:` returns True
+        assert _parse_record_split({}) is None
+
+
+@pytest.mark.unit
+class TestParseStreak:
+    """Tests for _parse_streak function."""
+
+    def test_parse_valid_streak(self) -> None:
+        """Test parsing valid streak data."""
+        data = {"streakCode": "W", "streakCount": 3}
+        result = _parse_streak(data)
+
+        assert result is not None
+        assert result.code == "W"
+        assert result.count == 3
+
+    def test_parse_missing_streak_code(self) -> None:
+        """Test parsing with missing streak code."""
+        data = {"streakCount": 3}
+        assert _parse_streak(data) is None
+
+    def test_parse_missing_streak_count(self) -> None:
+        """Test parsing with missing streak count."""
+        data = {"streakCode": "W"}
+        assert _parse_streak(data) is None
+
+    def test_parse_losing_streak(self) -> None:
+        """Test parsing losing streak."""
+        data = {"streakCode": "L", "streakCount": 2}
+        result = _parse_streak(data)
+
+        assert result is not None
+        assert result.code == "L"
+        assert result.count == 2
+
+
+@pytest.mark.unit
+class TestParseTeamStandings:
+    """Tests for _parse_team_standings function."""
+
+    def test_parse_complete_standings(self) -> None:
+        """Test parsing complete team standings."""
+        result = _parse_team_standings(SAMPLE_TEAM_STANDINGS)
+
+        assert result.team_abbrev == "BOS"
+        assert result.team_name == "Boston Bruins"
+        assert result.team_common_name == "Bruins"
+        assert result.conference_abbrev == "E"
+        assert result.division_abbrev == "A"
+        assert result.season_id == 20242025
+        assert result.games_played == 35
+        assert result.wins == 22
+        assert result.losses == 10
+        assert result.ot_losses == 3
+        assert result.points == 47
+        assert result.goal_differential == 27
+        assert result.league_sequence == 5
+        assert result.streak is not None
+        assert result.streak.code == "W"
+        assert result.streak.count == 3
+        assert result.home_record is not None
+        assert result.road_record is not None
+        assert result.last_10_record is not None
+
+    def test_parse_minimal_standings(self) -> None:
+        """Test parsing minimal standings data."""
+        data: dict[str, Any] = {
+            "teamAbbrev": {"default": "NYR"},
+        }
+        result = _parse_team_standings(data)
+
+        assert result.team_abbrev == "NYR"
+        assert result.team_name == ""
+        assert result.wins == 0
+        assert result.points == 0
+        assert result.streak is None
+        assert result.home_record is None
+
+    def test_parse_string_team_name(self) -> None:
+        """Test parsing when team name is a string (not dict)."""
+        data = {
+            "teamAbbrev": {"default": "MTL"},
+            "teamName": "Montreal Canadiens",
+            "teamCommonName": "Canadiens",
+        }
+        result = _parse_team_standings(data)
+
+        assert result.team_name == "Montreal Canadiens"
+        assert result.team_common_name == "Canadiens"
+
+
+@pytest.mark.unit
+class TestParseStandings:
+    """Tests for _parse_standings function."""
+
+    def test_parse_complete_standings(self) -> None:
+        """Test parsing complete standings response."""
+        result = _parse_standings(SAMPLE_STANDINGS_RESPONSE, date(2024, 12, 20))
+
+        assert result.standings_date == date(2024, 12, 20)
+        assert result.season_id == 20242025
+        assert result.team_count == 1
+        assert result.standings[0].team_abbrev == "BOS"
+
+    def test_parse_empty_standings(self) -> None:
+        """Test parsing empty standings response."""
+        result = _parse_standings({"standings": []}, date(2024, 12, 20))
+
+        assert result.team_count == 0
+        assert result.season_id == 0
+
+
+@pytest.mark.unit
+class TestParsedStandings:
+    """Tests for ParsedStandings dataclass."""
+
+    @pytest.fixture
+    def sample_standings(self) -> ParsedStandings:
+        """Create sample standings for testing."""
+        return _parse_standings(SAMPLE_STANDINGS_RESPONSE, date(2024, 12, 20))
+
+    def test_get_team_found(self, sample_standings: ParsedStandings) -> None:
+        """Test getting team by abbreviation."""
+        team = sample_standings.get_team("BOS")
+        assert team is not None
+        assert team.team_abbrev == "BOS"
+
+    def test_get_team_not_found(self, sample_standings: ParsedStandings) -> None:
+        """Test getting non-existent team."""
+        team = sample_standings.get_team("XXX")
+        assert team is None
+
+    def test_get_by_conference(self, sample_standings: ParsedStandings) -> None:
+        """Test getting teams by conference."""
+        eastern = sample_standings.get_by_conference("E")
+        assert len(eastern) == 1
+        assert eastern[0].team_abbrev == "BOS"
+
+    def test_get_by_division(self, sample_standings: ParsedStandings) -> None:
+        """Test getting teams by division."""
+        atlantic = sample_standings.get_by_division("A")
+        assert len(atlantic) == 1
+        assert atlantic[0].team_abbrev == "BOS"
+
+
+@pytest.mark.unit
+class TestTeamStandings:
+    """Tests for TeamStandings dataclass."""
+
+    def test_team_standings_is_frozen(self) -> None:
+        """Test that TeamStandings is immutable."""
+        standings = _parse_team_standings(SAMPLE_TEAM_STANDINGS)
+
+        with pytest.raises(AttributeError):
+            standings.wins = 50  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestStandingsDownloader:
+    """Tests for StandingsDownloader class."""
+
+    @pytest.fixture
+    def mock_http_client(self) -> MagicMock:
+        """Create a mock HTTP client."""
+        client = MagicMock()
+        client.get = AsyncMock()
+        client.close = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mock_rate_limiter(self) -> MagicMock:
+        """Create a mock rate limiter."""
+        limiter = MagicMock()
+        limiter.wait = AsyncMock()
+        return limiter
+
+    @pytest.fixture
+    def config(self) -> DownloaderConfig:
+        """Create a test configuration."""
+        return DownloaderConfig(
+            base_url="https://api-web.nhle.com/v1",
+            requests_per_second=10.0,
+        )
+
+    @pytest.fixture
+    def downloader(
+        self,
+        config: DownloaderConfig,
+        mock_http_client: MagicMock,
+        mock_rate_limiter: MagicMock,
+    ) -> StandingsDownloader:
+        """Create a StandingsDownloader with mock HTTP client."""
+        dl = StandingsDownloader(
+            config,
+            http_client=mock_http_client,
+            rate_limiter=mock_rate_limiter,
+        )
+        dl._owns_http_client = False
+        return dl
+
+    def test_source_name(self, downloader: StandingsDownloader) -> None:
+        """Test that source_name returns correct identifier."""
+        assert downloader.source_name == "nhl_json_standings"
+
+    @pytest.mark.asyncio
+    async def test_get_current_standings_success(
+        self,
+        downloader: StandingsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test successful current standings download."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = SAMPLE_STANDINGS_RESPONSE
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        standings = await downloader.get_current_standings()
+
+        assert standings.team_count == 1
+        assert standings.standings[0].team_abbrev == "BOS"
+        mock_http_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_current_standings_failure(
+        self,
+        downloader: StandingsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test handling of failed standings download."""
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 500
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(DownloadError) as exc_info:
+            await downloader.get_current_standings()
+
+        assert "Failed to fetch current standings" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_standings_for_date_success(
+        self,
+        downloader: StandingsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test successful historical standings download."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = SAMPLE_STANDINGS_RESPONSE
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        standings_date = date(2024, 12, 1)
+        standings = await downloader.get_standings_for_date(standings_date)
+
+        assert standings.standings_date == standings_date
+        assert standings.team_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_standings_for_date_failure(
+        self,
+        downloader: StandingsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test handling of failed historical standings download."""
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 404
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(DownloadError) as exc_info:
+            await downloader.get_standings_for_date(date(2000, 1, 1))
+
+        assert "Failed to fetch standings" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_available_seasons_success(
+        self,
+        downloader: StandingsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test successful seasons list download."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "seasons": [
+                {"seasonId": 20242025},
+                {"seasonId": 20232024},
+            ]
+        }
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        seasons = await downloader.get_available_seasons()
+
+        assert len(seasons) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_available_seasons_failure(
+        self,
+        downloader: StandingsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test handling of failed seasons download."""
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 500
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(DownloadError) as exc_info:
+            await downloader.get_available_seasons()
+
+        assert "Failed to fetch standings seasons" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_standings_range_success(
+        self,
+        downloader: StandingsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test downloading standings over a date range."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = SAMPLE_STANDINGS_RESPONSE
+
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        start = date(2024, 12, 1)
+        end = date(2024, 12, 15)
+        snapshots = await downloader.get_standings_range(start, end, interval_days=7)
+
+        # Should have 3 snapshots: Dec 1, Dec 8, Dec 15
+        assert len(snapshots) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_standings_range_partial_failure(
+        self,
+        downloader: StandingsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test that range download continues on individual failures."""
+        success_response = MagicMock()
+        success_response.is_success = True
+        success_response.is_rate_limited = False
+        success_response.is_server_error = False
+        success_response.status = 200
+        success_response.retry_after = None
+        success_response.json.return_value = SAMPLE_STANDINGS_RESPONSE
+
+        fail_response = MagicMock()
+        fail_response.is_success = False
+        fail_response.is_rate_limited = False
+        fail_response.is_server_error = False
+        fail_response.status = 404
+
+        # First fails, second succeeds
+        mock_http_client.get = AsyncMock(side_effect=[fail_response, success_response])
+
+        start = date(2024, 12, 1)
+        end = date(2024, 12, 8)
+        snapshots = await downloader.get_standings_range(start, end, interval_days=7)
+
+        # Should only have 1 snapshot (second one succeeded)
+        assert len(snapshots) == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_game_not_applicable(
+        self, downloader: StandingsDownloader
+    ) -> None:
+        """Test that _fetch_game returns placeholder."""
+        result = await downloader._fetch_game(12345)
+
+        assert "_note" in result
+        assert "date-based" in result["_note"]
+
+
+@pytest.mark.unit
+class TestCreateStandingsDownloader:
+    """Tests for create_standings_downloader factory function."""
+
+    def test_create_with_defaults(self) -> None:
+        """Test creating downloader with default parameters."""
+        downloader = create_standings_downloader()
+
+        assert downloader.source_name == "nhl_json_standings"
+        assert downloader.config.base_url == "https://api-web.nhle.com/v1"
+        assert downloader.config.requests_per_second == 5.0
+        assert downloader.config.max_retries == 3
+
+    def test_create_with_custom_params(self) -> None:
+        """Test creating downloader with custom parameters."""
+        downloader = create_standings_downloader(
+            requests_per_second=10.0,
+            max_retries=5,
+        )
+
+        assert downloader.config.requests_per_second == 10.0
+        assert downloader.config.max_retries == 5
+
+    def test_health_check_url_set(self) -> None:
+        """Test that health check URL is configured."""
+        downloader = create_standings_downloader()
+
+        assert downloader.config.health_check_url == "standings/now"


### PR DESCRIPTION
## Summary
- Add StandingsDownloader for downloading league standings from NHL JSON API
- Support for current standings and historical standings by date
- Get available seasons with standings data
- Download standings snapshots over a date range
- Filter by conference/division
- Access streak info, home/road splits, last 10 records

## Changes
- `src/nhl_api/downloaders/sources/nhl_json/standings.py` - New StandingsDownloader class
- `tests/unit/downloaders/sources/nhl_json/test_standings.py` - 34 unit tests

## API Endpoints Used
- `GET /standings/now` - Current standings
- `GET /standings/{date}` - Historical standings
- `GET /standings-season` - Available seasons

## Test plan
- [x] All 34 unit tests pass
- [x] 99% code coverage on standings module
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] Pre-commit hooks pass

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)