### PR TITLE
feat(downloaders): Add DailyFaceoff Base Downloader Infrastructure (#102)

### DIFF
--- a/src/nhl_api/downloaders/sources/__init__.py
+++ b/src/nhl_api/downloaders/sources/__init__.py
@@ -3,9 +3,16 @@
 This package contains downloaders for various NHL data sources:
 - nhl_json: Official NHL JSON API (api-web.nhle.com)
 - html: NHL HTML game reports (www.nhl.com/scores/htmlreports)
-- external: Third-party sources like QuantHockey, DailyFaceoff (future)
+- dailyfaceoff: DailyFaceoff.com team lineup data
+- external: Third-party sources like QuantHockey (future)
 """
 
+from nhl_api.downloaders.sources.dailyfaceoff import (
+    DAILYFACEOFF_CONFIG,
+    TEAM_SLUGS,
+    BaseDailyFaceoffDownloader,
+    DailyFaceoffConfig,
+)
 from nhl_api.downloaders.sources.html import (
     HTML_DOWNLOADER_CONFIG,
     BaseHTMLDownloader,
@@ -13,7 +20,13 @@ from nhl_api.downloaders.sources.html import (
 )
 
 __all__ = [
+    # HTML
     "BaseHTMLDownloader",
     "HTML_DOWNLOADER_CONFIG",
     "HTMLDownloaderConfig",
+    # DailyFaceoff
+    "BaseDailyFaceoffDownloader",
+    "DAILYFACEOFF_CONFIG",
+    "DailyFaceoffConfig",
+    "TEAM_SLUGS",
 ]

--- a/src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py
@@ -1,0 +1,37 @@
+"""DailyFaceoff downloaders for NHL team lineup data.
+
+This package provides downloaders for extracting lineup and roster
+information from DailyFaceoff.com.
+
+Available downloaders:
+- BaseDailyFaceoffDownloader: Base class for all DailyFaceoff downloaders
+
+Example usage:
+    from nhl_api.downloaders.sources.dailyfaceoff import (
+        BaseDailyFaceoffDownloader,
+        DailyFaceoffConfig,
+        TEAM_SLUGS,
+    )
+"""
+
+from nhl_api.downloaders.sources.dailyfaceoff.base_dailyfaceoff_downloader import (
+    DAILYFACEOFF_CONFIG,
+    BaseDailyFaceoffDownloader,
+    DailyFaceoffConfig,
+)
+from nhl_api.downloaders.sources.dailyfaceoff.team_mapping import (
+    TEAM_ABBREVIATIONS,
+    TEAM_SLUGS,
+    get_team_abbreviation,
+    get_team_slug,
+)
+
+__all__ = [
+    "BaseDailyFaceoffDownloader",
+    "DAILYFACEOFF_CONFIG",
+    "DailyFaceoffConfig",
+    "TEAM_SLUGS",
+    "TEAM_ABBREVIATIONS",
+    "get_team_slug",
+    "get_team_abbreviation",
+]

--- a/src/nhl_api/downloaders/sources/dailyfaceoff/base_dailyfaceoff_downloader.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/base_dailyfaceoff_downloader.py
@@ -1,0 +1,459 @@
+"""Base class for DailyFaceoff downloaders.
+
+This module provides the base implementation for downloading and parsing
+data from DailyFaceoff.com, which provides NHL team lineup information
+including line combinations, power play units, and starting goalies.
+
+Example usage:
+    class LineCombinationsDownloader(BaseDailyFaceoffDownloader):
+        @property
+        def data_type(self) -> str:
+            return "line_combinations"
+
+        async def download_team(self, team_id: int) -> dict[str, Any]:
+            # Implementation
+            ...
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bs4 import BeautifulSoup
+
+from nhl_api.downloaders.base.base_downloader import (
+    BaseDownloader,
+    DownloaderConfig,
+)
+from nhl_api.downloaders.base.protocol import (
+    DownloadError,
+    DownloadResult,
+    DownloadStatus,
+)
+from nhl_api.downloaders.sources.dailyfaceoff.team_mapping import (
+    TEAM_SLUGS,
+    get_team_abbreviation,
+    get_team_slug,
+)
+
+if TYPE_CHECKING:
+    from nhl_api.downloaders.base.rate_limiter import RateLimiter
+    from nhl_api.downloaders.base.retry_handler import RetryHandler
+    from nhl_api.utils.http_client import HTTPClient
+
+logger = logging.getLogger(__name__)
+
+# DailyFaceoff base URL
+DAILYFACEOFF_BASE_URL = "https://www.dailyfaceoff.com"
+
+# Conservative rate limit for DailyFaceoff (requests per second)
+# Being respectful to external sites
+DEFAULT_DAILYFACEOFF_RATE_LIMIT = 1.0
+
+# User agent for requests
+DEFAULT_USER_AGENT = "NHL-API-Collector/1.0 (Data Research)"
+
+
+@dataclass
+class DailyFaceoffConfig(DownloaderConfig):
+    """Configuration for DailyFaceoff downloaders.
+
+    Attributes:
+        base_url: Base URL for DailyFaceoff website
+        requests_per_second: Rate limit for requests (conservative for external sites)
+        max_retries: Maximum retry attempts for failed requests
+        retry_base_delay: Initial delay between retries in seconds
+        http_timeout: HTTP request timeout in seconds
+        health_check_url: URL path for health check
+        user_agent: User agent string for HTTP requests
+    """
+
+    base_url: str = DAILYFACEOFF_BASE_URL
+    requests_per_second: float = DEFAULT_DAILYFACEOFF_RATE_LIMIT
+    max_retries: int = 3
+    retry_base_delay: float = 2.0  # Longer delay for external site
+    http_timeout: float = 30.0
+    health_check_url: str = "/teams"
+    user_agent: str = DEFAULT_USER_AGENT
+
+
+# Default configuration instance
+DAILYFACEOFF_CONFIG = DailyFaceoffConfig()
+
+
+class BaseDailyFaceoffDownloader(BaseDownloader):
+    """Abstract base class for DailyFaceoff downloaders.
+
+    This class extends BaseDownloader with DailyFaceoff-specific functionality:
+    - Team ID to URL slug mapping
+    - HTML parsing with BeautifulSoup
+    - Team-based download iteration
+
+    Subclasses must implement:
+    - data_type: Property returning the type of data being downloaded
+    - page_path: Property returning the page path for the data type
+    - _parse_page: Method to parse the HTML into structured data
+
+    Example:
+        class LineCombinationsDownloader(BaseDailyFaceoffDownloader):
+            @property
+            def data_type(self) -> str:
+                return "line_combinations"
+
+            @property
+            def page_path(self) -> str:
+                return "line-combinations"
+
+            async def _parse_page(
+                self, soup: BeautifulSoup, team_id: int
+            ) -> dict[str, Any]:
+                # Extract line combination data from HTML
+                ...
+
+        config = DailyFaceoffConfig()
+        async with LineCombinationsDownloader(config) as downloader:
+            result = await downloader.download_team(10)  # Toronto Maple Leafs
+    """
+
+    def __init__(
+        self,
+        config: DailyFaceoffConfig | None = None,
+        *,
+        http_client: HTTPClient | None = None,
+        rate_limiter: RateLimiter | None = None,
+        retry_handler: RetryHandler | None = None,
+        progress_callback: Callable[..., None] | None = None,
+        team_ids: list[int] | None = None,
+    ) -> None:
+        """Initialize the DailyFaceoff downloader.
+
+        Args:
+            config: Downloader configuration
+            http_client: Optional custom HTTP client
+            rate_limiter: Optional custom rate limiter
+            retry_handler: Optional custom retry handler
+            progress_callback: Optional callback for progress updates
+            team_ids: Optional list of team IDs to download (default: all active teams)
+        """
+        super().__init__(
+            config or DailyFaceoffConfig(),
+            http_client=http_client,
+            rate_limiter=rate_limiter,
+            retry_handler=retry_handler,
+            progress_callback=progress_callback,
+        )
+        # Default to all teams except historical Arizona Coyotes
+        self._team_ids: list[int] = team_ids or [
+            tid
+            for tid in TEAM_SLUGS.keys()
+            if tid != 53  # Exclude Arizona (relocated)
+        ]
+        self._config: DailyFaceoffConfig  # Type hint for IDE
+
+    @property
+    @abstractmethod
+    def data_type(self) -> str:
+        """Type of data being downloaded.
+
+        Examples: "line_combinations", "power_play", "starting_goalies"
+
+        Returns:
+            Data type identifier
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def page_path(self) -> str:
+        """URL path segment for this data type.
+
+        This is appended to the team URL to form the full page URL.
+        Examples: "line-combinations", "power-play", "starting-goalies"
+
+        Returns:
+            URL path segment
+        """
+        ...
+
+    @property
+    def source_name(self) -> str:
+        """Unique identifier for this data source.
+
+        Returns:
+            Source name in format 'dailyfaceoff_{data_type}'
+        """
+        return f"dailyfaceoff_{self.data_type}"
+
+    @abstractmethod
+    async def _parse_page(self, soup: BeautifulSoup, team_id: int) -> dict[str, Any]:
+        """Parse the DailyFaceoff page into structured data.
+
+        This method should be implemented by subclasses to handle
+        page-specific parsing logic.
+
+        Args:
+            soup: Parsed BeautifulSoup document
+            team_id: NHL team ID
+
+        Returns:
+            Parsed page data as a dictionary
+
+        Raises:
+            DownloadError: If parsing fails
+        """
+        ...
+
+    def set_team_ids(self, team_ids: list[int]) -> None:
+        """Set team IDs for bulk download.
+
+        Args:
+            team_ids: List of NHL team IDs to download
+        """
+        self._team_ids = list(team_ids)
+        logger.debug(
+            "%s: Set %d team IDs for download",
+            self.source_name,
+            len(self._team_ids),
+        )
+
+    def _get_team_slug(self, team_id: int) -> str:
+        """Get DailyFaceoff URL slug for a team.
+
+        Args:
+            team_id: NHL team ID
+
+        Returns:
+            DailyFaceoff URL slug
+
+        Raises:
+            KeyError: If team_id is not recognized
+        """
+        return get_team_slug(team_id)
+
+    def _get_team_abbreviation(self, team_id: int) -> str:
+        """Get NHL abbreviation for a team.
+
+        Args:
+            team_id: NHL team ID
+
+        Returns:
+            Three-letter team abbreviation
+
+        Raises:
+            KeyError: If team_id is not recognized
+        """
+        return get_team_abbreviation(team_id)
+
+    def _build_team_url(self, team_id: int) -> str:
+        """Build DailyFaceoff team page URL.
+
+        DailyFaceoff team pages use the format:
+        https://www.dailyfaceoff.com/teams/{slug}/{page_path}
+
+        Args:
+            team_id: NHL team ID
+
+        Returns:
+            Full URL for the team page
+        """
+        slug = self._get_team_slug(team_id)
+        return f"{self.config.base_url}/teams/{slug}/{self.page_path}"
+
+    def _parse_html(self, content: bytes) -> BeautifulSoup:
+        """Parse HTML content with lxml parser.
+
+        Args:
+            content: Raw HTML bytes
+
+        Returns:
+            Parsed BeautifulSoup document
+        """
+        # Decode with error replacement for malformed characters
+        html_text = content.decode("utf-8", errors="replace")
+        return BeautifulSoup(html_text, "lxml")
+
+    def _validate_html(self, content: bytes) -> bool:
+        """Validate that content is HTML.
+
+        Args:
+            content: Raw bytes to validate
+
+        Returns:
+            True if content appears to be HTML
+        """
+        sample = content[:500].decode("utf-8", errors="replace").lower()
+        return "<html" in sample or "<!doctype" in sample
+
+    async def _fetch_game(self, game_id: int) -> dict[str, Any]:
+        """Not used for DailyFaceoff - downloads are team-based.
+
+        DailyFaceoff data is organized by team, not by game.
+        Use download_team() or download_all_teams() instead.
+
+        Args:
+            game_id: Not used
+
+        Raises:
+            NotImplementedError: Always, as this method is not applicable
+        """
+        raise NotImplementedError(
+            f"{self.source_name}: DailyFaceoff downloads are team-based. "
+            "Use download_team() or download_all_teams() instead."
+        )
+
+    async def _fetch_season_games(self, season_id: int) -> AsyncGenerator[int, None]:
+        """Not used for DailyFaceoff - downloads are team-based.
+
+        This method yields nothing as DailyFaceoff data is organized by team.
+
+        Args:
+            season_id: Not used
+
+        Yields:
+            Nothing
+        """
+        logger.warning(
+            "%s: DailyFaceoff downloads are team-based. "
+            "Use download_all_teams() instead of download_season().",
+            self.source_name,
+        )
+        return
+        yield  # Make this a generator that yields nothing
+
+    async def download_team(self, team_id: int) -> DownloadResult:
+        """Download data for a specific team.
+
+        Args:
+            team_id: NHL team ID
+
+        Returns:
+            DownloadResult with the team data
+
+        Raises:
+            DownloadError: If the download fails after retries
+        """
+        url = self._build_team_url(team_id)
+        abbreviation = self._get_team_abbreviation(team_id)
+
+        logger.debug(
+            "%s: Downloading %s for team %s (%d)",
+            self.source_name,
+            self.data_type,
+            abbreviation,
+            team_id,
+        )
+
+        try:
+            # Use relative path for _get() method
+            path = url.replace(self.config.base_url, "")
+            response = await self._get(path)
+
+            if not response.is_success:
+                raise DownloadError(
+                    f"Failed to fetch team page: HTTP {response.status}",
+                    source=self.source_name,
+                )
+
+            # Get raw content
+            raw_content = response.content
+
+            # Validate HTML content
+            if not self._validate_html(raw_content):
+                raise DownloadError(
+                    "Response is not valid HTML",
+                    source=self.source_name,
+                )
+
+            # Parse HTML
+            soup = self._parse_html(raw_content)
+
+            # Call subclass parser
+            parsed_data = await self._parse_page(soup, team_id)
+
+            return DownloadResult(
+                source=self.source_name,
+                season_id=0,  # DailyFaceoff shows current data, no season ID
+                game_id=0,  # Not game-specific
+                data={
+                    "team_id": team_id,
+                    "team_abbreviation": abbreviation,
+                    **parsed_data,
+                },
+                status=DownloadStatus.COMPLETED,
+                raw_content=raw_content,
+            )
+
+        except DownloadError:
+            raise
+        except Exception as e:
+            logger.exception(
+                "%s: Error downloading team %d",
+                self.source_name,
+                team_id,
+            )
+            raise DownloadError(
+                f"Failed to download team {team_id}: {e}",
+                source=self.source_name,
+                cause=e,
+            ) from e
+
+    async def download_all_teams(self) -> AsyncGenerator[DownloadResult, None]:
+        """Download data for all configured teams.
+
+        Yields:
+            DownloadResult for each team
+
+        Raises:
+            DownloadError: If a critical error prevents continuation
+        """
+        logger.info(
+            "%s: Starting download for %d teams",
+            self.source_name,
+            len(self._team_ids),
+        )
+
+        self.set_total_items(len(self._team_ids))
+        current_item = 0
+
+        for team_id in self._team_ids:
+            current_item += 1
+            abbreviation = self._get_team_abbreviation(team_id)
+
+            # Notify progress
+            self._notify_progress(
+                current=current_item,
+                total=len(self._team_ids),
+                status=DownloadStatus.DOWNLOADING,
+                message=f"Downloading {abbreviation}",
+            )
+
+            try:
+                result = await self.download_team(team_id)
+                yield result
+
+            except DownloadError as e:
+                logger.warning(
+                    "%s: Failed to download team %s (%d): %s",
+                    self.source_name,
+                    abbreviation,
+                    team_id,
+                    e,
+                )
+                yield DownloadResult(
+                    source=self.source_name,
+                    season_id=0,
+                    game_id=0,
+                    data={"team_id": team_id, "team_abbreviation": abbreviation},
+                    status=DownloadStatus.FAILED,
+                    error_message=str(e),
+                )
+
+        logger.info(
+            "%s: Completed download for %d teams",
+            self.source_name,
+            len(self._team_ids),
+        )

--- a/src/nhl_api/downloaders/sources/dailyfaceoff/team_mapping.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/team_mapping.py
@@ -1,0 +1,140 @@
+"""Team ID to DailyFaceoff URL slug mapping.
+
+DailyFaceoff uses URL-friendly team slugs in their team pages:
+https://www.dailyfaceoff.com/teams/{slug}/line-combinations
+
+This module provides bidirectional mapping between NHL team IDs and
+DailyFaceoff URL slugs.
+"""
+
+from __future__ import annotations
+
+# NHL Team ID to DailyFaceoff URL slug mapping
+# Team IDs are from the official NHL API
+# Slugs are from DailyFaceoff.com team page URLs
+TEAM_SLUGS: dict[int, str] = {
+    1: "new-jersey-devils",
+    2: "new-york-islanders",
+    3: "new-york-rangers",
+    4: "philadelphia-flyers",
+    5: "pittsburgh-penguins",
+    6: "boston-bruins",
+    7: "buffalo-sabres",
+    8: "montreal-canadiens",
+    9: "ottawa-senators",
+    10: "toronto-maple-leafs",
+    12: "carolina-hurricanes",
+    13: "florida-panthers",
+    14: "tampa-bay-lightning",
+    15: "washington-capitals",
+    16: "chicago-blackhawks",
+    17: "detroit-red-wings",
+    18: "nashville-predators",
+    19: "st-louis-blues",
+    20: "calgary-flames",
+    21: "colorado-avalanche",
+    22: "edmonton-oilers",
+    23: "vancouver-canucks",
+    24: "anaheim-ducks",
+    25: "dallas-stars",
+    26: "los-angeles-kings",
+    28: "san-jose-sharks",
+    29: "columbus-blue-jackets",
+    30: "minnesota-wild",
+    52: "winnipeg-jets",
+    53: "arizona-coyotes",  # Historical - relocated to Utah
+    54: "vegas-golden-knights",
+    55: "seattle-kraken",
+    59: "utah-hockey-club",
+}
+
+# NHL Team ID to abbreviation mapping
+TEAM_ABBREVIATIONS: dict[int, str] = {
+    1: "NJD",
+    2: "NYI",
+    3: "NYR",
+    4: "PHI",
+    5: "PIT",
+    6: "BOS",
+    7: "BUF",
+    8: "MTL",
+    9: "OTT",
+    10: "TOR",
+    12: "CAR",
+    13: "FLA",
+    14: "TBL",
+    15: "WSH",
+    16: "CHI",
+    17: "DET",
+    18: "NSH",
+    19: "STL",
+    20: "CGY",
+    21: "COL",
+    22: "EDM",
+    23: "VAN",
+    24: "ANA",
+    25: "DAL",
+    26: "LAK",
+    28: "SJS",
+    29: "CBJ",
+    30: "MIN",
+    52: "WPG",
+    53: "ARI",
+    54: "VGK",
+    55: "SEA",
+    59: "UTA",
+}
+
+# Reverse mapping: slug to team ID
+_SLUG_TO_ID: dict[str, int] = {slug: team_id for team_id, slug in TEAM_SLUGS.items()}
+
+
+def get_team_slug(team_id: int) -> str:
+    """Get DailyFaceoff URL slug for a team.
+
+    Args:
+        team_id: NHL team ID
+
+    Returns:
+        DailyFaceoff URL slug
+
+    Raises:
+        KeyError: If team_id is not recognized
+    """
+    if team_id not in TEAM_SLUGS:
+        raise KeyError(f"Unknown team ID: {team_id}")
+    return TEAM_SLUGS[team_id]
+
+
+def get_team_abbreviation(team_id: int) -> str:
+    """Get NHL abbreviation for a team.
+
+    Args:
+        team_id: NHL team ID
+
+    Returns:
+        Three-letter team abbreviation
+
+    Raises:
+        KeyError: If team_id is not recognized
+    """
+    if team_id not in TEAM_ABBREVIATIONS:
+        raise KeyError(f"Unknown team ID: {team_id}")
+    return TEAM_ABBREVIATIONS[team_id]
+
+
+def get_team_id_from_slug(slug: str) -> int:
+    """Get NHL team ID from DailyFaceoff URL slug.
+
+    Args:
+        slug: DailyFaceoff URL slug
+
+    Returns:
+        NHL team ID
+
+    Raises:
+        KeyError: If slug is not recognized
+    """
+    if slug not in _SLUG_TO_ID:
+        raise KeyError(f"Unknown team slug: {slug}")
+    return _SLUG_TO_ID[slug]

--- a/tests/unit/downloaders/sources/dailyfaceoff/__init__.py
+++ b/tests/unit/downloaders/sources/dailyfaceoff/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for DailyFaceoff downloaders."""

--- a/tests/unit/downloaders/sources/dailyfaceoff/test_base_dailyfaceoff_downloader.py
+++ b/tests/unit/downloaders/sources/dailyfaceoff/test_base_dailyfaceoff_downloader.py
@@ -1,0 +1,293 @@
+"""Unit tests for BaseDailyFaceoffDownloader."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bs4 import BeautifulSoup
+
+from nhl_api.downloaders.base.protocol import DownloadError, DownloadStatus
+from nhl_api.downloaders.sources.dailyfaceoff.base_dailyfaceoff_downloader import (
+    DAILYFACEOFF_BASE_URL,
+    DEFAULT_DAILYFACEOFF_RATE_LIMIT,
+    BaseDailyFaceoffDownloader,
+    DailyFaceoffConfig,
+)
+from nhl_api.downloaders.sources.dailyfaceoff.team_mapping import TEAM_SLUGS
+
+
+class ConcreteDownloader(BaseDailyFaceoffDownloader):
+    """Concrete implementation for testing."""
+
+    @property
+    def data_type(self) -> str:
+        return "test_data"
+
+    @property
+    def page_path(self) -> str:
+        return "test-page"
+
+    async def _parse_page(self, soup: BeautifulSoup, team_id: int) -> dict[str, Any]:
+        return {"parsed": True, "team_id": team_id}
+
+
+class TestDailyFaceoffConfig:
+    """Tests for DailyFaceoffConfig."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = DailyFaceoffConfig()
+        assert config.base_url == DAILYFACEOFF_BASE_URL
+        assert config.requests_per_second == DEFAULT_DAILYFACEOFF_RATE_LIMIT
+        assert config.max_retries == 3
+        assert config.retry_base_delay == 2.0
+        assert config.http_timeout == 30.0
+        assert config.health_check_url == "/teams"
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = DailyFaceoffConfig(
+            requests_per_second=0.5,
+            max_retries=5,
+            http_timeout=60.0,
+        )
+        assert config.requests_per_second == 0.5
+        assert config.max_retries == 5
+        assert config.http_timeout == 60.0
+
+    def test_conservative_rate_limit(self) -> None:
+        """Verify default rate limit is conservative (1 req/s or less)."""
+        assert DEFAULT_DAILYFACEOFF_RATE_LIMIT <= 1.0
+
+
+class TestBaseDailyFaceoffDownloader:
+    """Tests for BaseDailyFaceoffDownloader."""
+
+    def test_source_name(self) -> None:
+        """Test source_name property."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        assert downloader.source_name == "dailyfaceoff_test_data"
+
+    def test_default_team_ids(self) -> None:
+        """Test default team IDs excludes Arizona (relocated)."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        # Should have all teams except Arizona (ID 53)
+        assert 53 not in downloader._team_ids
+        assert len(downloader._team_ids) == len(TEAM_SLUGS) - 1
+
+    def test_custom_team_ids(self) -> None:
+        """Test custom team IDs."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config, team_ids=[10, 6, 1])
+        assert downloader._team_ids == [10, 6, 1]
+
+    def test_set_team_ids(self) -> None:
+        """Test set_team_ids method."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        downloader.set_team_ids([20, 21, 22])
+        assert downloader._team_ids == [20, 21, 22]
+
+    def test_get_team_slug(self) -> None:
+        """Test _get_team_slug method."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        assert downloader._get_team_slug(10) == "toronto-maple-leafs"
+        assert downloader._get_team_slug(6) == "boston-bruins"
+
+    def test_get_team_slug_invalid(self) -> None:
+        """Test _get_team_slug with invalid team ID."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        with pytest.raises(KeyError):
+            downloader._get_team_slug(999)
+
+    def test_get_team_abbreviation(self) -> None:
+        """Test _get_team_abbreviation method."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        assert downloader._get_team_abbreviation(10) == "TOR"
+        assert downloader._get_team_abbreviation(6) == "BOS"
+
+    def test_build_team_url(self) -> None:
+        """Test _build_team_url method."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        url = downloader._build_team_url(10)
+        expected = f"{DAILYFACEOFF_BASE_URL}/teams/toronto-maple-leafs/test-page"
+        assert url == expected
+
+    def test_build_team_url_all_teams(self) -> None:
+        """Test _build_team_url for all teams."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        for team_id, slug in TEAM_SLUGS.items():
+            url = downloader._build_team_url(team_id)
+            expected = f"{DAILYFACEOFF_BASE_URL}/teams/{slug}/test-page"
+            assert url == expected, f"Failed for team {team_id}"
+
+    def test_parse_html(self) -> None:
+        """Test _parse_html method."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        html = b"<html><body><h1>Test</h1></body></html>"
+        soup = downloader._parse_html(html)
+        h1 = soup.find("h1")
+        assert h1 is not None
+        assert h1.get_text() == "Test"
+
+    def test_parse_html_with_encoding_errors(self) -> None:
+        """Test _parse_html handles encoding errors."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        # Invalid UTF-8 bytes
+        html = b"<html><body>\xff\xfe</body></html>"
+        soup = downloader._parse_html(html)
+        assert soup is not None
+
+    def test_validate_html_valid(self) -> None:
+        """Test _validate_html with valid HTML."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        assert downloader._validate_html(b"<!DOCTYPE html><html>")
+        assert downloader._validate_html(b"<html><body>")
+
+    def test_validate_html_invalid(self) -> None:
+        """Test _validate_html with invalid content."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        assert not downloader._validate_html(b'{"json": "data"}')
+        assert not downloader._validate_html(b"plain text")
+
+    @pytest.mark.asyncio
+    async def test_fetch_game_not_implemented(self) -> None:
+        """Test _fetch_game raises NotImplementedError."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        with pytest.raises(NotImplementedError, match="team-based"):
+            await downloader._fetch_game(2024020001)
+
+    @pytest.mark.asyncio
+    async def test_fetch_season_games_warns(self) -> None:
+        """Test _fetch_season_games logs warning and yields nothing."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+        games = [g async for g in downloader._fetch_season_games(20242025)]
+        assert games == []
+
+
+class TestDownloadTeam:
+    """Tests for download_team method."""
+
+    @pytest.mark.asyncio
+    async def test_download_team_success(self) -> None:
+        """Test successful team download."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+
+        # Mock HTTP response
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.content = b"<!DOCTYPE html><html><body>Test</body></html>"
+
+        with patch.object(
+            downloader, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            async with downloader:
+                result = await downloader.download_team(10)
+
+        assert result.status == DownloadStatus.COMPLETED
+        assert result.data["team_id"] == 10
+        assert result.data["team_abbreviation"] == "TOR"
+        assert result.data["parsed"] is True
+        assert result.raw_content == mock_response.content
+
+    @pytest.mark.asyncio
+    async def test_download_team_http_error(self) -> None:
+        """Test team download with HTTP error."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.status = 404
+
+        with patch.object(
+            downloader, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            async with downloader:
+                with pytest.raises(DownloadError, match="HTTP 404"):
+                    await downloader.download_team(10)
+
+    @pytest.mark.asyncio
+    async def test_download_team_invalid_html(self) -> None:
+        """Test team download with invalid HTML response."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config)
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.content = b'{"not": "html"}'
+
+        with patch.object(
+            downloader, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            async with downloader:
+                with pytest.raises(DownloadError, match="not valid HTML"):
+                    await downloader.download_team(10)
+
+
+class TestDownloadAllTeams:
+    """Tests for download_all_teams method."""
+
+    @pytest.mark.asyncio
+    async def test_download_all_teams(self) -> None:
+        """Test downloading all teams."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config, team_ids=[10, 6])
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.content = b"<!DOCTYPE html><html><body>Test</body></html>"
+
+        with patch.object(
+            downloader, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            async with downloader:
+                results = [r async for r in downloader.download_all_teams()]
+
+        assert len(results) == 2
+        assert results[0].data["team_abbreviation"] == "TOR"
+        assert results[1].data["team_abbreviation"] == "BOS"
+
+    @pytest.mark.asyncio
+    async def test_download_all_teams_with_failure(self) -> None:
+        """Test download_all_teams handles individual failures."""
+        config = DailyFaceoffConfig()
+        downloader = ConcreteDownloader(config, team_ids=[10, 6])
+
+        # First call succeeds, second fails
+        mock_response_success = MagicMock()
+        mock_response_success.is_success = True
+        mock_response_success.content = b"<!DOCTYPE html><html><body>Test</body></html>"
+
+        mock_response_fail = MagicMock()
+        mock_response_fail.is_success = False
+        mock_response_fail.status = 500
+
+        with patch.object(
+            downloader,
+            "_get",
+            new_callable=AsyncMock,
+            side_effect=[mock_response_success, mock_response_fail],
+        ):
+            async with downloader:
+                results = [r async for r in downloader.download_all_teams()]
+
+        assert len(results) == 2
+        assert results[0].status == DownloadStatus.COMPLETED
+        assert results[1].status == DownloadStatus.FAILED

--- a/tests/unit/downloaders/sources/dailyfaceoff/test_team_mapping.py
+++ b/tests/unit/downloaders/sources/dailyfaceoff/test_team_mapping.py
@@ -1,0 +1,155 @@
+"""Unit tests for DailyFaceoff team mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from nhl_api.downloaders.sources.dailyfaceoff.team_mapping import (
+    TEAM_ABBREVIATIONS,
+    TEAM_SLUGS,
+    get_team_abbreviation,
+    get_team_id_from_slug,
+    get_team_slug,
+)
+
+
+class TestTeamSlugs:
+    """Tests for TEAM_SLUGS mapping."""
+
+    def test_all_32_teams_present(self) -> None:
+        """Verify all 32 current NHL teams are mapped."""
+        # Current active teams (excluding historical Arizona at ID 53)
+        expected_ids = {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,  # Eastern originals
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,  # More Eastern/Central
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            28,
+            29,
+            30,  # Western
+            52,
+            53,
+            54,
+            55,
+            59,  # Expansion/relocation
+        }
+        assert set(TEAM_SLUGS.keys()) == expected_ids
+
+    def test_slug_format(self) -> None:
+        """Verify all slugs are lowercase with hyphens."""
+        for team_id, slug in TEAM_SLUGS.items():
+            assert slug == slug.lower(), f"Team {team_id} slug not lowercase: {slug}"
+            assert " " not in slug, f"Team {team_id} slug has spaces: {slug}"
+            assert slug.replace("-", "").isalpha(), (
+                f"Team {team_id} slug has invalid chars: {slug}"
+            )
+
+    def test_specific_teams(self) -> None:
+        """Verify specific team mappings."""
+        assert TEAM_SLUGS[1] == "new-jersey-devils"
+        assert TEAM_SLUGS[10] == "toronto-maple-leafs"
+        assert TEAM_SLUGS[19] == "st-louis-blues"
+        assert TEAM_SLUGS[54] == "vegas-golden-knights"
+        assert TEAM_SLUGS[55] == "seattle-kraken"
+        assert TEAM_SLUGS[59] == "utah-hockey-club"
+
+    def test_historical_arizona(self) -> None:
+        """Verify Arizona Coyotes still in mapping for historical data."""
+        assert 53 in TEAM_SLUGS
+        assert TEAM_SLUGS[53] == "arizona-coyotes"
+
+
+class TestTeamAbbreviations:
+    """Tests for TEAM_ABBREVIATIONS mapping."""
+
+    def test_all_teams_have_abbreviations(self) -> None:
+        """Verify abbreviations match slugs."""
+        assert set(TEAM_ABBREVIATIONS.keys()) == set(TEAM_SLUGS.keys())
+
+    def test_abbreviation_format(self) -> None:
+        """Verify all abbreviations are 3 uppercase letters."""
+        for team_id, abbrev in TEAM_ABBREVIATIONS.items():
+            assert len(abbrev) == 3, f"Team {team_id} abbrev wrong length: {abbrev}"
+            assert abbrev == abbrev.upper(), f"Team {team_id} abbrev not uppercase"
+            assert abbrev.isalpha(), f"Team {team_id} abbrev not alphabetic: {abbrev}"
+
+    def test_specific_abbreviations(self) -> None:
+        """Verify specific team abbreviations."""
+        assert TEAM_ABBREVIATIONS[1] == "NJD"
+        assert TEAM_ABBREVIATIONS[10] == "TOR"
+        assert TEAM_ABBREVIATIONS[26] == "LAK"
+        assert TEAM_ABBREVIATIONS[54] == "VGK"
+        assert TEAM_ABBREVIATIONS[59] == "UTA"
+
+
+class TestGetTeamSlug:
+    """Tests for get_team_slug function."""
+
+    def test_valid_team_id(self) -> None:
+        """Test getting slug for valid team ID."""
+        assert get_team_slug(10) == "toronto-maple-leafs"
+        assert get_team_slug(6) == "boston-bruins"
+
+    def test_invalid_team_id(self) -> None:
+        """Test that invalid team ID raises KeyError."""
+        with pytest.raises(KeyError, match="Unknown team ID: 999"):
+            get_team_slug(999)
+
+    def test_missing_team_id_11(self) -> None:
+        """Test that team ID 11 (unused) raises KeyError."""
+        with pytest.raises(KeyError, match="Unknown team ID: 11"):
+            get_team_slug(11)
+
+
+class TestGetTeamAbbreviation:
+    """Tests for get_team_abbreviation function."""
+
+    def test_valid_team_id(self) -> None:
+        """Test getting abbreviation for valid team ID."""
+        assert get_team_abbreviation(10) == "TOR"
+        assert get_team_abbreviation(6) == "BOS"
+
+    def test_invalid_team_id(self) -> None:
+        """Test that invalid team ID raises KeyError."""
+        with pytest.raises(KeyError, match="Unknown team ID: 999"):
+            get_team_abbreviation(999)
+
+
+class TestGetTeamIdFromSlug:
+    """Tests for get_team_id_from_slug function."""
+
+    def test_valid_slug(self) -> None:
+        """Test getting team ID from valid slug."""
+        assert get_team_id_from_slug("toronto-maple-leafs") == 10
+        assert get_team_id_from_slug("boston-bruins") == 6
+
+    def test_invalid_slug(self) -> None:
+        """Test that invalid slug raises KeyError."""
+        with pytest.raises(KeyError, match="Unknown team slug: invalid-team"):
+            get_team_id_from_slug("invalid-team")
+
+    def test_all_slugs_reversible(self) -> None:
+        """Test that all slugs can be reversed to team IDs."""
+        for team_id, slug in TEAM_SLUGS.items():
+            assert get_team_id_from_slug(slug) == team_id


### PR DESCRIPTION
## Summary

Implements Wave 5b.1 - DailyFaceoff Base Downloader Infrastructure:

- `BaseDailyFaceoffDownloader` extending `BaseDownloader` with team-based download pattern
- `DailyFaceoffConfig` with conservative rate limit (1.0 req/s) for respectful external site access
- Complete team ID → URL slug mapping for all 32 NHL teams
- `download_team()` and `download_all_teams()` methods
- HTML parsing with BeautifulSoup (lxml parser)
- Team mapping includes Utah Hockey Club (2024-25 relocation)

## Files Created

- `src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py`
- `src/nhl_api/downloaders/sources/dailyfaceoff/base_dailyfaceoff_downloader.py`
- `src/nhl_api/downloaders/sources/dailyfaceoff/team_mapping.py`
- `tests/unit/downloaders/sources/dailyfaceoff/` (38 tests, 97%+ coverage)

## Test Plan

- [x] All 38 unit tests pass
- [x] Type checking passes (mypy --strict)
- [x] Code formatting passes (ruff)
- [x] Overall project coverage: 90.32%

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)