### PR TITLE
feat(downloaders): Add Base External Downloader infrastructure (#94)

### DIFF
--- a/src/nhl_api/downloaders/sources/external/__init__.py
+++ b/src/nhl_api/downloaders/sources/external/__init__.py
@@ -1,0 +1,52 @@
+"""External source downloaders for third-party data.
+
+This package contains base classes and utilities for downloading data
+from external (non-NHL) sources like QuantHockey and DailyFaceoff.
+
+External sources require more conservative rate limiting and custom
+User-Agent headers to respect third-party site policies.
+
+Subpackages (future):
+- quanthockey: QuantHockey historical statistics
+- dailyfaceoff: DailyFaceoff lineup and injury data
+
+Example usage:
+    from nhl_api.downloaders.sources.external import (
+        BaseExternalDownloader,
+        ExternalDownloaderConfig,
+    )
+
+    class QuantHockeyDownloader(BaseExternalDownloader):
+        @property
+        def source_name(self) -> str:
+            return "quanthockey_stats"
+
+        async def _parse_response(
+            self, response: HTTPResponse, context: dict[str, Any]
+        ) -> dict[str, Any]:
+            # Parse QuantHockey HTML
+            ...
+
+    config = ExternalDownloaderConfig(
+        base_url="https://www.quanthockey.com",
+        requests_per_second=0.5,
+    )
+    async with QuantHockeyDownloader(config) as downloader:
+        result = await downloader.fetch_resource("/stats/page")
+"""
+
+from nhl_api.downloaders.sources.external.base_external_downloader import (
+    BaseExternalDownloader,
+    ContentParsingError,
+    ExternalDownloaderConfig,
+    ExternalSourceError,
+    ValidationError,
+)
+
+__all__ = [
+    "BaseExternalDownloader",
+    "ContentParsingError",
+    "ExternalDownloaderConfig",
+    "ExternalSourceError",
+    "ValidationError",
+]

--- a/src/nhl_api/downloaders/sources/external/base_external_downloader.py
+++ b/src/nhl_api/downloaders/sources/external/base_external_downloader.py
@@ -1,0 +1,640 @@
+"""Base class for external (third-party) data source downloaders.
+
+This module provides the base implementation for downloading data from
+external sources like QuantHockey and DailyFaceoff. It extends BaseDownloader
+with features specific to third-party sites:
+
+- Custom User-Agent with respectful bot identifier
+- More conservative rate limiting (0.5 req/s default)
+- Response validation hooks
+- Raw response preservation
+- Flexible download patterns (not tied to NHL game IDs)
+
+Example usage:
+    class DailyFaceoffDownloader(BaseExternalDownloader):
+        @property
+        def source_name(self) -> str:
+            return "dailyfaceoff_lines"
+
+        async def _parse_response(
+            self, response: HTTPResponse, context: dict[str, Any]
+        ) -> dict[str, Any]:
+            # Parse DailyFaceoff HTML
+            soup = BeautifulSoup(response.content, "lxml")
+            return self._extract_line_data(soup)
+
+    config = ExternalDownloaderConfig(
+        base_url="https://www.dailyfaceoff.com",
+    )
+    async with DailyFaceoffDownloader(config) as downloader:
+        result = await downloader.fetch_resource("/teams/boston-bruins/line-combinations")
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from nhl_api.downloaders.base.base_downloader import (
+    BaseDownloader,
+    DownloaderConfig,
+)
+from nhl_api.downloaders.base.protocol import (
+    DownloadError,
+    DownloadResult,
+    DownloadStatus,
+)
+
+if TYPE_CHECKING:
+    from nhl_api.downloaders.base.rate_limiter import RateLimiter
+    from nhl_api.downloaders.base.retry_handler import RetryHandler
+    from nhl_api.utils.http_client import HTTPClient, HTTPResponse
+
+logger = logging.getLogger(__name__)
+
+# Conservative rate limit for external sources (requests per second)
+DEFAULT_EXTERNAL_RATE_LIMIT = 0.5  # 1 request every 2 seconds
+
+# Respectful User-Agent for third-party sites
+DEFAULT_USER_AGENT = (
+    "NHL-API-Collector/1.0 (Data Research; github.com/cooneycw/nhl-api)"
+)
+
+
+# =============================================================================
+# Exception Classes
+# =============================================================================
+
+
+class ExternalSourceError(DownloadError):
+    """Base exception for external source errors.
+
+    Extends DownloadError with URL tracking for external sources.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        source: str | None = None,
+        url: str | None = None,
+        cause: Exception | None = None,
+        game_id: int | None = None,
+    ) -> None:
+        """Initialize the external source error.
+
+        Args:
+            message: Human-readable error description
+            source: Data source name where error occurred
+            url: URL that caused the error
+            cause: Original exception that caused this error
+            game_id: Game ID if error is game-specific
+        """
+        super().__init__(message, source=source, game_id=game_id, cause=cause)
+        self.url = url
+
+    def __str__(self) -> str:
+        parts = [super().__str__()]
+        if self.url:
+            parts.append(f"url={self.url}")
+        return " ".join(parts)
+
+
+class ValidationError(ExternalSourceError):
+    """Raised when response validation fails.
+
+    This error indicates the response was received but doesn't meet
+    validation criteria (wrong status, empty content, invalid format).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        response_status: int | None = None,
+        content_type: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the validation error.
+
+        Args:
+            message: Human-readable error description
+            response_status: HTTP status code of the response
+            content_type: Content-Type header value
+            **kwargs: Additional arguments for ExternalSourceError
+        """
+        super().__init__(message, **kwargs)
+        self.response_status = response_status
+        self.content_type = content_type
+
+
+class ContentParsingError(ExternalSourceError):
+    """Raised when response content cannot be parsed.
+
+    This error indicates the response was valid but parsing failed
+    (malformed HTML, unexpected structure, missing data).
+    """
+
+    pass
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+@dataclass
+class ExternalDownloaderConfig(DownloaderConfig):
+    """Configuration for external data source downloaders.
+
+    Extends DownloaderConfig with settings appropriate for third-party sites.
+    Uses more conservative defaults to respect external site policies.
+
+    Attributes:
+        base_url: Base URL for the external source (required)
+        requests_per_second: Rate limit - conservative default (0.5 req/s)
+        max_retries: Maximum retry attempts
+        retry_base_delay: Initial delay between retries (longer for external)
+        http_timeout: HTTP request timeout (longer for external sites)
+        health_check_url: URL for health check (relative to base_url)
+        user_agent: User-Agent header for requests
+        custom_headers: Additional HTTP headers to send
+        store_raw_response: Whether to preserve raw bytes in results
+        validate_response: Enable response validation hooks
+        require_content: Fail if response body is empty
+    """
+
+    base_url: str = ""  # Required - no default
+    requests_per_second: float = DEFAULT_EXTERNAL_RATE_LIMIT
+    max_retries: int = 3
+    retry_base_delay: float = 2.0  # Longer initial delay for external sites
+    http_timeout: float = 45.0  # External sites may be slower
+    health_check_url: str = ""
+    user_agent: str = DEFAULT_USER_AGENT
+    custom_headers: dict[str, str] = field(default_factory=dict)
+    store_raw_response: bool = True
+    validate_response: bool = True
+    require_content: bool = True
+
+
+# Default configuration instance
+EXTERNAL_DOWNLOADER_CONFIG = ExternalDownloaderConfig()
+
+
+# =============================================================================
+# Base External Downloader
+# =============================================================================
+
+
+class BaseExternalDownloader(BaseDownloader):
+    """Abstract base class for third-party data source downloaders.
+
+    This class extends BaseDownloader with features specific to external sources:
+    - Custom User-Agent and headers
+    - More conservative rate limiting
+    - Response validation hooks
+    - Raw response preservation
+    - Non-game-based download patterns
+
+    Subclasses must implement:
+    - source_name: Property returning unique source identifier
+    - _parse_response: Method to parse response into structured data
+
+    Subclasses may override:
+    - _validate_response: Custom validation logic
+    - _build_url: Source-specific URL construction
+    - source_category: Grouping for related sources
+
+    Example:
+        class QuantHockeySeasonDownloader(BaseExternalDownloader):
+            @property
+            def source_name(self) -> str:
+                return "quanthockey_season"
+
+            async def _parse_response(
+                self, response: HTTPResponse, context: dict[str, Any]
+            ) -> dict[str, Any]:
+                # Parse QuantHockey HTML
+                ...
+
+        config = ExternalDownloaderConfig(
+            base_url="https://www.quanthockey.com",
+        )
+        async with QuantHockeySeasonDownloader(config) as downloader:
+            result = await downloader.fetch_resource("/nhl/seasons/2024-25.html")
+    """
+
+    config: ExternalDownloaderConfig  # Type hint for IDE support
+
+    def __init__(
+        self,
+        config: ExternalDownloaderConfig | None = None,
+        *,
+        http_client: HTTPClient | None = None,
+        rate_limiter: RateLimiter | None = None,
+        retry_handler: RetryHandler | None = None,
+        progress_callback: Callable[..., None] | None = None,
+    ) -> None:
+        """Initialize the external downloader.
+
+        Args:
+            config: Downloader configuration
+            http_client: Optional custom HTTP client
+            rate_limiter: Optional custom rate limiter
+            retry_handler: Optional custom retry handler
+            progress_callback: Optional callback for progress updates
+        """
+        super().__init__(
+            config or ExternalDownloaderConfig(),
+            http_client=http_client,
+            rate_limiter=rate_limiter,
+            retry_handler=retry_handler,
+            progress_callback=progress_callback,
+        )
+        self._store_raw = (
+            getattr(config, "store_raw_response", True) if config else True
+        )
+        self._last_raw_content: bytes | None = None
+
+    @property
+    def source_category(self) -> str:
+        """Category for grouping related sources.
+
+        Default implementation returns the first part of source_name
+        (before the first underscore).
+
+        Examples:
+            - "quanthockey_season" -> "quanthockey"
+            - "dailyfaceoff_lines" -> "dailyfaceoff"
+        """
+        return self.source_name.split("_")[0]
+
+    # =========================================================================
+    # Request Methods
+    # =========================================================================
+
+    def _get_headers(self) -> dict[str, str]:
+        """Get HTTP headers for requests.
+
+        Combines User-Agent with custom headers from config.
+        Standard browser-like headers are included for compatibility.
+
+        Returns:
+            Dictionary of HTTP headers
+        """
+        headers = {
+            "User-Agent": self.config.user_agent,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
+        }
+        headers.update(self.config.custom_headers)
+        return headers
+
+    async def _get_with_headers(
+        self,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> HTTPResponse:
+        """Perform a GET request with external source headers.
+
+        Extends base _get to add User-Agent and custom headers.
+        This method is rate-limited and retried automatically.
+
+        Args:
+            url: Full URL or path (appended to base_url if relative)
+            params: Optional query parameters
+            headers: Optional additional headers (merged with defaults)
+
+        Returns:
+            HTTP response
+
+        Raises:
+            ExternalSourceError: If request fails after retries
+        """
+        # Build full URL if needed
+        if not url.startswith(("http://", "https://")):
+            url = f"{self.config.base_url.rstrip('/')}/{url.lstrip('/')}"
+
+        # Merge headers
+        request_headers = self._get_headers()
+        if headers:
+            request_headers.update(headers)
+
+        # Use parent's _get which handles rate limiting and retries
+        # We need to temporarily store headers for the request
+        client = await self._ensure_client()
+
+        from nhl_api.downloaders.base.retry_handler import RetryableError
+
+        async def do_request() -> HTTPResponse:
+            await self._rate_limiter.wait()
+            response = await client.get(url, params=params, headers=request_headers)
+
+            if response.is_rate_limited:
+                raise RetryableError(
+                    f"Rate limited: {url}",
+                    status_code=429,
+                    retry_after=response.retry_after,
+                    source=self.source_name,
+                )
+
+            if response.is_server_error:
+                raise RetryableError(
+                    f"Server error {response.status}: {url}",
+                    status_code=response.status,
+                    source=self.source_name,
+                )
+
+            return response
+
+        try:
+            return await self._retry_handler.execute(
+                do_request,
+                operation_name=f"{self.source_name}:GET:{url}",
+                source=self.source_name,
+            )
+        except Exception as e:
+            if isinstance(e, ExternalSourceError):
+                raise
+            raise ExternalSourceError(
+                f"Request failed: {e}",
+                source=self.source_name,
+                url=url,
+                cause=e if isinstance(e, Exception) else None,
+            ) from e
+
+    # =========================================================================
+    # Validation Methods
+    # =========================================================================
+
+    async def _validate_response(self, response: HTTPResponse) -> bool:
+        """Validate that response is acceptable.
+
+        Default implementation checks:
+        - Status code is 2xx
+        - Content is not empty (if require_content=True)
+
+        Subclasses can override for source-specific validation.
+
+        Args:
+            response: HTTP response to validate
+
+        Returns:
+            True if response is valid
+
+        Raises:
+            ValidationError: If response fails validation
+        """
+        if not self.config.validate_response:
+            return True
+
+        # Check status
+        if not response.is_success:
+            raise ValidationError(
+                f"Request failed with status {response.status}",
+                response_status=response.status,
+                source=self.source_name,
+            )
+
+        # Check content
+        if self.config.require_content:
+            content = response.content
+            if not content or len(content) == 0:
+                raise ValidationError(
+                    "Response body is empty",
+                    response_status=response.status,
+                    source=self.source_name,
+                )
+
+        return True
+
+    # =========================================================================
+    # Abstract Methods
+    # =========================================================================
+
+    @abstractmethod
+    async def _parse_response(
+        self,
+        response: HTTPResponse,
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Parse response content into structured data.
+
+        This method must be implemented by subclasses to handle
+        source-specific parsing logic.
+
+        Args:
+            response: HTTP response to parse
+            context: Additional context (URL, params, etc.)
+
+        Returns:
+            Parsed data as dictionary
+
+        Raises:
+            ContentParsingError: If parsing fails
+        """
+        ...
+
+    # =========================================================================
+    # High-Level Methods
+    # =========================================================================
+
+    async def fetch_resource(
+        self,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> DownloadResult:
+        """Fetch a resource from the external source.
+
+        This is the primary download method for external sources.
+        It handles the full download flow: request, validation,
+        parsing, and result creation.
+
+        Args:
+            path: URL path relative to base_url
+            params: Optional query parameters
+            context: Optional context for result metadata
+
+        Returns:
+            DownloadResult with parsed data
+
+        Raises:
+            ExternalSourceError: If download fails
+            ValidationError: If response validation fails
+            ContentParsingError: If parsing fails
+        """
+        url = f"{self.config.base_url.rstrip('/')}/{path.lstrip('/')}"
+        context = context or {}
+        context["url"] = url
+        context["path"] = path
+        context["params"] = params
+
+        logger.debug(
+            "%s: Fetching resource %s",
+            self.source_name,
+            url,
+        )
+
+        try:
+            # Fetch with headers
+            response = await self._get_with_headers(url, params=params)
+
+            # Validate response
+            await self._validate_response(response)
+
+            # Store raw content if configured
+            raw_content: bytes | None = None
+            if self._store_raw:
+                raw_content = response.content
+                self._last_raw_content = raw_content
+
+            # Parse response
+            try:
+                data = await self._parse_response(response, context)
+            except ContentParsingError:
+                raise
+            except Exception as e:
+                raise ContentParsingError(
+                    f"Failed to parse response: {e}",
+                    source=self.source_name,
+                    url=url,
+                    cause=e,
+                ) from e
+
+            return DownloadResult(
+                source=self.source_name,
+                season_id=context.get("season_id", 0),
+                data=data,
+                downloaded_at=datetime.now(UTC),
+                game_id=context.get("game_id"),
+                status=DownloadStatus.COMPLETED,
+                raw_content=raw_content,
+            )
+
+        except (ExternalSourceError, ValidationError, ContentParsingError):
+            raise
+        except Exception as e:
+            logger.exception(
+                "%s: Unexpected error fetching %s",
+                self.source_name,
+                url,
+            )
+            raise ExternalSourceError(
+                f"Failed to fetch resource: {e}",
+                source=self.source_name,
+                url=url,
+                cause=e,
+            ) from e
+
+    async def fetch_page(
+        self,
+        url: str,
+        *,
+        validate: bool = True,
+    ) -> tuple[HTTPResponse, bytes]:
+        """Fetch a page and return both response and content.
+
+        Lower-level method for custom parsing workflows where
+        you need direct access to the response and content.
+
+        Args:
+            url: Full URL or path relative to base_url
+            validate: Whether to run validation (default True)
+
+        Returns:
+            Tuple of (HTTPResponse, content bytes)
+
+        Raises:
+            ExternalSourceError: If request fails
+            ValidationError: If validation fails
+        """
+        response = await self._get_with_headers(url)
+
+        if validate:
+            await self._validate_response(response)
+
+        content = response.content
+        if self._store_raw:
+            self._last_raw_content = content
+
+        return response, content
+
+    # =========================================================================
+    # Default Implementations of Base Methods
+    # =========================================================================
+
+    async def _fetch_game(self, game_id: int) -> dict[str, Any]:
+        """Default implementation raises NotImplementedError.
+
+        External sources may not support game-based downloads.
+        Subclasses that support games should override this method.
+
+        Args:
+            game_id: NHL game ID
+
+        Returns:
+            Game data as dictionary
+
+        Raises:
+            NotImplementedError: By default, external sources don't support this
+        """
+        raise NotImplementedError(
+            f"{self.source_name} does not support game-based downloads. "
+            "Use fetch_resource() or source-specific methods instead."
+        )
+
+    async def _fetch_season_games(self, season_id: int) -> AsyncGenerator[int, None]:
+        """Default implementation yields nothing.
+
+        External sources may use different season structures.
+        Subclasses that support season downloads should override this.
+
+        Args:
+            season_id: NHL season ID
+
+        Yields:
+            Game IDs (empty by default)
+        """
+        logger.warning(
+            "%s: _fetch_season_games not implemented for external sources. "
+            "Use fetch_resource() or source-specific methods instead.",
+            self.source_name,
+        )
+        return
+        yield  # Make it a generator
+
+    # =========================================================================
+    # Utility Methods
+    # =========================================================================
+
+    def _build_url(self, path: str, **kwargs: Any) -> str:
+        """Build URL for a request.
+
+        Default implementation joins base_url with path.
+        Subclasses can override for complex URL patterns.
+
+        Args:
+            path: URL path
+            **kwargs: Additional URL components (ignored by default)
+
+        Returns:
+            Full URL string
+        """
+        return f"{self.config.base_url.rstrip('/')}/{path.lstrip('/')}"
+
+    @property
+    def last_raw_content(self) -> bytes | None:
+        """Get the raw content from the last request.
+
+        Useful for debugging or reprocessing.
+        Only available if store_raw_response=True in config.
+        """
+        return self._last_raw_content

--- a/tests/unit/downloaders/sources/external/__init__.py
+++ b/tests/unit/downloaders/sources/external/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for external source downloaders."""

--- a/tests/unit/downloaders/sources/external/test_base_external_downloader.py
+++ b/tests/unit/downloaders/sources/external/test_base_external_downloader.py
@@ -1,0 +1,687 @@
+"""Unit tests for BaseExternalDownloader.
+
+Tests cover:
+- Configuration and initialization
+- Header setup and User-Agent
+- Response validation
+- Request methods with rate limiting
+- Fetch resource flow
+- Error handling
+- Exception classes
+- Default method behavior
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nhl_api.downloaders.base.protocol import DownloadStatus
+from nhl_api.downloaders.sources.external.base_external_downloader import (
+    DEFAULT_EXTERNAL_RATE_LIMIT,
+    DEFAULT_USER_AGENT,
+    EXTERNAL_DOWNLOADER_CONFIG,
+    BaseExternalDownloader,
+    ContentParsingError,
+    ExternalDownloaderConfig,
+    ExternalSourceError,
+    ValidationError,
+)
+from nhl_api.utils.http_client import HTTPResponse
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+class ConcreteExternalDownloader(BaseExternalDownloader):
+    """Concrete implementation for testing abstract base class."""
+
+    @property
+    def source_name(self) -> str:
+        return "test_external"
+
+    async def _parse_response(
+        self,
+        response: HTTPResponse,
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Simple parser for testing."""
+        content = response.content.decode("utf-8") if response.content else ""
+        return {
+            "content_length": len(content),
+            "url": context.get("url", ""),
+            "parsed": True,
+        }
+
+
+class FailingParser(BaseExternalDownloader):
+    """Downloader that fails during parsing."""
+
+    @property
+    def source_name(self) -> str:
+        return "failing_parser"
+
+    async def _parse_response(
+        self,
+        response: HTTPResponse,
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Parser that always fails."""
+        raise ValueError("Parsing failed intentionally")
+
+
+@pytest.fixture
+def config() -> ExternalDownloaderConfig:
+    """Create test configuration."""
+    return ExternalDownloaderConfig(
+        base_url="https://example.com",
+        requests_per_second=10.0,  # Fast for testing
+        max_retries=2,
+        http_timeout=5.0,
+        store_raw_response=True,
+    )
+
+
+@pytest.fixture
+def downloader(config: ExternalDownloaderConfig) -> ConcreteExternalDownloader:
+    """Create test downloader instance."""
+    return ConcreteExternalDownloader(config)
+
+
+@pytest.fixture
+def mock_http_client() -> MagicMock:
+    """Create mock HTTP client."""
+    client = MagicMock()
+    client._create_session = AsyncMock()
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def mock_response() -> MagicMock:
+    """Create mock HTTP response."""
+    response = MagicMock(spec=HTTPResponse)
+    response.is_success = True
+    response.is_rate_limited = False
+    response.is_server_error = False
+    response.status = 200
+    response.content = b"<html><body>Test content</body></html>"
+    response.retry_after = None
+    return response
+
+
+@pytest.fixture
+def empty_response() -> MagicMock:
+    """Create mock HTTP response with empty content."""
+    response = MagicMock(spec=HTTPResponse)
+    response.is_success = True
+    response.is_rate_limited = False
+    response.is_server_error = False
+    response.status = 200
+    response.content = b""
+    response.retry_after = None
+    return response
+
+
+# =============================================================================
+# Configuration Tests
+# =============================================================================
+
+
+class TestExternalDownloaderConfig:
+    """Tests for ExternalDownloaderConfig."""
+
+    def test_default_config_values(self) -> None:
+        """Test default configuration values are conservative."""
+        config = ExternalDownloaderConfig()
+        assert config.base_url == ""
+        assert config.requests_per_second == DEFAULT_EXTERNAL_RATE_LIMIT
+        assert config.requests_per_second == 0.5
+        assert config.max_retries == 3
+        assert config.retry_base_delay == 2.0
+        assert config.http_timeout == 45.0
+        assert config.user_agent == DEFAULT_USER_AGENT
+        assert config.custom_headers == {}
+        assert config.store_raw_response is True
+        assert config.validate_response is True
+        assert config.require_content is True
+
+    def test_custom_config_values(self) -> None:
+        """Test custom configuration values."""
+        custom_headers = {"X-Custom": "value"}
+        config = ExternalDownloaderConfig(
+            base_url="https://custom.example.com",
+            requests_per_second=1.0,
+            max_retries=5,
+            retry_base_delay=3.0,
+            http_timeout=60.0,
+            user_agent="Custom-Agent/1.0",
+            custom_headers=custom_headers,
+            store_raw_response=False,
+            validate_response=False,
+            require_content=False,
+        )
+        assert config.base_url == "https://custom.example.com"
+        assert config.requests_per_second == 1.0
+        assert config.max_retries == 5
+        assert config.retry_base_delay == 3.0
+        assert config.http_timeout == 60.0
+        assert config.user_agent == "Custom-Agent/1.0"
+        assert config.custom_headers == custom_headers
+        assert config.store_raw_response is False
+        assert config.validate_response is False
+        assert config.require_content is False
+
+    def test_default_config_instance(self) -> None:
+        """Test the default config singleton."""
+        assert EXTERNAL_DOWNLOADER_CONFIG.base_url == ""
+        assert EXTERNAL_DOWNLOADER_CONFIG.requests_per_second == 0.5
+        assert EXTERNAL_DOWNLOADER_CONFIG.user_agent == DEFAULT_USER_AGENT
+
+    def test_rate_limit_more_conservative_than_base(self) -> None:
+        """Test that default rate limit is more conservative than BaseDownloader."""
+        # BaseDownloader uses 5.0, we should use 0.5
+        config = ExternalDownloaderConfig()
+        assert config.requests_per_second < 5.0
+        assert config.requests_per_second == 0.5
+
+    def test_config_inherits_from_downloader_config(self) -> None:
+        """Test that config inherits base DownloaderConfig fields."""
+        config = ExternalDownloaderConfig(base_url="https://test.com")
+        # These are inherited from DownloaderConfig
+        assert hasattr(config, "base_url")
+        assert hasattr(config, "requests_per_second")
+        assert hasattr(config, "max_retries")
+        assert hasattr(config, "retry_base_delay")
+        assert hasattr(config, "http_timeout")
+        assert hasattr(config, "health_check_url")
+
+
+# =============================================================================
+# Initialization Tests
+# =============================================================================
+
+
+class TestBaseExternalDownloaderInit:
+    """Tests for BaseExternalDownloader initialization."""
+
+    def test_source_name_property(self, downloader: ConcreteExternalDownloader) -> None:
+        """Test source_name property is required."""
+        assert downloader.source_name == "test_external"
+
+    def test_source_category_default(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test source_category is derived from source_name."""
+        assert downloader.source_category == "test"
+
+    def test_source_category_with_multiple_underscores(
+        self, config: ExternalDownloaderConfig
+    ) -> None:
+        """Test source_category with complex source_name."""
+
+        class MultiUnderscoreDownloader(BaseExternalDownloader):
+            @property
+            def source_name(self) -> str:
+                return "quanthockey_season_stats"
+
+            async def _parse_response(
+                self, response: HTTPResponse, context: dict[str, Any]
+            ) -> dict[str, Any]:
+                return {}
+
+        downloader = MultiUnderscoreDownloader(config)
+        assert downloader.source_category == "quanthockey"
+
+    def test_init_with_default_config(self) -> None:
+        """Test initialization with default config."""
+        downloader = ConcreteExternalDownloader()
+        assert downloader.config.base_url == ""
+        assert downloader.config.requests_per_second == 0.5
+
+    def test_init_stores_raw_response_setting(
+        self, config: ExternalDownloaderConfig
+    ) -> None:
+        """Test that store_raw_response setting is captured."""
+        downloader = ConcreteExternalDownloader(config)
+        assert downloader._store_raw is True
+
+        config_no_raw = ExternalDownloaderConfig(
+            base_url="https://example.com",
+            store_raw_response=False,
+        )
+        downloader_no_raw = ConcreteExternalDownloader(config_no_raw)
+        assert downloader_no_raw._store_raw is False
+
+
+# =============================================================================
+# Header Tests
+# =============================================================================
+
+
+class TestHeaders:
+    """Tests for HTTP header handling."""
+
+    def test_get_headers_includes_user_agent(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test that User-Agent is included in headers."""
+        headers = downloader._get_headers()
+        assert "User-Agent" in headers
+        assert headers["User-Agent"] == downloader.config.user_agent
+
+    def test_get_headers_includes_accept(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test that Accept header is included."""
+        headers = downloader._get_headers()
+        assert "Accept" in headers
+        assert "text/html" in headers["Accept"]
+
+    def test_get_headers_includes_accept_language(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test that Accept-Language header is included."""
+        headers = downloader._get_headers()
+        assert "Accept-Language" in headers
+        assert "en-US" in headers["Accept-Language"]
+
+    def test_get_headers_merges_custom_headers(self) -> None:
+        """Test that custom headers are merged."""
+        config = ExternalDownloaderConfig(
+            base_url="https://example.com",
+            custom_headers={"X-Custom": "test-value", "X-Api-Key": "secret"},
+        )
+        downloader = ConcreteExternalDownloader(config)
+        headers = downloader._get_headers()
+        assert headers["X-Custom"] == "test-value"
+        assert headers["X-Api-Key"] == "secret"
+        # Standard headers should still be present
+        assert "User-Agent" in headers
+
+    def test_custom_headers_override_defaults(self) -> None:
+        """Test that custom headers can override defaults."""
+        config = ExternalDownloaderConfig(
+            base_url="https://example.com",
+            custom_headers={"Accept": "application/json"},
+        )
+        downloader = ConcreteExternalDownloader(config)
+        headers = downloader._get_headers()
+        assert headers["Accept"] == "application/json"
+
+
+# =============================================================================
+# Response Validation Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestResponseValidation:
+    """Tests for response validation."""
+
+    async def test_validate_success_response(
+        self, downloader: ConcreteExternalDownloader, mock_response: MagicMock
+    ) -> None:
+        """Test validation passes for 2xx responses with content."""
+        result = await downloader._validate_response(mock_response)
+        assert result is True
+
+    async def test_validate_rejects_failed_status(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test validation fails for non-2xx responses."""
+        response = MagicMock(spec=HTTPResponse)
+        response.is_success = False
+        response.status = 404
+        response.content = b"Not Found"
+
+        with pytest.raises(ValidationError) as exc_info:
+            await downloader._validate_response(response)
+
+        assert exc_info.value.response_status == 404
+        assert "404" in str(exc_info.value)
+
+    async def test_validate_rejects_empty_content(
+        self, downloader: ConcreteExternalDownloader, empty_response: MagicMock
+    ) -> None:
+        """Test validation fails for empty response when require_content=True."""
+        with pytest.raises(ValidationError) as exc_info:
+            await downloader._validate_response(empty_response)
+
+        assert "empty" in str(exc_info.value).lower()
+
+    async def test_validate_allows_empty_when_disabled(
+        self, empty_response: MagicMock
+    ) -> None:
+        """Test empty content allowed when require_content=False."""
+        config = ExternalDownloaderConfig(
+            base_url="https://example.com",
+            require_content=False,
+        )
+        downloader = ConcreteExternalDownloader(config)
+        result = await downloader._validate_response(empty_response)
+        assert result is True
+
+    async def test_validate_skipped_when_disabled(
+        self,
+    ) -> None:
+        """Test validation is skipped when validate_response=False."""
+        config = ExternalDownloaderConfig(
+            base_url="https://example.com",
+            validate_response=False,
+        )
+        downloader = ConcreteExternalDownloader(config)
+
+        # Even a failed response should pass
+        response = MagicMock(spec=HTTPResponse)
+        response.is_success = False
+        response.status = 500
+        response.content = b""
+
+        result = await downloader._validate_response(response)
+        assert result is True
+
+
+# =============================================================================
+# Fetch Resource Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestFetchResource:
+    """Tests for fetch_resource method."""
+
+    async def test_fetch_resource_success(
+        self,
+        downloader: ConcreteExternalDownloader,
+        mock_http_client: MagicMock,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test successful resource fetch."""
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(downloader, "_http_client", mock_http_client):
+            with patch.object(downloader._rate_limiter, "wait", AsyncMock()):
+                result = await downloader.fetch_resource("/test/path")
+
+        assert result.status == DownloadStatus.COMPLETED
+        assert result.is_successful
+        assert result.source == "test_external"
+        assert result.data["parsed"] is True
+
+    async def test_fetch_resource_stores_raw_content(
+        self,
+        downloader: ConcreteExternalDownloader,
+        mock_http_client: MagicMock,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test raw content is stored when configured."""
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(downloader, "_http_client", mock_http_client):
+            with patch.object(downloader._rate_limiter, "wait", AsyncMock()):
+                result = await downloader.fetch_resource("/test/path")
+
+        assert result.raw_content is not None
+        assert result.raw_content == mock_response.content
+        assert downloader.last_raw_content == mock_response.content
+
+    async def test_fetch_resource_with_context(
+        self,
+        downloader: ConcreteExternalDownloader,
+        mock_http_client: MagicMock,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test fetch with custom context."""
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+        context = {"season_id": 20242025, "game_id": 2024020001}
+
+        with patch.object(downloader, "_http_client", mock_http_client):
+            with patch.object(downloader._rate_limiter, "wait", AsyncMock()):
+                result = await downloader.fetch_resource("/test/path", context=context)
+
+        assert result.season_id == 20242025
+        assert result.game_id == 2024020001
+
+    async def test_fetch_resource_validation_failure(
+        self,
+        downloader: ConcreteExternalDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test fetch fails on validation error."""
+        failed_response = MagicMock(spec=HTTPResponse)
+        failed_response.is_success = False
+        failed_response.is_rate_limited = False
+        failed_response.is_server_error = False
+        failed_response.status = 404
+        failed_response.content = b"Not Found"
+
+        mock_http_client.get = AsyncMock(return_value=failed_response)
+
+        with patch.object(downloader, "_http_client", mock_http_client):
+            with patch.object(downloader._rate_limiter, "wait", AsyncMock()):
+                with pytest.raises(ValidationError):
+                    await downloader.fetch_resource("/not/found")
+
+    async def test_fetch_resource_parse_error(
+        self,
+        mock_http_client: MagicMock,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test fetch fails on parse error."""
+        config = ExternalDownloaderConfig(base_url="https://example.com")
+        downloader = FailingParser(config)
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(downloader, "_http_client", mock_http_client):
+            with patch.object(downloader._rate_limiter, "wait", AsyncMock()):
+                with pytest.raises(ContentParsingError) as exc_info:
+                    await downloader.fetch_resource("/test/path")
+
+        assert "Parsing failed" in str(exc_info.value.cause)
+
+
+# =============================================================================
+# Default Method Behavior Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestDefaultMethodBehavior:
+    """Tests for default implementations of base methods."""
+
+    async def test_fetch_game_raises_not_implemented(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test _fetch_game raises NotImplementedError by default."""
+        with pytest.raises(NotImplementedError) as exc_info:
+            await downloader._fetch_game(2024020001)
+
+        assert "test_external" in str(exc_info.value)
+        assert "game-based downloads" in str(exc_info.value)
+
+    async def test_fetch_season_games_yields_nothing(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test _fetch_season_games yields empty by default."""
+        game_ids = []
+        async for game_id in downloader._fetch_season_games(20242025):
+            game_ids.append(game_id)
+
+        assert game_ids == []
+
+
+# =============================================================================
+# Exception Tests
+# =============================================================================
+
+
+class TestExternalSourceErrors:
+    """Tests for custom exception classes."""
+
+    def test_external_source_error_includes_url(self) -> None:
+        """Test ExternalSourceError includes URL."""
+        error = ExternalSourceError(
+            "Test error",
+            source="test_source",
+            url="https://example.com/page",
+        )
+        assert error.url == "https://example.com/page"
+        assert "test_source" in str(error)
+        assert "url=https://example.com/page" in str(error)
+
+    def test_external_source_error_without_url(self) -> None:
+        """Test ExternalSourceError without URL."""
+        error = ExternalSourceError("Test error", source="test_source")
+        assert error.url is None
+        assert "test_source" in str(error)
+        assert "url=" not in str(error)
+
+    def test_validation_error_attributes(self) -> None:
+        """Test ValidationError includes status and content_type."""
+        error = ValidationError(
+            "Validation failed",
+            response_status=404,
+            content_type="text/html",
+            source="test_source",
+        )
+        assert error.response_status == 404
+        assert error.content_type == "text/html"
+        assert error.source == "test_source"
+
+    def test_validation_error_inherits_from_external_source_error(self) -> None:
+        """Test ValidationError is an ExternalSourceError."""
+        error = ValidationError("Test")
+        assert isinstance(error, ExternalSourceError)
+
+    def test_content_parsing_error(self) -> None:
+        """Test ContentParsingError for parse failures."""
+        cause = ValueError("Invalid JSON")
+        error = ContentParsingError(
+            "Failed to parse response",
+            source="test_source",
+            url="https://example.com/api",
+            cause=cause,
+        )
+        assert error.source == "test_source"
+        assert error.url == "https://example.com/api"
+        assert error.cause == cause
+
+    def test_content_parsing_error_inherits_from_external_source_error(self) -> None:
+        """Test ContentParsingError is an ExternalSourceError."""
+        error = ContentParsingError("Test")
+        assert isinstance(error, ExternalSourceError)
+
+
+# =============================================================================
+# URL Building Tests
+# =============================================================================
+
+
+class TestURLBuilding:
+    """Tests for URL building."""
+
+    def test_build_url_simple_path(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test URL building with simple path."""
+        url = downloader._build_url("/stats/page")
+        assert url == "https://example.com/stats/page"
+
+    def test_build_url_handles_trailing_slash(self) -> None:
+        """Test URL building handles trailing slash in base_url."""
+        config = ExternalDownloaderConfig(base_url="https://example.com/")
+        downloader = ConcreteExternalDownloader(config)
+        url = downloader._build_url("/stats/page")
+        assert url == "https://example.com/stats/page"
+
+    def test_build_url_handles_no_leading_slash(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test URL building handles path without leading slash."""
+        url = downloader._build_url("stats/page")
+        assert url == "https://example.com/stats/page"
+
+
+# =============================================================================
+# Utility Tests
+# =============================================================================
+
+
+class TestUtilities:
+    """Tests for utility methods."""
+
+    def test_last_raw_content_initially_none(
+        self, downloader: ConcreteExternalDownloader
+    ) -> None:
+        """Test last_raw_content is None initially."""
+        assert downloader.last_raw_content is None
+
+    @pytest.mark.asyncio
+    async def test_last_raw_content_after_fetch(
+        self,
+        downloader: ConcreteExternalDownloader,
+        mock_http_client: MagicMock,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test last_raw_content is set after fetch."""
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(downloader, "_http_client", mock_http_client):
+            with patch.object(downloader._rate_limiter, "wait", AsyncMock()):
+                await downloader.fetch_resource("/test")
+
+        assert downloader.last_raw_content == mock_response.content
+
+
+# =============================================================================
+# Integration-Like Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestFetchPage:
+    """Tests for fetch_page method."""
+
+    async def test_fetch_page_returns_response_and_content(
+        self,
+        downloader: ConcreteExternalDownloader,
+        mock_http_client: MagicMock,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test fetch_page returns both response and content."""
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(downloader, "_http_client", mock_http_client):
+            with patch.object(downloader._rate_limiter, "wait", AsyncMock()):
+                response, content = await downloader.fetch_page("/test")
+
+        assert response == mock_response
+        assert content == mock_response.content
+
+    async def test_fetch_page_without_validation(
+        self,
+        downloader: ConcreteExternalDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test fetch_page can skip validation."""
+        failed_response = MagicMock(spec=HTTPResponse)
+        failed_response.is_success = False
+        failed_response.is_rate_limited = False
+        failed_response.is_server_error = False
+        failed_response.status = 404
+        failed_response.content = b"Not Found"
+
+        mock_http_client.get = AsyncMock(return_value=failed_response)
+
+        with patch.object(downloader, "_http_client", mock_http_client):
+            with patch.object(downloader._rate_limiter, "wait", AsyncMock()):
+                # Should not raise because validate=False
+                response, content = await downloader.fetch_page(
+                    "/not/found", validate=False
+                )
+
+        assert response.status == 404


### PR DESCRIPTION
## Summary

- Add `BaseExternalDownloader` extending `BaseDownloader` for third-party sources
- Add `ExternalDownloaderConfig` with conservative defaults (0.5 req/s)
- Add exception classes: `ExternalSourceError`, `ValidationError`, `ContentParsingError`
- Add `fetch_resource()` and `fetch_page()` methods for flexible downloads
- Custom User-Agent: `NHL-API-Collector/1.0 (Data Research)`

## Key Features

- Conservative rate limiting (0.5 req/s vs 5.0 for NHL API)
- Configurable User-Agent and custom headers
- Response validation hooks
- Raw response preservation for reprocessing
- Flexible pattern not tied to NHL game IDs

## Test Plan

- [x] 40 unit tests covering config, init, headers, validation, fetch, errors
- [x] 92% code coverage on new module
- [x] mypy strict mode passes
- [x] ruff lint and format pass
- [x] Pre-commit hooks pass

## Unblocks

- Wave 5a: QuantHockey downloaders (#96-101)
- Wave 5b: DailyFaceoff downloaders (#102-108)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)