### PR TITLE
feat(downloaders): Add Game Summary (GS) HTML Downloader (#75)

### DIFF
--- a/src/nhl_api/downloaders/sources/html/__init__.py
+++ b/src/nhl_api/downloaders/sources/html/__init__.py
@@ -20,9 +20,23 @@ from nhl_api.downloaders.sources.html.base_html_downloader import (
     BaseHTMLDownloader,
     HTMLDownloaderConfig,
 )
+from nhl_api.downloaders.sources.html.game_summary import (
+    GameSummaryDownloader,
+    GoalInfo,
+    ParsedGameSummary,
+    PenaltyInfo,
+    PlayerInfo,
+    TeamInfo,
+)
 
 __all__ = [
     "BaseHTMLDownloader",
+    "GameSummaryDownloader",
+    "GoalInfo",
     "HTML_DOWNLOADER_CONFIG",
     "HTMLDownloaderConfig",
+    "ParsedGameSummary",
+    "PenaltyInfo",
+    "PlayerInfo",
+    "TeamInfo",
 ]

--- a/src/nhl_api/downloaders/sources/html/game_summary.py
+++ b/src/nhl_api/downloaders/sources/html/game_summary.py
@@ -1,0 +1,676 @@
+"""NHL Game Summary (GS) HTML Downloader.
+
+Downloads and parses Game Summary HTML reports from the NHL website.
+These reports contain scoring summaries, penalty summaries, and game metadata.
+
+URL Pattern: https://www.nhl.com/scores/htmlreports/{season}/GS{game_suffix}.HTM
+
+Example usage:
+    config = HTMLDownloaderConfig()
+    async with GameSummaryDownloader(config) as downloader:
+        result = await downloader.download_game(2024020500)
+        summary = result.data
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from bs4 import BeautifulSoup, Tag
+
+from nhl_api.downloaders.sources.html.base_html_downloader import (
+    BaseHTMLDownloader,
+)
+
+logger = logging.getLogger(__name__)
+
+# Exception codes that indicate non-goal entries in scoring table
+EXCEPTION_CODES = frozenset(
+    {
+        "unsuccessful penalty shot",
+        "no goal",
+        "missed",
+        "failed",
+        "penalty shot",
+        "ps",
+    }
+)
+
+# Pattern to extract team abbreviation from image URL
+TEAM_LOGO_PATTERN = re.compile(r"logoc([a-z]{3})\.gif", re.IGNORECASE)
+
+# Pattern to extract attendance number
+ATTENDANCE_PATTERN = re.compile(r"Attendance[:\s]+([0-9,]+)", re.IGNORECASE)
+
+# Pattern to extract game start/end times
+TIME_PATTERN = re.compile(r"(\d{1,2}:\d{2})\s*(AM|PM)?", re.IGNORECASE)
+
+
+@dataclass
+class PlayerInfo:
+    """Player information parsed from HTML."""
+
+    number: int | None
+    name: str
+    season_total: int | None = None
+
+
+@dataclass
+class GoalInfo:
+    """Goal information from scoring summary."""
+
+    goal_number: int
+    period: int
+    time: str
+    strength: str  # EV, PP, SH, EN
+    team: str
+    scorer: PlayerInfo
+    assist1: PlayerInfo | None = None
+    assist2: PlayerInfo | None = None
+    away_on_ice: list[int] = field(default_factory=list)
+    home_on_ice: list[int] = field(default_factory=list)
+
+
+@dataclass
+class PenaltyInfo:
+    """Penalty information from penalty summary."""
+
+    penalty_number: int
+    period: int
+    time: str
+    team: str
+    player: PlayerInfo
+    pim: int
+    infraction: str
+
+
+@dataclass
+class TeamInfo:
+    """Team information from game header."""
+
+    name: str
+    abbrev: str
+    goals: int
+    shots: int = 0
+
+
+@dataclass
+class PeriodSummary:
+    """Per-period statistics."""
+
+    period: str  # "1", "2", "3", "OT", "SO"
+    away_goals: int = 0
+    home_goals: int = 0
+    away_shots: int = 0
+    home_shots: int = 0
+
+
+@dataclass
+class ParsedGameSummary:
+    """Complete parsed game summary data."""
+
+    game_id: int
+    season_id: int
+    date: str
+    venue: str
+    attendance: int | None
+    start_time: str | None
+    end_time: str | None
+    away_team: TeamInfo
+    home_team: TeamInfo
+    goals: list[GoalInfo] = field(default_factory=list)
+    penalties: list[PenaltyInfo] = field(default_factory=list)
+    period_summary: list[PeriodSummary] = field(default_factory=list)
+    referees: list[str] = field(default_factory=list)
+    linesmen: list[str] = field(default_factory=list)
+
+
+class GameSummaryDownloader(BaseHTMLDownloader):
+    """Downloads and parses NHL Game Summary HTML reports.
+
+    The Game Summary report contains:
+    - Game header (teams, final score, venue, attendance)
+    - Scoring summary (goals with scorers, assists, players on ice)
+    - Penalty summary (penalties by period)
+    - Period-by-period breakdown
+    - Officials
+
+    Example:
+        config = HTMLDownloaderConfig()
+        async with GameSummaryDownloader(config) as downloader:
+            result = await downloader.download_game(2024020500)
+
+            # Access parsed data
+            goals = result.data["goals"]
+            penalties = result.data["penalties"]
+
+            # Access raw HTML for reprocessing
+            raw_html = result.raw_content
+    """
+
+    @property
+    def report_type(self) -> str:
+        """Return report type code for Game Summary."""
+        return "GS"
+
+    async def _parse_report(self, soup: BeautifulSoup, game_id: int) -> dict[str, Any]:
+        """Parse Game Summary HTML into structured data.
+
+        Args:
+            soup: Parsed BeautifulSoup document
+            game_id: NHL game ID
+
+        Returns:
+            Dictionary containing parsed game summary data
+        """
+        season_id = self._extract_season_from_game_id(game_id)
+
+        # Parse game header
+        away_team, home_team = self._parse_teams(soup)
+        date, venue, attendance = self._parse_game_info(soup)
+        start_time, end_time = self._parse_times(soup)
+
+        # Parse scoring summary
+        goals = self._parse_scoring_summary(soup)
+
+        # Parse penalty summary
+        penalties = self._parse_penalty_summary(soup)
+
+        # Parse period summary
+        period_summary = self._parse_period_summary(soup)
+
+        # Parse officials
+        referees, linesmen = self._parse_officials(soup)
+
+        # Build result
+        summary = ParsedGameSummary(
+            game_id=game_id,
+            season_id=season_id,
+            date=date,
+            venue=venue,
+            attendance=attendance,
+            start_time=start_time,
+            end_time=end_time,
+            away_team=away_team,
+            home_team=home_team,
+            goals=goals,
+            penalties=penalties,
+            period_summary=period_summary,
+            referees=referees,
+            linesmen=linesmen,
+        )
+
+        return self._summary_to_dict(summary)
+
+    def _parse_teams(self, soup: BeautifulSoup) -> tuple[TeamInfo, TeamInfo]:
+        """Parse team information from header.
+
+        Returns:
+            Tuple of (away_team, home_team) TeamInfo objects
+        """
+        away_team = TeamInfo(name="", abbrev="", goals=0)
+        home_team = TeamInfo(name="", abbrev="", goals=0)
+
+        # Find visitor and home sections
+        visitor_table = soup.find("table", id="Visitor")
+        home_table = soup.find("table", id="Home")
+
+        if visitor_table:
+            away_team = self._parse_team_table(visitor_table)
+
+        if home_table:
+            home_team = self._parse_team_table(home_table)
+
+        return away_team, home_team
+
+    def _parse_team_table(self, table: Tag) -> TeamInfo:
+        """Parse a single team table."""
+        name = ""
+        abbrev = ""
+        goals = 0
+
+        # Find team name by searching for "Game X" pattern in td cells
+        game_pattern = re.compile(r"Game \d+")
+        for td in table.find_all("td"):
+            if hasattr(td, "get_text"):
+                text = td.get_text(strip=True)
+                if game_pattern.search(text):
+                    # Extract team name before "Game X"
+                    if "Game" in text:
+                        name = text.split("Game")[0].strip()
+                    break
+
+        # Find team logo to get abbreviation
+        img = table.find("img", alt=True)
+        if img and isinstance(img, Tag):
+            alt_text = cast(str, img.get("alt", ""))
+            if alt_text:
+                name = alt_text
+            src = cast(str, img.get("src", ""))
+            match = TEAM_LOGO_PATTERN.search(src)
+            if match:
+                abbrev = match.group(1).upper()
+
+        # Find score (large font size) by checking style attribute
+        for td in table.find_all("td"):
+            if isinstance(td, Tag):
+                style = cast(str, td.get("style", ""))
+                if "font-size" in style and "40px" in style:
+                    goals = self._safe_int(self._get_text(td), 0) or 0
+                    break
+
+        return TeamInfo(name=name, abbrev=abbrev, goals=goals)
+
+    def _parse_game_info(self, soup: BeautifulSoup) -> tuple[str, str, int | None]:
+        """Parse game date, venue, and attendance.
+
+        Returns:
+            Tuple of (date, venue, attendance)
+        """
+        date = ""
+        venue = ""
+        attendance = None
+
+        # Find GameInfo table
+        game_info = soup.find("table", id="GameInfo")
+        if game_info:
+            cells = game_info.find_all("td")
+            for cell in cells:
+                text = self._get_text(cell)
+
+                # Date format: "Saturday, December 21, 2024"
+                if any(
+                    day in text
+                    for day in [
+                        "Monday",
+                        "Tuesday",
+                        "Wednesday",
+                        "Thursday",
+                        "Friday",
+                        "Saturday",
+                        "Sunday",
+                    ]
+                ):
+                    date = text
+
+                # Venue and attendance
+                if "Attendance" in text:
+                    match = ATTENDANCE_PATTERN.search(text)
+                    if match:
+                        attendance = self._safe_int(match.group(1).replace(",", ""))
+                    # Venue is before attendance
+                    parts = text.split("Attendance")
+                    if parts:
+                        venue = parts[0].strip()
+
+        return date, venue, attendance
+
+    def _parse_times(self, soup: BeautifulSoup) -> tuple[str | None, str | None]:
+        """Parse game start and end times.
+
+        Returns:
+            Tuple of (start_time, end_time)
+        """
+        start_time = None
+        end_time = None
+
+        game_info = soup.find("table", id="GameInfo")
+        if game_info:
+            cells = game_info.find_all("td")
+            for cell in cells:
+                text = self._get_text(cell)
+                if "Start" in text:
+                    match = TIME_PATTERN.search(text)
+                    if match:
+                        start_time = match.group(0)
+                elif "End" in text:
+                    match = TIME_PATTERN.search(text)
+                    if match:
+                        end_time = match.group(0)
+
+        return start_time, end_time
+
+    def _parse_scoring_summary(self, soup: BeautifulSoup) -> list[GoalInfo]:
+        """Parse the scoring summary table.
+
+        Returns:
+            List of GoalInfo objects
+        """
+        goals: list[GoalInfo] = []
+
+        # Find scoring summary section by looking for sectionheading class
+        scoring_header = None
+        for td in soup.find_all("td", class_="sectionheading"):
+            if hasattr(td, "get_text"):
+                text = td.get_text(strip=True)
+                if "SCORING SUMMARY" in text.upper():
+                    scoring_header = td
+                    break
+        if not scoring_header:
+            return goals
+
+        # Navigate to the table containing goals
+        parent = scoring_header.find_parent("table")
+        if not parent:
+            return goals
+
+        # Find the next table with actual goal data
+        next_table = parent.find_next("table")
+        if not next_table:
+            return goals
+
+        # Get all rows (skip header)
+        rows = next_table.find_all("tr")
+        for row in rows[1:]:  # Skip header row
+            cells = row.find_all("td")
+            if len(cells) < 8:
+                continue
+
+            # Check for exception codes
+            goal_scorer_text = self._get_text(cells[5])
+            if self._is_exception_goal(goal_scorer_text):
+                continue
+
+            try:
+                goal = self._parse_goal_row(cells)
+                if goal:
+                    goals.append(goal)
+            except (ValueError, IndexError) as e:
+                logger.debug("Failed to parse goal row: %s", e)
+                continue
+
+        return goals
+
+    def _is_exception_goal(self, text: str) -> bool:
+        """Check if goal text contains exception codes."""
+        text_lower = text.lower()
+        return any(code in text_lower for code in EXCEPTION_CODES)
+
+    def _parse_goal_row(self, cells: list[Tag]) -> GoalInfo | None:
+        """Parse a single goal row from the scoring table."""
+        if len(cells) < 8:
+            return None
+
+        goal_number = self._safe_int(self._get_text(cells[0]))
+        if goal_number is None:
+            return None
+
+        period_text = self._get_text(cells[1])
+        period = self._parse_period(period_text)
+
+        time = self._get_text(cells[2])
+        strength = self._get_text(cells[3])
+        team = self._get_text(cells[4])
+
+        scorer = self._parse_player_from_cell(cells[5])
+        assist1 = self._parse_player_from_cell(cells[6]) if len(cells) > 6 else None
+        assist2 = self._parse_player_from_cell(cells[7]) if len(cells) > 7 else None
+
+        # Parse players on ice
+        away_on_ice: list[int] = []
+        home_on_ice: list[int] = []
+
+        if len(cells) > 8:
+            away_on_ice = self._parse_on_ice(cells[8])
+        if len(cells) > 9:
+            home_on_ice = self._parse_on_ice(cells[9])
+
+        return GoalInfo(
+            goal_number=goal_number,
+            period=period,
+            time=time,
+            strength=strength,
+            team=team,
+            scorer=scorer,
+            assist1=assist1,
+            assist2=assist2,
+            away_on_ice=away_on_ice,
+            home_on_ice=home_on_ice,
+        )
+
+    def _parse_period(self, text: str) -> int:
+        """Parse period number from text."""
+        text = text.strip().upper()
+        if text == "OT":
+            return 4
+        if text == "SO":
+            return 5
+        return self._safe_int(text, 0) or 0
+
+    def _parse_player_from_cell(self, cell: Tag) -> PlayerInfo:
+        """Parse player info from a table cell."""
+        text = self._get_text(cell)
+        if not text:
+            return PlayerInfo(number=None, name="")
+
+        info = self._parse_player_info(text)
+        return PlayerInfo(
+            number=info.get("number"),
+            name=info.get("name", ""),
+            season_total=info.get("stat"),
+        )
+
+    def _parse_on_ice(self, cell: Tag) -> list[int]:
+        """Parse player numbers from on-ice cell."""
+        numbers: list[int] = []
+        fonts = cell.find_all("font")
+        for font in fonts:
+            text = self._get_text(font)
+            num = self._safe_int(text)
+            if num is not None:
+                numbers.append(num)
+        return numbers
+
+    def _parse_penalty_summary(self, soup: BeautifulSoup) -> list[PenaltyInfo]:
+        """Parse the penalty summary section.
+
+        Returns:
+            List of PenaltyInfo objects
+        """
+        penalties: list[PenaltyInfo] = []
+
+        # Find penalty summary table
+        penalty_table = soup.find("table", id="PenaltySummary")
+        if not penalty_table:
+            return penalties
+
+        # Find the main penalty tables (one for visitor, one for home)
+        # These are direct child tables with the oddColor/evenColor rows
+        for row in penalty_table.find_all("tr", class_=["oddColor", "evenColor"]):
+            # Get direct td children only (not nested table cells)
+            cells = row.find_all("td", recursive=False)
+            if len(cells) < 6:
+                continue
+
+            try:
+                penalty = self._parse_penalty_row(cells)
+                if penalty:
+                    penalties.append(penalty)
+            except (ValueError, IndexError) as e:
+                logger.debug("Failed to parse penalty row: %s", e)
+                continue
+
+        return penalties
+
+    def _parse_penalty_row(self, cells: list[Tag]) -> PenaltyInfo | None:
+        """Parse a single penalty row."""
+        if len(cells) < 6:
+            return None
+
+        penalty_number = self._safe_int(self._get_text(cells[0]))
+        if penalty_number is None:
+            return None
+
+        period = self._safe_int(self._get_text(cells[1]), 0) or 0
+        time = self._get_text(cells[2])
+
+        # Player cell contains nested table with number and name
+        player_cell = cells[3]
+        player = self._parse_player_from_penalty_cell(player_cell)
+
+        pim = self._safe_int(self._get_text(cells[4]), 0) or 0
+        infraction = self._get_text(cells[5])
+
+        return PenaltyInfo(
+            penalty_number=penalty_number,
+            period=period,
+            time=time,
+            team="",  # Team determined by which table
+            player=player,
+            pim=pim,
+            infraction=infraction,
+        )
+
+    def _parse_player_from_penalty_cell(self, cell: Tag) -> PlayerInfo:
+        """Parse player info from a penalty cell with nested table.
+
+        The penalty player cell contains a nested table with structure:
+        <table>
+            <tr>
+                <td width="15">28</td>  <!-- number -->
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td>A.ROMANOV</td>  <!-- name -->
+            </tr>
+        </table>
+        """
+        # Try to find nested table
+        nested_table = cell.find("table")
+        if nested_table:
+            inner_cells = nested_table.find_all("td")
+            if len(inner_cells) >= 4:
+                number = self._safe_int(self._get_text(inner_cells[0]))
+                name = self._get_text(inner_cells[-1])  # Last cell has name
+                return PlayerInfo(number=number, name=name)
+
+        # Fallback: parse as simple text
+        text = self._get_text(cell)
+        info = self._parse_player_info(text)
+        return PlayerInfo(
+            number=info.get("number"),
+            name=info.get("name", ""),
+        )
+
+    def _parse_period_summary(self, soup: BeautifulSoup) -> list[PeriodSummary]:
+        """Parse period-by-period summary.
+
+        Returns:
+            List of PeriodSummary objects
+        """
+        # TODO: Implement period summary parsing
+        # This requires finding the period totals table
+        return []
+
+    def _parse_officials(self, soup: BeautifulSoup) -> tuple[list[str], list[str]]:
+        """Parse officials from the report.
+
+        Returns:
+            Tuple of (referees, linesmen)
+        """
+        referees: list[str] = []
+        linesmen: list[str] = []
+
+        # Find officials section
+        for td in soup.find_all("td"):
+            text = self._get_text(td)
+            if "Referee" in text:
+                # Extract referee names
+                parts = text.replace("Referees:", "").replace("Referee:", "")
+                for name in parts.split(","):
+                    name = name.strip()
+                    if name and name not in ["Referees", "Referee"]:
+                        referees.append(name)
+            elif "Linesmen" in text or "Linesman" in text:
+                # Extract linesman names
+                parts = text.replace("Linesmen:", "").replace("Linesman:", "")
+                for name in parts.split(","):
+                    name = name.strip()
+                    if name and name not in ["Linesmen", "Linesman"]:
+                        linesmen.append(name)
+
+        return referees, linesmen
+
+    def _summary_to_dict(self, summary: ParsedGameSummary) -> dict[str, Any]:
+        """Convert ParsedGameSummary to dictionary."""
+        return {
+            "game_id": summary.game_id,
+            "season_id": summary.season_id,
+            "date": summary.date,
+            "venue": summary.venue,
+            "attendance": summary.attendance,
+            "start_time": summary.start_time,
+            "end_time": summary.end_time,
+            "away_team": {
+                "name": summary.away_team.name,
+                "abbrev": summary.away_team.abbrev,
+                "goals": summary.away_team.goals,
+                "shots": summary.away_team.shots,
+            },
+            "home_team": {
+                "name": summary.home_team.name,
+                "abbrev": summary.home_team.abbrev,
+                "goals": summary.home_team.goals,
+                "shots": summary.home_team.shots,
+            },
+            "goals": [
+                {
+                    "goal_number": g.goal_number,
+                    "period": g.period,
+                    "time": g.time,
+                    "strength": g.strength,
+                    "team": g.team,
+                    "scorer": {
+                        "number": g.scorer.number,
+                        "name": g.scorer.name,
+                        "season_total": g.scorer.season_total,
+                    },
+                    "assist1": {
+                        "number": g.assist1.number,
+                        "name": g.assist1.name,
+                        "season_total": g.assist1.season_total,
+                    }
+                    if g.assist1 and g.assist1.name
+                    else None,
+                    "assist2": {
+                        "number": g.assist2.number,
+                        "name": g.assist2.name,
+                        "season_total": g.assist2.season_total,
+                    }
+                    if g.assist2 and g.assist2.name
+                    else None,
+                    "away_on_ice": g.away_on_ice,
+                    "home_on_ice": g.home_on_ice,
+                }
+                for g in summary.goals
+            ],
+            "penalties": [
+                {
+                    "penalty_number": p.penalty_number,
+                    "period": p.period,
+                    "time": p.time,
+                    "team": p.team,
+                    "player": {
+                        "number": p.player.number,
+                        "name": p.player.name,
+                    },
+                    "pim": p.pim,
+                    "infraction": p.infraction,
+                }
+                for p in summary.penalties
+            ],
+            "period_summary": [
+                {
+                    "period": ps.period,
+                    "away_goals": ps.away_goals,
+                    "home_goals": ps.home_goals,
+                    "away_shots": ps.away_shots,
+                    "home_shots": ps.home_shots,
+                }
+                for ps in summary.period_summary
+            ],
+            "referees": summary.referees,
+            "linesmen": summary.linesmen,
+        }

--- a/tests/fixtures/html/GS020500.HTM
+++ b/tests/fixtures/html/GS020500.HTM
@@ -1,0 +1,852 @@
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Game Summary</title>
+</head>
+<style type="text/css">
+				@media screen
+				{
+				     .print-class { display: block;}
+				}
+				@media print
+				{
+				     .print-class { display: none;}
+				}
+
+				p, td {font-family: arial,verdana; font-size: 10px;}
+				body {margin: 0; border:solid; border-width: 0;}
+				.title {fon-weight:bold;font-size:14px;}
+				.tablewidth{width: 650px;}
+				.columnwidth{width: 320px;}
+				.sectionheading{font-weight:bold;}
+				.visitorsectionheading{font-weight:bold;background-color: #E7E7E7;color:#000000;}
+				.homesectionheading{font-weight:bold;background-color: #E7E7E7;color:#000000;}
+				.teamHeading{font-weight:bold;font-size:14px;}
+				.heading {font-weight:bold}
+				.totalRow{font-size:10px;font-weight:bold;}
+				.bold{font-weight:bold;}
+				.border {border:1px solid black;border-collapse: collapse;}
+				.noborder {border:0px solid black;border-collapse: collapse;}
+				.tborder{border-top:1px solid black;}
+				.bborder{border-bottom:1px solid black;}
+				.lborder{border-left:1px solid black;}
+				.rborder{border-right:1px solid black;}
+				.oddColor{background-color: #E7E7E7;}
+				.evenColor{background-color: #FFFFFF;}
+				.spacer{font-size:1px;height:5px;}
+				
+			</style>
+<body topmargin="0" leftmargin="0"><script language="javascript" defer><!--
+				//Disable right mouse click Script
+									
+				function clickIE4(){
+				if (event.button==2){
+				return false;
+				}
+				}
+				
+				function clickNS4(e){
+				if (document.layers||document.getElementById&&!document.all){
+				if (e.which==2||e.which==3){
+				return false;
+				}
+				}
+				}
+														
+				if (document.layers){
+				document.captureEvents(Event.MOUSEDOWN);
+				document.onmousedown=clickNS4;
+				}
+				else if (document.all&&!document.getElementById){
+				document.onmousedown=clickIE4;
+				}
+				
+				document.oncontextmenu=new Function("return false");
+		
+			--></script><div class="print-class" align="center"><script languange="javascript" type="text/javascript" src="https://www.nhl.com/scores/htmlreports/scripts/gsTop.js"><!--&nbsp;--></script></div>
+<table id="MainTable" border="0" cellpadding="0" cellspacing="0" class="tablewidth" align="center">
+<tr>
+<td width="100%" align="center">
+<table id="StdHeader" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td align="center">
+<table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" xmlns:ext="urn:schemas-microsoft-com:xslt">
+<tr>
+<td valign="top">
+<table id="Visitor" border="0" cellpadding="0" cellspacing="0" align="center">
+<tr>
+<td align="center" style="font-size: 12px;font-weight:bold">VISITOR</td>
+</tr>
+<tr>
+<td>
+<table border="0" cellpadding="4" cellspacing="20" align="center">
+<tr>
+<td align="center"><img src="https://www.nhl.com/scores/htmlreports/20242025-images/logocnyi.gif" alt="NEW YORK ISLANDERS" width="50" height="50" border="0"></td>
+<td align="center" style="font-size: 40px;font-weight:bold">0</td>
+<td align="center"><img src="https://www.nhl.com/scores/htmlreports/20242025-images/logocnhl.gif" width="50" height="50" border="0"></td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td align="center" style="font-size: 10px;font-weight:bold">NEW YORK ISLANDERS<br>Game 33 Away Game 18</td>
+</tr>
+</table>
+</td>
+<td>
+<table id="GameInfo" border="0" cellpadding="0" cellspacing="0" align="center">
+<tr>
+<td style="font-size: 14px;font-weight:bold" align="center">Game Summary</td>
+</tr>
+<tr>
+<td style="font-size: 14px;font-weight:bold" align="center">&nbsp;</td>
+</tr>
+<tr>
+<td align="center" style="font-size: 10px;font-weight:bold"></td>
+</tr>
+<tr>
+<td align="center" style="font-size: 10px;font-weight:bold">Tuesday, December 17, 2024</td>
+</tr>
+<tr>
+<td align="center" style="font-size: 10px;font-weight:bold">Attendance 18,700&nbsp;at&nbsp;Lenovo Center</td>
+</tr>
+<tr>
+<td align="center" style="font-size: 10px;font-weight:bold">Start&nbsp;7:38&nbsp;EST; End&nbsp;10:03&nbsp;EST</td>
+</tr>
+<tr>
+<td align="center" style="font-size: 10px;font-weight:bold">Game 0500</td>
+</tr>
+<tr>
+<td align="center" style="font-size: 10px;font-weight:bold">Final</td>
+</tr>
+</table>
+</td>
+<td valign="top">
+<table id="Home" border="0" cellpadding="" cellspacing="0" align="center">
+<tr>
+<td align="center" style="font-size: 12px;font-weight:bold">HOME</td>
+</tr>
+<tr>
+<td>
+<table border="0" cellpadding="4" cellspacing="20" align="center">
+<tr>
+<td align="center"><img src="https://www.nhl.com/scores/htmlreports/20242025-images/logocnhl.gif" width="50" height="50" border="0"></td>
+<td align="center" style="font-size: 40px;font-weight:bold">4</td>
+<td align="center"><img src="https://www.nhl.com/scores/htmlreports/20242025-images/logoccar.gif" alt="CAROLINA HURRICANES" width="50" height="50" border="0"></td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td align="center" style="font-size: 10px;font-weight:bold">CAROLINA HURRICANES<br>Game 31 Home Game 17</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td width="100%" class="spacer + tborder">&nbsp;</td>
+</tr>
+<tr>
+<td align="center" width="100%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td align="center" class="sectionheading">SCORING SUMMARY</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td class="border">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td class="heading + bborder" align="center">G</td>
+<td class="heading + bborder" align="center">Per</td>
+<td class="heading + bborder" align="center">Time</td>
+<td class="heading + bborder" align="center">Str</td>
+<td class="heading + bborder" align="center">Team</td>
+<td class="heading + bborder" align="left">Goal Scorer</td>
+<td class="heading + bborder" align="left">Assist</td>
+<td class="heading + bborder" align="left">Assist</td>
+<td class="heading + bborder" align="left">NYI on Ice</td>
+<td class="heading + bborder" align="left">CAR on Ice</td>
+</tr>
+<tr class="oddColor">
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">5:47</td>
+<td align="center">PP</td>
+<td align="center">CAR</td>
+<td align="left">37 A.SVECHNIKOV(12)</td>
+<td align="left">20 S.AHO(24)</td>
+<td align="left">4 S.GOSTISBEHERE(20)</td>
+<td>
+<font style="cursor:hand;" title="Defense - ADAM PELECH">3</font>, <font style="cursor:hand;" title="Defense - RYAN PULOCK">6</font>, <font style="cursor:hand;" title="Center - BO HORVAT">14</font>, <font style="cursor:hand;" title="Center - BROCK NELSON">29</font>, <font style="cursor:hand;" title="Goalie - ILYA SOROKIN">30</font>
+</td>
+<td>
+<font style="cursor:hand;" title="Defense - SHAYNE GOSTISBEHERE">4</font>, <font style="cursor:hand;" title="Center - SEBASTIAN AHO">20</font>, <font style="cursor:hand;" title="Center - SETH JARVIS">24</font>, <font style="cursor:hand;" title="Right Wing - ANDREI SVECHNIKOV">37</font>, <font style="cursor:hand;" title="Goalie - PYOTR KOCHETKOV">52</font>, <font style="cursor:hand;" title="Center - MARTIN NECAS">88</font>
+</td>
+</tr>
+<tr class="evenColor">
+<td align="center">2</td>
+<td align="center">1</td>
+<td align="center">8:21</td>
+<td align="center">EV</td>
+<td align="center">CAR</td>
+<td align="left">48 J.MARTINOOK(8)</td>
+<td align="left">11 J.STAAL(9)</td>
+<td align="left"></td>
+<td>
+<font style="cursor:hand;" title="Defense - NOAH DOBSON">8</font>, <font style="cursor:hand;" title="Left Wing - PIERRE ENGVALL">18</font>, <font style="cursor:hand;" title="Center - KYLE PALMIERI">21</font>, <font style="cursor:hand;" title="Defense - ALEXANDER ROMANOV">28</font>, <font style="cursor:hand;" title="Center - BROCK NELSON">29</font>, <font style="cursor:hand;" title="Goalie - ILYA SOROKIN">30</font>
+</td>
+<td>
+<font style="cursor:hand;" title="Defense - BRENT BURNS">8</font>, <font style="cursor:hand;" title="Center - JORDAN STAAL">11</font>, <font style="cursor:hand;" title="Left Wing - WILLIAM CARRIER">28</font>, <font style="cursor:hand;" title="Left Wing - JORDAN MARTINOOK">48</font>, <font style="cursor:hand;" title="Goalie - PYOTR KOCHETKOV">52</font>, <font style="cursor:hand;" title="Defense - JACCOB SLAVIN">74</font>
+</td>
+</tr>
+<tr class="oddColor">
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">11:13</td>
+<td align="center">EV</td>
+<td align="center">CAR</td>
+<td align="left">27 T.JOST(2)</td>
+<td align="left">4 S.GOSTISBEHERE(21)</td>
+<td align="left">96 J.ROSLOVIC(5)</td>
+<td>
+<font style="cursor:hand;" title="Defense - NOAH DOBSON">8</font>, <font style="cursor:hand;" title="Right Wing - HUDSON FASCHING">20</font>, <font style="cursor:hand;" title="Defense - ALEXANDER ROMANOV">28</font>, <font style="cursor:hand;" title="Goalie - ILYA SOROKIN">30</font>, <font style="cursor:hand;" title="Center - KYLE MACLEAN">32</font>, <font style="cursor:hand;" title="Center - CASEY CIZIKAS">53</font>
+</td>
+<td>
+<font style="cursor:hand;" title="Defense - SHAYNE GOSTISBEHERE">4</font>, <font style="cursor:hand;" title="Defense - SEAN WALKER">26</font>, <font style="cursor:hand;" title="Center - TYSON JOST">27</font>, <font style="cursor:hand;" title="Goalie - PYOTR KOCHETKOV">52</font>, <font style="cursor:hand;" title="Right Wing - JACKSON BLAKE">53</font>, <font style="cursor:hand;" title="Center - JACK ROSLOVIC">96</font>
+</td>
+</tr>
+<tr class="evenColor">
+<td align="center">4</td>
+<td align="center">2</td>
+<td align="center">19:44</td>
+<td align="center">EV</td>
+<td align="center">CAR</td>
+<td align="left">20 S.AHO(9)</td>
+<td align="left">50 E.ROBINSON(10)</td>
+<td align="left">74 J.SLAVIN(8)</td>
+<td>
+<font style="cursor:hand;" title="Defense - ADAM PELECH">3</font>, <font style="cursor:hand;" title="Center - MATHEW BARZAL">13</font>, <font style="cursor:hand;" title="Defense - DENNIS CHOLOWSKI">25</font>, <font style="cursor:hand;" title="Left Wing - ANDERS LEE">27</font>, <font style="cursor:hand;" title="Goalie - ILYA SOROKIN">30</font>, <font style="cursor:hand;" title="Center - JEAN-GABRIEL PAGEAU">44</font>
+</td>
+<td>
+<font style="cursor:hand;" title="Defense - BRENT BURNS">8</font>, <font style="cursor:hand;" title="Center - SEBASTIAN AHO">20</font>, <font style="cursor:hand;" title="Center - SETH JARVIS">24</font>, <font style="cursor:hand;" title="Left Wing - ERIC ROBINSON">50</font>, <font style="cursor:hand;" title="Goalie - PYOTR KOCHETKOV">52</font>, <font style="cursor:hand;" title="Defense - JACCOB SLAVIN">74</font>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td width="100%" class="spacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="100%" align="center">
+<table id="VPenaltySummary" border="0" cellpadding="0" cellspacing="5" width="100%">
+<tr>
+<td align="center" width="50%" class="teamHeading + border ">NEW YORK ISLANDERS</td>
+<td align="center" width="50%" class="teamHeading + border">CAROLINA HURRICANES</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr valign="top">
+<td align="center" width="100%">
+<table id="PenaltySummary" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td align="center" class="sectionheading">PENALTY SUMMARY</td>
+</tr>
+<tr>
+<td>
+<table border="0" cellpadding="0" cellspacing="5" width="100%">
+<tr><td>
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td width="50%" valign="top" align="center" class="lborder + rborder + tborder">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td class="heading + bborder" align="center">#</td>
+<td class="heading + bborder" align="center">Per</td>
+<td class="heading + bborder" align="center">Time</td>
+<td class="heading + bborder" align="left">Player</td>
+<td class="heading + bborder" align="center">PIM</td>
+<td class="heading + bborder" align="left">Penalty</td>
+</tr>
+<tr class="oddColor">
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">5:12</td>
+<td align="left">
+<table cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td width="15" align="right">28</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>A.ROMANOV</td>
+</tr>
+</table>
+</td>
+<td align="center">2</td>
+<td align="left">High-sticking</td>
+</tr>
+<tr class="evenColor">
+<td align="center">2</td>
+<td align="center">2</td>
+<td align="center">14:32</td>
+<td align="left">
+<table cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td width="15" align="right">32</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>K.MACLEAN</td>
+</tr>
+</table>
+</td>
+<td align="center">2</td>
+<td align="left">Interference</td>
+</tr>
+<tr class="oddColor">
+<td align="center">3</td>
+<td align="center">3</td>
+<td align="center">10:08</td>
+<td align="left">
+<table cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td width="15" align="right">29</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>B.NELSON</td>
+</tr>
+</table>
+</td>
+<td align="center">2</td>
+<td align="left">Hooking</td>
+</tr>
+</table>
+</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td width="50%" valign="top" align="center" class="lborder + rborder + tborder">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td class="heading + bborder" align="center">#</td>
+<td class="heading + bborder" align="center">Per</td>
+<td class="heading + bborder" align="center">Time</td>
+<td class="heading + bborder" align="left">Player</td>
+<td class="heading + bborder" align="center">PIM</td>
+<td class="heading + bborder" align="left">Penalty</td>
+</tr>
+<tr class="oddColor">
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">11:25</td>
+<td align="left">
+<table cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td width="15" align="right">53</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>J.BLAKE</td>
+</tr>
+</table>
+</td>
+<td align="center">2</td>
+<td align="left">Hooking</td>
+</tr>
+<tr class="evenColor">
+<td align="center">2</td>
+<td align="center">2</td>
+<td align="center">14:32</td>
+<td align="left">
+<table cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td width="15" align="right">53</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>J.BLAKE</td>
+</tr>
+</table>
+</td>
+<td align="center">2</td>
+<td align="left">Embellishment</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top" align="center" class="lborder + rborder + bborder">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr class="evenColor">
+<td align="right" class="bold + oddColor + tborder" width="60%">
+<table cellpadding="0" cellspacing="0" border="0">
+<td class="bold">TOT (PN-PIM)</td>
+<td>&nbsp;</td>
+</table>
+</td>
+<td align="left" class="bold + oddColor + tborder" width="40%">3-6</td>
+</tr>
+<tr class="evenColor">
+<td align="right" class="bold + oddColor + tborder" width="60%">
+<table cellpadding="0" cellspacing="0" border="0">
+<td class="bold">Power Plays (Goals-Opp./PPTime)</td>
+<td>&nbsp;</td>
+</table>
+</td>
+<td align="left" class="bold + oddColor + tborder" width="40%">0-1/02:00</td>
+</tr>
+</table>
+</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td width="50%" valign="top" align="center" class="lborder + rborder + bborder">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr class="evenColor">
+<td align="right" class="bold + oddColor + tborder" width="60%">
+<table cellpadding="0" cellspacing="0" border="0">
+<td class="bold">TOT (PN-PIM)</td>
+<td>&nbsp;</td>
+</table>
+</td>
+<td align="left" class="bold + oddColor + tborder" width="40%">2-4</td>
+</tr>
+<tr class="evenColor">
+<td align="right" class="bold + oddColor + tborder" width="60%">
+<table cellpadding="0" cellspacing="0" border="0">
+<td class="bold">Power Plays (Goals-Opp./PPTime)</td>
+<td>&nbsp;</td>
+</table>
+</td>
+<td align="left" class="bold + oddColor + tborder" width="40%">1-2/02:35</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td></tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td width="100%" class="spacer">&nbsp;</td>
+</tr>
+<tr valign="top">
+<td align="center" width="100%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td align="center" class="sectionheading">BY PERIOD</td>
+</tr>
+<tr>
+<td>
+<table border="0" cellpadding="0" cellspacing="5" width="100%">
+<tr>
+<td width="50%" valign="top" class="tborder + lborder + rborder">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr class="heading">
+<td align="center" class="heading + bborder" width="20%">Per</td>
+<td align="center" class="heading + bborder" width="20%">Goals</td>
+<td align="center" class="heading + bborder" width="20%">Shots</td>
+<td align="center" class="heading + bborder" width="20%">PN</td>
+<td align="center" class="heading + bborder" width="20%">PIM</td>
+</tr>
+<tr class="oddColor">
+<td align="center" class=" + bborder + rborder">1</td>
+<td align="center" class=" + bborder + rborder">0</td>
+<td align="center" class=" + bborder + rborder">13</td>
+<td align="center" class=" + bborder + rborder">1</td>
+<td align="center" class=" + bborder">2</td>
+</tr>
+<tr class="evenColor">
+<td align="center" class=" + bborder + rborder">2</td>
+<td align="center" class=" + bborder + rborder">0</td>
+<td align="center" class=" + bborder + rborder">10</td>
+<td align="center" class=" + bborder + rborder">1</td>
+<td align="center" class=" + bborder">2</td>
+</tr>
+<tr class="oddColor">
+<td align="center" class=" + bborder + rborder">3</td>
+<td align="center" class=" + bborder + rborder">0</td>
+<td align="center" class=" + bborder + rborder">9</td>
+<td align="center" class=" + bborder + rborder">1</td>
+<td align="center" class=" + bborder">2</td>
+</tr>
+<tr class="evenColor">
+<td align="center" class="bold + oddColor + bborder + rborder">TOT</td>
+<td align="center" class="bold + oddColor + bborder + rborder">0</td>
+<td align="center" class="bold + oddColor + bborder + rborder">32</td>
+<td align="center" class="bold + oddColor + bborder + rborder">3</td>
+<td align="center" class="bold + oddColor + bborder">6</td>
+</tr>
+</table>
+</td>
+<td width="50%" align="center" class="tborder + lborder + rborder">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr class="heading">
+<td align="center" class="heading + bborder" width="20%">Per</td>
+<td align="center" class="heading + bborder" width="20%">Goals</td>
+<td align="center" class="heading + bborder" width="20%">Shots</td>
+<td align="center" class="heading + bborder" width="20%">PN</td>
+<td align="center" class="heading + bborder" width="20%">PIM</td>
+</tr>
+<tr class="oddColor">
+<td align="center" class=" + bborder + rborder">1</td>
+<td align="center" class=" + bborder + rborder">2</td>
+<td align="center" class=" + bborder + rborder">11</td>
+<td align="center" class=" + bborder + rborder">1</td>
+<td align="center" class=" + bborder">2</td>
+</tr>
+<tr class="evenColor">
+<td align="center" class=" + bborder + rborder">2</td>
+<td align="center" class=" + bborder + rborder">2</td>
+<td align="center" class=" + bborder + rborder">12</td>
+<td align="center" class=" + bborder + rborder">1</td>
+<td align="center" class=" + bborder">2</td>
+</tr>
+<tr class="oddColor">
+<td align="center" class=" + bborder + rborder">3</td>
+<td align="center" class=" + bborder + rborder">0</td>
+<td align="center" class=" + bborder + rborder">6</td>
+<td align="center" class=" + bborder + rborder">0</td>
+<td align="center" class=" + bborder">0</td>
+</tr>
+<tr class="evenColor">
+<td align="center" class="bold + oddColor + bborder + rborder">TOT</td>
+<td align="center" class="bold + oddColor + bborder + rborder">4</td>
+<td align="center" class="bold + oddColor + bborder + rborder">29</td>
+<td align="center" class="bold + oddColor + bborder + rborder">2</td>
+<td align="center" class="bold + oddColor + bborder">4</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td width="100%" class="spacer">&nbsp;</td>
+</tr>
+<tr valign="top">
+<td align="center" width="100%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td align="center" class="sectionheading">POWER PLAYS (Goals-Occurrences / Time)</td>
+</tr>
+<tr>
+<td>
+<table border="0" cellpadding="0" cellspacing="5" width="100%">
+<tr>
+<td width="50%" valign="top" class="border">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr class="heading">
+<td align="center" class="heading + bborder" width="25%">5v4</td>
+<td align="center" class="heading + bborder" width="25%">5v3</td>
+<td align="center" class="heading + bborder" width="25%">4v3</td>
+<td align="center" class="heading + bborder" width="25%">&nbsp;</td>
+</tr>
+<tr class="oddColor">
+<td align="center">0-1/02:00</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</table>
+</td>
+<td width="50%" valign="top" class="border">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr class="heading">
+<td align="center" class="heading + bborder" width="25%">5v4</td>
+<td align="center" class="heading + bborder" width="25%">5v3</td>
+<td align="center" class="heading + bborder" width="25%">4v3</td>
+<td align="center" class="heading + bborder" width="25%">&nbsp;</td>
+</tr>
+<tr class="oddColor">
+<td align="center">1-2/02:35</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr valign="top">
+<td align="center" width="100%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td align="center" class="sectionheading">EVEN STRENGTH (Goals-Occurrences / Time)</td>
+</tr>
+<tr>
+<td>
+<table border="0" cellpadding="0" cellspacing="5" width="100%">
+<tr>
+<td width="50%" valign="top" class="border">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr class="heading">
+<td align="center" class="heading + bborder" width="25%">5v5</td>
+<td align="center" class="heading + bborder" width="25%">4v4</td>
+<td align="center" class="heading + bborder" width="25%">3v3</td>
+<td align="center" class="heading + bborder" width="25%">TOT</td>
+</tr>
+<tr class="oddColor">
+<td align="center" class="">0-5/53:25</td>
+<td align="center" class="">0-1/02:00</td>
+<td align="center" class="">&nbsp;</td>
+<td align="center" class="">0-6/55:25</td>
+</tr>
+</table>
+</td>
+<td width="50%" valign="top" class="border">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr class="heading">
+<td align="center" class="heading + bborder" width="25%">5v5</td>
+<td align="center" class="heading + bborder" width="25%">4v4</td>
+<td align="center" class="heading + bborder" width="25%">3v3</td>
+<td align="center" class="heading + bborder" width="25%">TOT</td>
+</tr>
+<tr class="oddColor">
+<td align="center" class="">3-5/53:25</td>
+<td align="center" class="">0-1/02:00</td>
+<td align="center" class="">&nbsp;</td>
+<td align="center" class="">3-6/55:25</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td width="100%" class="spacer">&nbsp;</td>
+</tr>
+<tr>
+<td align="center" class="sectionheading" width="100%">GOALTENDER SUMMARY</td>
+</tr>
+<tr>
+<td align="center" width="100%" class="tborder">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td align="center" colspan="3" rowspan="2" valign="middle" class="lborder + rborder + bborder + visitorsectionheading">NEW YORK ISLANDERS</td>
+<td colspan="4" align="center" class="rborder + bborder + visitorsectionheading">TOI</td>
+<td align="center" colspan="4" class="rborder + bborder + visitorsectionheading">GOALS-SHOTS AGAINST</td>
+</tr>
+<tr>
+<td align="center" class="rborder + bborder + visitorsectionheading">EV</td>
+<td align="center" class="rborder + bborder + visitorsectionheading">PP</td>
+<td align="center" class="rborder + bborder + visitorsectionheading">SH</td>
+<td align="center" class="rborder + bborder + visitorsectionheading">TOT</td>
+<td align="center" class="rborder + bborder + visitorsectionheading">1</td>
+<td align="center" class="rborder + bborder + visitorsectionheading">2</td>
+<td align="center" class="rborder + bborder + visitorsectionheading">3</td>
+<td align="center" class="rborder + bborder + visitorsectionheading">TOT</td>
+</tr>
+<tr class="evenColor">
+<td align="center" class="lborder + bborder + rborder">30</td>
+<td align="center" class="bborder + rborder">G</td>
+<td class="bborder + rborder">SOROKIN, ILYA (L) </td>
+<td align="center" class="bborder + rborder">37:25</td>
+<td align="center" class="bborder + rborder">02:00</td>
+<td align="center" class="bborder + rborder">00:35</td>
+<td align="center" class="bborder + rborder">40:00</td>
+<td align="center" class="bborder + rborder">2-11</td>
+<td align="center" class="bborder + rborder">2-12</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">4-23</td>
+</tr>
+<tr class="oddColor">
+<td align="center" class="lborder + bborder + rborder">50</td>
+<td align="center" class="bborder + rborder">G</td>
+<td class="bborder + rborder">HOGBERG, MARCUS</td>
+<td align="center" class="bborder + rborder">18:00</td>
+<td align="center" class="bborder + rborder">00:00</td>
+<td align="center" class="bborder + rborder">02:00</td>
+<td align="center" class="bborder + rborder">20:00</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">0-6</td>
+<td align="center" class="bborder + rborder">0-6</td>
+</tr>
+<tr class="evenColor + bold">
+<td colspan="3" class="rborder" align="right">TEAM TOTALS&nbsp;</td>
+<td align="center" class="bborder + rborder">55:25</td>
+<td align="center" class="bborder + rborder">02:00</td>
+<td align="center" class="bborder + rborder">02:35</td>
+<td align="center" class="bborder + rborder">60:00</td>
+<td align="center" class="bborder + rborder">2-11</td>
+<td align="center" class="bborder + rborder">2-12</td>
+<td align="center" class="bborder + rborder">0-6</td>
+<td align="center" class="bborder + rborder">4-29</td>
+</tr>
+<tr>
+<td width="100%" class="spacer + bborder" colspan="22">&nbsp;</td>
+</tr>
+<tr>
+<td align="center" colspan="3" rowspan="2" valign="middle" class="lborder + rborder + bborder + homesectionheading">CAROLINA HURRICANES</td>
+<td colspan="4" align="center" class="rborder + bborder + homesectionheading">TOI</td>
+<td align="center" colspan="4" class="rborder + bborder + homesectionheading">GOALS-SHOTS AGAINST</td>
+</tr>
+<tr>
+<td align="center" class="rborder + bborder + homesectionheading">EV</td>
+<td align="center" class="rborder + bborder + homesectionheading">PP</td>
+<td align="center" class="rborder + bborder + homesectionheading">SH</td>
+<td align="center" class="rborder + bborder + homesectionheading">TOT</td>
+<td align="center" class="rborder + bborder + homesectionheading">1</td>
+<td align="center" class="rborder + bborder + homesectionheading">2</td>
+<td align="center" class="rborder + bborder + homesectionheading">3</td>
+<td align="center" class="rborder + bborder + homesectionheading">TOT</td>
+</tr>
+<tr class="evenColor">
+<td align="center" class="lborder + bborder + rborder">34</td>
+<td align="center" class="bborder + rborder">G</td>
+<td class="bborder + rborder">TOKARSKI, DUSTIN</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+<td align="center" class="bborder + rborder">&nbsp;</td>
+</tr>
+<tr class="oddColor">
+<td align="center" class="lborder + bborder + rborder">52</td>
+<td align="center" class="bborder + rborder">G</td>
+<td class="bborder + rborder">KOCHETKOV, PYOTR (W) </td>
+<td align="center" class="bborder + rborder">55:25</td>
+<td align="center" class="bborder + rborder">02:35</td>
+<td align="center" class="bborder + rborder">02:00</td>
+<td align="center" class="bborder + rborder">60:00</td>
+<td align="center" class="bborder + rborder">0-13</td>
+<td align="center" class="bborder + rborder">0-10</td>
+<td align="center" class="bborder + rborder">0-9</td>
+<td align="center" class="bborder + rborder">0-32</td>
+</tr>
+<tr class="evenColor + bold">
+<td colspan="3" class="rborder" align="right">TEAM TOTALS&nbsp;</td>
+<td align="center" class="bborder + rborder">55:25</td>
+<td align="center" class="bborder + rborder">02:35</td>
+<td align="center" class="bborder + rborder">02:00</td>
+<td align="center" class="bborder + rborder">60:00</td>
+<td align="center" class="bborder + rborder">0-13</td>
+<td align="center" class="bborder + rborder">0-10</td>
+<td align="center" class="bborder + rborder">0-9</td>
+<td align="center" class="bborder + rborder">0-32</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td width="100%" class="spacer">&nbsp;</td>
+</tr>
+<tr valign="top">
+<td align="center" width="100%" class="border">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr valign="top">
+<td align="center" class="sectionheading + rborder" width="50%">OFFICIALS</td>
+<td align="center" width="50%"><span class="sectionheading">3 STARS</span>&nbsp;By:Media</td>
+</tr>
+<tr>
+<td class="rborder" width="50%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr valign="top">
+<td align="center" class="heading">Referee</td>
+<td align="center" class="heading">Linesperson</td>
+</tr>
+<tr valign="top">
+<td align="center">
+<table cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td align="left">#7 Garrett Rank</td>
+</tr>
+<tr>
+<td align="left">#8 Francois StLaurent</td>
+</tr>
+</table>
+</td>
+<td align="center">
+<table cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td align="left">#56 Julien Fournier</td>
+</tr>
+<tr>
+<td align="left">#96 David Brisebois</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr valign="top">
+<td align="center" class="heading">Standby&nbsp;</td>
+<td align="center" class="heading">Standby&nbsp;</td>
+</tr>
+<tr valign="top">
+<td align="center">
+<table cellpadding="0" cellspacing="0" border="0"></table>
+</td>
+<td align="center">
+<table cellpadding="0" cellspacing="0" border="0"></table>
+</td>
+</tr>
+</table>
+</td>
+<td align="center" width="50%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+<tr>
+<td align="center">
+<table border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+<tr>
+<td align="center">1.</td>
+<td align="center">CAR</td>
+<td align="center">G</td>
+<td align="left">52 P.KOCHETKOV</td>
+</tr>
+<tr>
+<td align="center">2.</td>
+<td align="center">CAR</td>
+<td align="center">D</td>
+<td align="left">4 S.GOSTISBEHERE</td>
+</tr>
+<tr>
+<td align="center">3.</td>
+<td align="center">CAR</td>
+<td align="center">C</td>
+<td align="left">20 S.AHO</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td width="100%" class="spacer">&nbsp;</td>
+</tr>
+<tr>
+<td class="tborder">&#169; Copyright 2024, National Hockey League
+							&nbsp;2024-12-17 22.21.30</td>
+</tr>
+</table>
+<div class="print-class" align="center"><script languange="javascript" type="text/javascript" src="https://www.nhl.com/scores/htmlreports/scripts/gsBottom.js"><!--&nbsp;--></script></div>
+</body>
+</html>

--- a/tests/unit/downloaders/sources/html/test_game_summary.py
+++ b/tests/unit/downloaders/sources/html/test_game_summary.py
@@ -1,0 +1,491 @@
+"""Unit tests for GameSummaryDownloader.
+
+Tests cover:
+- HTML parsing of game summary reports
+- Team parsing from header
+- Scoring summary extraction
+- Penalty summary extraction
+- Exception code filtering
+- Integration with BaseHTMLDownloader
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bs4 import BeautifulSoup
+
+from nhl_api.downloaders.base.protocol import DownloadStatus
+from nhl_api.downloaders.sources.html.base_html_downloader import (
+    HTMLDownloaderConfig,
+)
+from nhl_api.downloaders.sources.html.game_summary import (
+    EXCEPTION_CODES,
+    GameSummaryDownloader,
+    GoalInfo,
+    PenaltyInfo,
+    PlayerInfo,
+    TeamInfo,
+)
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def config() -> HTMLDownloaderConfig:
+    """Create test configuration."""
+    return HTMLDownloaderConfig(
+        base_url="https://www.nhl.com/scores/htmlreports",
+        requests_per_second=10.0,
+        max_retries=2,
+        http_timeout=5.0,
+        store_raw_html=True,
+    )
+
+
+@pytest.fixture
+def downloader(config: HTMLDownloaderConfig) -> GameSummaryDownloader:
+    """Create test downloader instance."""
+    return GameSummaryDownloader(config)
+
+
+@pytest.fixture
+def sample_html() -> bytes:
+    """Load sample Game Summary HTML fixture."""
+    fixture_path = (
+        Path(__file__).parent.parent.parent.parent.parent
+        / "fixtures"
+        / "html"
+        / "GS020500.HTM"
+    )
+    if fixture_path.exists():
+        return fixture_path.read_bytes()
+    # Fallback minimal HTML for testing
+    return b"""<!DOCTYPE html>
+<html>
+<head><title>Game Summary</title></head>
+<body>
+<table id="Visitor">
+    <tr><td><img src="logocnyi.gif" alt="NEW YORK ISLANDERS"></td></tr>
+    <tr><td style="font-size: 40px;font-weight:bold">0</td></tr>
+    <tr><td>NEW YORK ISLANDERS Game 33 Away Game 18</td></tr>
+</table>
+<table id="Home">
+    <tr><td><img src="logoccar.gif" alt="CAROLINA HURRICANES"></td></tr>
+    <tr><td style="font-size: 40px;font-weight:bold">4</td></tr>
+    <tr><td>CAROLINA HURRICANES Game 31 Home Game 17</td></tr>
+</table>
+<table id="GameInfo">
+    <tr><td>Game Summary</td></tr>
+    <tr><td>Saturday, December 21, 2024</td></tr>
+    <tr><td>PNC Arena Attendance 18,680</td></tr>
+    <tr><td>Start 7:00 PM</td></tr>
+    <tr><td>End 9:30 PM</td></tr>
+</table>
+<table>
+    <tr><td class="sectionheading">SCORING SUMMARY</td></tr>
+</table>
+<table>
+    <tr>
+        <td class="heading">G</td>
+        <td class="heading">Per</td>
+        <td class="heading">Time</td>
+        <td class="heading">Str</td>
+        <td class="heading">Team</td>
+        <td class="heading">Goal Scorer</td>
+        <td class="heading">Assist</td>
+        <td class="heading">Assist</td>
+        <td class="heading">NYI on Ice</td>
+        <td class="heading">CAR on Ice</td>
+    </tr>
+    <tr class="oddColor">
+        <td align="center">1</td>
+        <td align="center">1</td>
+        <td align="center">5:47</td>
+        <td align="center">PP</td>
+        <td align="center">CAR</td>
+        <td align="left">37 A.SVECHNIKOV(12)</td>
+        <td align="left">20 S.AHO(24)</td>
+        <td align="left">4 S.GOSTISBEHERE(20)</td>
+        <td><font title="Player">3</font>, <font title="Player">6</font></td>
+        <td><font title="Player">4</font>, <font title="Player">20</font></td>
+    </tr>
+</table>
+<table id="PenaltySummary">
+    <tr><td class="sectionheading">PENALTY SUMMARY</td></tr>
+    <tr><td>
+        <table>
+            <tr>
+                <td class="heading">#</td>
+                <td class="heading">Per</td>
+                <td class="heading">Time</td>
+                <td class="heading">Player</td>
+                <td class="heading">PIM</td>
+                <td class="heading">Penalty</td>
+            </tr>
+            <tr class="oddColor">
+                <td align="center">1</td>
+                <td align="center">1</td>
+                <td align="center">5:12</td>
+                <td align="left">28 A.ROMANOV</td>
+                <td align="center">2</td>
+                <td align="left">High-sticking</td>
+            </tr>
+        </table>
+    </td></tr>
+</table>
+</body>
+</html>"""
+
+
+@pytest.fixture
+def sample_soup(sample_html: bytes) -> BeautifulSoup:
+    """Parse sample HTML into BeautifulSoup."""
+    return BeautifulSoup(sample_html.decode("utf-8"), "lxml")
+
+
+# =============================================================================
+# Configuration Tests
+# =============================================================================
+
+
+class TestGameSummaryDownloaderConfig:
+    """Tests for GameSummaryDownloader configuration."""
+
+    def test_report_type(self, downloader: GameSummaryDownloader) -> None:
+        """Test report_type is 'GS'."""
+        assert downloader.report_type == "GS"
+
+    def test_source_name(self, downloader: GameSummaryDownloader) -> None:
+        """Test source_name is 'html_gs'."""
+        assert downloader.source_name == "html_gs"
+
+
+# =============================================================================
+# Data Class Tests
+# =============================================================================
+
+
+class TestDataClasses:
+    """Tests for data classes."""
+
+    def test_player_info(self) -> None:
+        """Test PlayerInfo creation."""
+        player = PlayerInfo(number=37, name="A.SVECHNIKOV", season_total=12)
+        assert player.number == 37
+        assert player.name == "A.SVECHNIKOV"
+        assert player.season_total == 12
+
+    def test_goal_info(self) -> None:
+        """Test GoalInfo creation."""
+        scorer = PlayerInfo(number=37, name="A.SVECHNIKOV", season_total=12)
+        goal = GoalInfo(
+            goal_number=1,
+            period=1,
+            time="5:47",
+            strength="PP",
+            team="CAR",
+            scorer=scorer,
+        )
+        assert goal.goal_number == 1
+        assert goal.period == 1
+        assert goal.strength == "PP"
+        assert goal.team == "CAR"
+
+    def test_penalty_info(self) -> None:
+        """Test PenaltyInfo creation."""
+        player = PlayerInfo(number=28, name="A.ROMANOV")
+        penalty = PenaltyInfo(
+            penalty_number=1,
+            period=1,
+            time="5:12",
+            team="NYI",
+            player=player,
+            pim=2,
+            infraction="High-sticking",
+        )
+        assert penalty.penalty_number == 1
+        assert penalty.pim == 2
+        assert penalty.infraction == "High-sticking"
+
+    def test_team_info(self) -> None:
+        """Test TeamInfo creation."""
+        team = TeamInfo(name="CAROLINA HURRICANES", abbrev="CAR", goals=4)
+        assert team.name == "CAROLINA HURRICANES"
+        assert team.abbrev == "CAR"
+        assert team.goals == 4
+
+
+# =============================================================================
+# Exception Code Tests
+# =============================================================================
+
+
+class TestExceptionCodes:
+    """Tests for exception code handling."""
+
+    def test_exception_codes_defined(self) -> None:
+        """Test EXCEPTION_CODES contains expected values."""
+        assert "unsuccessful penalty shot" in EXCEPTION_CODES
+        assert "no goal" in EXCEPTION_CODES
+        assert "missed" in EXCEPTION_CODES
+
+    def test_is_exception_goal(self, downloader: GameSummaryDownloader) -> None:
+        """Test _is_exception_goal method."""
+        assert downloader._is_exception_goal("No Goal - Offside") is True
+        assert downloader._is_exception_goal("Unsuccessful Penalty Shot") is True
+        assert downloader._is_exception_goal("37 A.SVECHNIKOV(12)") is False
+
+
+# =============================================================================
+# Team Parsing Tests
+# =============================================================================
+
+
+class TestTeamParsing:
+    """Tests for team information parsing."""
+
+    def test_parse_teams(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test parsing of team information."""
+        away, home = downloader._parse_teams(sample_soup)
+
+        # Check away team
+        assert away.name == "NEW YORK ISLANDERS"
+        assert away.goals == 0
+
+        # Check home team
+        assert home.name == "CAROLINA HURRICANES"
+        assert home.goals == 4
+
+
+# =============================================================================
+# Scoring Summary Tests
+# =============================================================================
+
+
+class TestScoringSummaryParsing:
+    """Tests for scoring summary parsing."""
+
+    def test_parse_scoring_summary(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test parsing of scoring summary."""
+        goals = downloader._parse_scoring_summary(sample_soup)
+
+        # Should have at least one goal
+        assert len(goals) >= 1
+
+        # Check first goal
+        first_goal = goals[0]
+        assert first_goal.goal_number == 1
+        assert first_goal.period == 1
+        assert first_goal.time == "5:47"
+        assert first_goal.strength == "PP"
+        assert first_goal.team == "CAR"
+
+    def test_parse_goal_scorer(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test parsing of goal scorer."""
+        goals = downloader._parse_scoring_summary(sample_soup)
+        if goals:
+            scorer = goals[0].scorer
+            assert scorer.number == 37
+            assert "SVECHNIKOV" in scorer.name
+
+    def test_parse_assists(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test parsing of assists."""
+        goals = downloader._parse_scoring_summary(sample_soup)
+        if goals and goals[0].assist1:
+            assert goals[0].assist1.number == 20
+            assert "AHO" in goals[0].assist1.name
+
+    def test_parse_period_ot(self, downloader: GameSummaryDownloader) -> None:
+        """Test period parsing for OT."""
+        assert downloader._parse_period("OT") == 4
+        assert downloader._parse_period("SO") == 5
+        assert downloader._parse_period("1") == 1
+        assert downloader._parse_period("3") == 3
+
+
+# =============================================================================
+# Penalty Summary Tests
+# =============================================================================
+
+
+class TestPenaltySummaryParsing:
+    """Tests for penalty summary parsing."""
+
+    def test_parse_penalty_summary(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test parsing of penalty summary."""
+        penalties = downloader._parse_penalty_summary(sample_soup)
+
+        # Should have at least one penalty
+        assert len(penalties) >= 1
+
+        # Check first penalty
+        first_penalty = penalties[0]
+        assert first_penalty.penalty_number == 1
+        assert first_penalty.period == 1
+        assert first_penalty.time == "5:12"
+        assert first_penalty.pim == 2
+        assert first_penalty.infraction == "High-sticking"
+
+
+# =============================================================================
+# Game Info Parsing Tests
+# =============================================================================
+
+
+class TestGameInfoParsing:
+    """Tests for game info parsing."""
+
+    def test_parse_game_info(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test parsing of game info."""
+        date, venue, attendance = downloader._parse_game_info(sample_soup)
+
+        # Check date
+        assert "December" in date or "Saturday" in date
+
+    def test_parse_times(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test parsing of start/end times."""
+        start, end = downloader._parse_times(sample_soup)
+
+        # Should have times if GameInfo table exists
+        # Times might be None if parsing fails, that's acceptable
+
+
+# =============================================================================
+# Full Parse Tests
+# =============================================================================
+
+
+class TestFullParse:
+    """Tests for full report parsing."""
+
+    @pytest.mark.asyncio
+    async def test_parse_report(
+        self,
+        downloader: GameSummaryDownloader,
+        sample_soup: BeautifulSoup,
+    ) -> None:
+        """Test full report parsing."""
+        result = await downloader._parse_report(sample_soup, 2024020500)
+
+        # Check structure
+        assert "game_id" in result
+        assert "season_id" in result
+        assert "away_team" in result
+        assert "home_team" in result
+        assert "goals" in result
+        assert "penalties" in result
+
+        # Check values
+        assert result["game_id"] == 2024020500
+        assert result["season_id"] == 20242025
+
+    @pytest.mark.asyncio
+    async def test_download_game_success(
+        self,
+        downloader: GameSummaryDownloader,
+        sample_html: bytes,
+    ) -> None:
+        """Test successful game download."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.content = sample_html
+
+        with patch.object(
+            downloader, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            async with downloader:
+                result = await downloader.download_game(2024020500)
+
+        assert result.is_successful
+        assert result.status == DownloadStatus.COMPLETED
+        assert result.game_id == 2024020500
+        assert result.source == "html_gs"
+        assert result.raw_content == sample_html
+
+
+# =============================================================================
+# Output Format Tests
+# =============================================================================
+
+
+class TestOutputFormat:
+    """Tests for output format compliance."""
+
+    @pytest.mark.asyncio
+    async def test_summary_to_dict(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test _summary_to_dict output format."""
+        result = await downloader._parse_report(sample_soup, 2024020500)
+
+        # Verify expected keys
+        expected_keys = {
+            "game_id",
+            "season_id",
+            "date",
+            "venue",
+            "attendance",
+            "start_time",
+            "end_time",
+            "away_team",
+            "home_team",
+            "goals",
+            "penalties",
+            "period_summary",
+            "referees",
+            "linesmen",
+        }
+        assert set(result.keys()) == expected_keys
+
+        # Verify team structure
+        assert "name" in result["away_team"]
+        assert "abbrev" in result["away_team"]
+        assert "goals" in result["away_team"]
+        assert "shots" in result["away_team"]
+
+    @pytest.mark.asyncio
+    async def test_goal_dict_format(
+        self, downloader: GameSummaryDownloader, sample_soup: BeautifulSoup
+    ) -> None:
+        """Test goal dictionary format."""
+        result = await downloader._parse_report(sample_soup, 2024020500)
+
+        if result["goals"]:
+            goal = result["goals"][0]
+            expected_keys = {
+                "goal_number",
+                "period",
+                "time",
+                "strength",
+                "team",
+                "scorer",
+                "assist1",
+                "assist2",
+                "away_on_ice",
+                "home_on_ice",
+            }
+            assert set(goal.keys()) == expected_keys
+
+            # Verify scorer structure
+            assert "number" in goal["scorer"]
+            assert "name" in goal["scorer"]
+            assert "season_total" in goal["scorer"]


### PR DESCRIPTION
## Summary
- Implements `GameSummaryDownloader` for parsing NHL Game Summary HTML reports
- Parses scoring summary, penalty summary, team info, and game metadata
- Includes dataclasses for structured data: `GoalInfo`, `PenaltyInfo`, `TeamInfo`, `PlayerInfo`
- Handles exception codes (No Goal, Penalty Shot, etc.) to filter non-goal entries
- Integrates with viewer monitoring API via `source_name: "html_gs"`

## Test plan
- [ ] Run unit tests: `pytest tests/unit/downloaders/sources/html/test_game_summary.py -v`
- [ ] Verify CI passes (mypy, ruff, pytest)
- [ ] Test with real HTML fixture (GS020500.HTM - NYI vs CAR game)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)