### PR TITLE
feat(downloaders): Add DailyFaceoff Power Play Units Downloader (#104)

### DIFF
--- a/src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py
@@ -6,16 +6,22 @@ information from DailyFaceoff.com.
 Available downloaders:
 - BaseDailyFaceoffDownloader: Base class for all DailyFaceoff downloaders
 - PenaltyKillDownloader: Penalty kill unit configurations (PK1, PK2)
+- PowerPlayDownloader: Download power play unit configurations (PP1, PP2)
 
 Example usage:
     from nhl_api.downloaders.sources.dailyfaceoff import (
         PenaltyKillDownloader,
+        PowerPlayDownloader,
         DailyFaceoffConfig,
     )
 
     config = DailyFaceoffConfig()
     async with PenaltyKillDownloader(config) as downloader:
         result = await downloader.download_team(10)  # Toronto
+
+    async with PowerPlayDownloader() as downloader:
+        result = await downloader.download_team(6)  # Boston Bruins
+        print(result.data["pp1"])
 """
 
 from nhl_api.downloaders.sources.dailyfaceoff.base_dailyfaceoff_downloader import (
@@ -28,6 +34,12 @@ from nhl_api.downloaders.sources.dailyfaceoff.penalty_kill import (
     PenaltyKillUnit,
     PKPlayer,
     TeamPenaltyKill,
+)
+from nhl_api.downloaders.sources.dailyfaceoff.power_play import (
+    PowerPlayDownloader,
+    PowerPlayPlayer,
+    PowerPlayUnit,
+    TeamPowerPlay,
 )
 from nhl_api.downloaders.sources.dailyfaceoff.team_mapping import (
     TEAM_ABBREVIATIONS,
@@ -46,6 +58,11 @@ __all__ = [
     "PenaltyKillUnit",
     "PKPlayer",
     "TeamPenaltyKill",
+    # Power Play
+    "PowerPlayDownloader",
+    "PowerPlayPlayer",
+    "PowerPlayUnit",
+    "TeamPowerPlay",
     # Team Mapping
     "TEAM_SLUGS",
     "TEAM_ABBREVIATIONS",

--- a/src/nhl_api/downloaders/sources/dailyfaceoff/power_play.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/power_play.py
@@ -1,0 +1,360 @@
+"""DailyFaceoff Power Play Units Downloader.
+
+This module provides a downloader for extracting power play unit configurations
+from DailyFaceoff.com for all NHL teams.
+
+Example usage:
+    config = DailyFaceoffConfig()
+    async with PowerPlayDownloader(config) as downloader:
+        result = await downloader.download_team(6)  # Boston Bruins
+        print(result.data["pp1"])  # First power play unit
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+
+from nhl_api.downloaders.sources.dailyfaceoff.base_dailyfaceoff_downloader import (
+    BaseDailyFaceoffDownloader,
+)
+
+if TYPE_CHECKING:
+    from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PowerPlayPlayer:
+    """A player in a power play unit.
+
+    Attributes:
+        player_id: DailyFaceoff player ID
+        name: Player's full name
+        jersey_number: Player's jersey number
+        position: Position identifier (sk1-sk5)
+        rating: DailyFaceoff rating (0-100)
+        season_goals: Goals this season
+        season_assists: Assists this season
+        season_points: Points this season
+    """
+
+    player_id: int
+    name: str
+    jersey_number: int
+    position: str
+    rating: float | None = None
+    season_goals: int | None = None
+    season_assists: int | None = None
+    season_points: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PowerPlayUnit:
+    """A power play unit configuration.
+
+    Attributes:
+        unit_number: Unit number (1 or 2)
+        players: List of 5 players in the unit
+    """
+
+    unit_number: int
+    players: tuple[PowerPlayPlayer, ...]
+
+    def __post_init__(self) -> None:
+        """Validate that unit has correct number of players."""
+        if len(self.players) > 5:
+            raise ValueError(
+                f"Power play unit cannot have more than 5 players, got {len(self.players)}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class TeamPowerPlay:
+    """Power play configuration for a team.
+
+    Attributes:
+        team_id: NHL team ID
+        team_abbreviation: Team abbreviation (e.g., "BOS")
+        pp1: First power play unit
+        pp2: Second power play unit
+        fetched_at: Timestamp when data was fetched
+    """
+
+    team_id: int
+    team_abbreviation: str
+    pp1: PowerPlayUnit | None
+    pp2: PowerPlayUnit | None
+    fetched_at: datetime
+
+
+class PowerPlayDownloader(BaseDailyFaceoffDownloader):
+    """Downloader for DailyFaceoff power play unit data.
+
+    This downloader extracts PP1 and PP2 configurations from DailyFaceoff's
+    line combinations page. The data is embedded as JSON in the page's
+    __NEXT_DATA__ script tag.
+
+    Example:
+        config = DailyFaceoffConfig()
+        async with PowerPlayDownloader(config) as downloader:
+            # Download single team
+            result = await downloader.download_team(6)  # Boston
+            pp_data = result.data
+            print(pp_data["pp1"]["players"])
+
+            # Download all teams
+            async for result in downloader.download_all_teams():
+                print(result.data["team_abbreviation"])
+    """
+
+    @property
+    def data_type(self) -> str:
+        """Return data type identifier."""
+        return "power_play"
+
+    @property
+    def page_path(self) -> str:
+        """Return URL path for line combinations page."""
+        return "line-combinations"
+
+    async def _parse_page(self, soup: BeautifulSoup, team_id: int) -> dict[str, Any]:
+        """Parse power play data from DailyFaceoff page.
+
+        DailyFaceoff embeds lineup data as JSON in a __NEXT_DATA__ script tag.
+        This method extracts that JSON and parses the PP1 and PP2 units.
+
+        Args:
+            soup: Parsed BeautifulSoup document
+            team_id: NHL team ID
+
+        Returns:
+            Dictionary containing parsed power play data
+
+        Raises:
+            DownloadError: If parsing fails
+        """
+        abbreviation = self._get_team_abbreviation(team_id)
+
+        # Extract __NEXT_DATA__ script content
+        next_data = self._extract_next_data(soup)
+        if next_data is None:
+            logger.warning(
+                "%s: No __NEXT_DATA__ found for team %s",
+                self.source_name,
+                abbreviation,
+            )
+            return self._empty_result(team_id, abbreviation)
+
+        # Navigate to players array
+        players_data = self._get_players_from_next_data(next_data)
+        if not players_data:
+            logger.warning(
+                "%s: No players data found for team %s",
+                self.source_name,
+                abbreviation,
+            )
+            return self._empty_result(team_id, abbreviation)
+
+        # Parse PP1 and PP2 units
+        pp1 = self._parse_unit(players_data, "pp1", 1)
+        pp2 = self._parse_unit(players_data, "pp2", 2)
+
+        team_pp = TeamPowerPlay(
+            team_id=team_id,
+            team_abbreviation=abbreviation,
+            pp1=pp1,
+            pp2=pp2,
+            fetched_at=datetime.now(UTC),
+        )
+
+        return self._to_dict(team_pp)
+
+    def _extract_next_data(self, soup: BeautifulSoup) -> dict[str, Any] | None:
+        """Extract JSON from __NEXT_DATA__ script tag.
+
+        Args:
+            soup: Parsed BeautifulSoup document
+
+        Returns:
+            Parsed JSON data or None if not found
+        """
+        script_tag = soup.find("script", {"id": "__NEXT_DATA__"})
+        if not script_tag or not script_tag.string:
+            return None
+
+        try:
+            return cast(dict[str, Any], json.loads(script_tag.string))
+        except json.JSONDecodeError as e:
+            logger.warning("Failed to parse __NEXT_DATA__ JSON: %s", e)
+            return None
+
+    def _get_players_from_next_data(
+        self, next_data: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Navigate to players array in NEXT_DATA structure.
+
+        The path is: props.pageProps.combinations.players
+
+        Args:
+            next_data: Parsed __NEXT_DATA__ JSON
+
+        Returns:
+            List of player dictionaries or empty list
+        """
+        try:
+            players = (
+                next_data.get("props", {})
+                .get("pageProps", {})
+                .get("combinations", {})
+                .get("players", [])
+            )
+            return cast(list[dict[str, Any]], players)
+        except (AttributeError, TypeError):
+            return []
+
+    def _parse_unit(
+        self,
+        players_data: list[dict[str, Any]],
+        group_id: str,
+        unit_number: int,
+    ) -> PowerPlayUnit | None:
+        """Parse a power play unit from players data.
+
+        Args:
+            players_data: List of all player dictionaries
+            group_id: Group identifier ("pp1" or "pp2")
+            unit_number: Unit number (1 or 2)
+
+        Returns:
+            PowerPlayUnit or None if no players found
+        """
+        unit_players = [p for p in players_data if p.get("groupIdentifier") == group_id]
+
+        if not unit_players:
+            return None
+
+        # Sort by position (sk1, sk2, sk3, sk4, sk5)
+        unit_players.sort(key=lambda p: p.get("positionIdentifier", "sk9"))
+
+        parsed_players = []
+        for player_data in unit_players:
+            player = self._parse_player(player_data)
+            if player:
+                parsed_players.append(player)
+
+        if not parsed_players:
+            return None
+
+        return PowerPlayUnit(
+            unit_number=unit_number,
+            players=tuple(parsed_players),
+        )
+
+    def _parse_player(self, player_data: dict[str, Any]) -> PowerPlayPlayer | None:
+        """Parse a single player from player data.
+
+        Args:
+            player_data: Player dictionary from JSON
+
+        Returns:
+            PowerPlayPlayer or None if required fields missing
+        """
+        player_id = player_data.get("playerId")
+        name = player_data.get("name")
+        jersey_number = player_data.get("jerseyNumber")
+        position = player_data.get("positionIdentifier")
+
+        # Require minimum fields - use isinstance checks for type safety
+        if (
+            not isinstance(player_id, int)
+            or not isinstance(name, str)
+            or not isinstance(position, str)
+        ):
+            return None
+
+        # Extract optional season stats
+        season = player_data.get("season", {}) or {}
+
+        return PowerPlayPlayer(
+            player_id=player_id,
+            name=name,
+            jersey_number=jersey_number if isinstance(jersey_number, int) else 0,
+            position=position,
+            rating=player_data.get("rating"),
+            season_goals=season.get("goals"),
+            season_assists=season.get("assists"),
+            season_points=season.get("points"),
+        )
+
+    def _empty_result(self, team_id: int, abbreviation: str) -> dict[str, Any]:
+        """Create empty result when parsing fails.
+
+        Args:
+            team_id: NHL team ID
+            abbreviation: Team abbreviation
+
+        Returns:
+            Dictionary with empty power play data
+        """
+        team_pp = TeamPowerPlay(
+            team_id=team_id,
+            team_abbreviation=abbreviation,
+            pp1=None,
+            pp2=None,
+            fetched_at=datetime.now(UTC),
+        )
+        return self._to_dict(team_pp)
+
+    def _to_dict(self, team_pp: TeamPowerPlay) -> dict[str, Any]:
+        """Convert TeamPowerPlay to dictionary.
+
+        Args:
+            team_pp: TeamPowerPlay dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "pp1": self._unit_to_dict(team_pp.pp1) if team_pp.pp1 else None,
+            "pp2": self._unit_to_dict(team_pp.pp2) if team_pp.pp2 else None,
+            "fetched_at": team_pp.fetched_at.isoformat(),
+        }
+
+    def _unit_to_dict(self, unit: PowerPlayUnit) -> dict[str, Any]:
+        """Convert PowerPlayUnit to dictionary.
+
+        Args:
+            unit: PowerPlayUnit dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "unit_number": unit.unit_number,
+            "players": [self._player_to_dict(p) for p in unit.players],
+        }
+
+    def _player_to_dict(self, player: PowerPlayPlayer) -> dict[str, Any]:
+        """Convert PowerPlayPlayer to dictionary.
+
+        Args:
+            player: PowerPlayPlayer dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "player_id": player.player_id,
+            "name": player.name,
+            "jersey_number": player.jersey_number,
+            "position": player.position,
+            "rating": player.rating,
+            "season_goals": player.season_goals,
+            "season_assists": player.season_assists,
+            "season_points": player.season_points,
+        }

--- a/tests/fixtures/dailyfaceoff/line_combinations_boston.html
+++ b/tests/fixtures/dailyfaceoff/line_combinations_boston.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Boston Bruins Line Combinations - DailyFaceoff</title>
+</head>
+<body>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "team": {
+        "id": 6,
+        "name": "Boston Bruins",
+        "abbreviation": "BOS"
+      },
+      "combinations": {
+        "players": [
+          {
+            "playerId": 28001,
+            "name": "Morgan Geekie",
+            "jerseyNumber": 39,
+            "positionName": "Skater 1",
+            "positionIdentifier": "sk1",
+            "groupIdentifier": "pp1",
+            "groupName": "1st Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 74.5,
+            "season": {
+              "goals": 25,
+              "assists": 14,
+              "points": 39
+            }
+          },
+          {
+            "playerId": 28002,
+            "name": "David Pastrnak",
+            "jerseyNumber": 88,
+            "positionName": "Skater 2",
+            "positionIdentifier": "sk2",
+            "groupIdentifier": "pp1",
+            "groupName": "1st Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 92.3,
+            "season": {
+              "goals": 47,
+              "assists": 63,
+              "points": 110
+            }
+          },
+          {
+            "playerId": 28003,
+            "name": "Brad Marchand",
+            "jerseyNumber": 63,
+            "positionName": "Skater 3",
+            "positionIdentifier": "sk3",
+            "groupIdentifier": "pp1",
+            "groupName": "1st Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 88.1,
+            "season": {
+              "goals": 29,
+              "assists": 38,
+              "points": 67
+            }
+          },
+          {
+            "playerId": 28004,
+            "name": "Charlie McAvoy",
+            "jerseyNumber": 73,
+            "positionName": "Skater 4",
+            "positionIdentifier": "sk4",
+            "groupIdentifier": "pp1",
+            "groupName": "1st Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 85.2,
+            "season": {
+              "goals": 8,
+              "assists": 42,
+              "points": 50
+            }
+          },
+          {
+            "playerId": 28005,
+            "name": "Hampus Lindholm",
+            "jerseyNumber": 27,
+            "positionName": "Skater 5",
+            "positionIdentifier": "sk5",
+            "groupIdentifier": "pp1",
+            "groupName": "1st Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 79.8,
+            "season": {
+              "goals": 6,
+              "assists": 32,
+              "points": 38
+            }
+          },
+          {
+            "playerId": 28011,
+            "name": "Pavel Zacha",
+            "jerseyNumber": 18,
+            "positionName": "Skater 1",
+            "positionIdentifier": "sk1",
+            "groupIdentifier": "pp2",
+            "groupName": "2nd Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 71.2,
+            "season": {
+              "goals": 21,
+              "assists": 35,
+              "points": 56
+            }
+          },
+          {
+            "playerId": 28012,
+            "name": "Jake DeBrusk",
+            "jerseyNumber": 74,
+            "positionName": "Skater 2",
+            "positionIdentifier": "sk2",
+            "groupIdentifier": "pp2",
+            "groupName": "2nd Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 68.9,
+            "season": {
+              "goals": 19,
+              "assists": 23,
+              "points": 42
+            }
+          },
+          {
+            "playerId": 28013,
+            "name": "Trent Frederic",
+            "jerseyNumber": 11,
+            "positionName": "Skater 3",
+            "positionIdentifier": "sk3",
+            "groupIdentifier": "pp2",
+            "groupName": "2nd Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 62.4,
+            "season": {
+              "goals": 14,
+              "assists": 18,
+              "points": 32
+            }
+          },
+          {
+            "playerId": 28014,
+            "name": "Brandon Carlo",
+            "jerseyNumber": 25,
+            "positionName": "Skater 4",
+            "positionIdentifier": "sk4",
+            "groupIdentifier": "pp2",
+            "groupName": "2nd Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 58.7,
+            "season": {
+              "goals": 2,
+              "assists": 12,
+              "points": 14
+            }
+          },
+          {
+            "playerId": 28015,
+            "name": "Matt Grzelcyk",
+            "jerseyNumber": 48,
+            "positionName": "Skater 5",
+            "positionIdentifier": "sk5",
+            "groupIdentifier": "pp2",
+            "groupName": "2nd Powerplay Unit",
+            "categoryIdentifier": "pp",
+            "rating": 55.3,
+            "season": {
+              "goals": 1,
+              "assists": 15,
+              "points": 16
+            }
+          },
+          {
+            "playerId": 29001,
+            "name": "Elias Lindholm",
+            "jerseyNumber": 28,
+            "positionName": "Center",
+            "positionIdentifier": "c",
+            "groupIdentifier": "l1",
+            "groupName": "1st Line",
+            "categoryIdentifier": "lines",
+            "rating": 76.4,
+            "season": {
+              "goals": 15,
+              "assists": 24,
+              "points": 39
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+</script>
+</body>
+</html>

--- a/tests/unit/downloaders/sources/dailyfaceoff/test_power_play.py
+++ b/tests/unit/downloaders/sources/dailyfaceoff/test_power_play.py
@@ -1,0 +1,681 @@
+"""Unit tests for PowerPlayDownloader."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bs4 import BeautifulSoup
+
+from nhl_api.downloaders.base.protocol import DownloadStatus
+from nhl_api.downloaders.sources.dailyfaceoff import (
+    PowerPlayDownloader,
+    PowerPlayPlayer,
+    PowerPlayUnit,
+    TeamPowerPlay,
+)
+
+# Path to fixtures
+FIXTURES_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent / "fixtures" / "dailyfaceoff"
+)
+
+
+class TestPowerPlayPlayer:
+    """Tests for PowerPlayPlayer dataclass."""
+
+    def test_create_player(self) -> None:
+        """Test creating a player with all fields."""
+        player = PowerPlayPlayer(
+            player_id=28001,
+            name="Morgan Geekie",
+            jersey_number=39,
+            position="sk1",
+            rating=74.5,
+            season_goals=25,
+            season_assists=14,
+            season_points=39,
+        )
+        assert player.player_id == 28001
+        assert player.name == "Morgan Geekie"
+        assert player.jersey_number == 39
+        assert player.position == "sk1"
+        assert player.rating == 74.5
+        assert player.season_goals == 25
+        assert player.season_assists == 14
+        assert player.season_points == 39
+
+    def test_create_player_minimal(self) -> None:
+        """Test creating a player with minimal fields."""
+        player = PowerPlayPlayer(
+            player_id=12345,
+            name="Test Player",
+            jersey_number=1,
+            position="sk1",
+        )
+        assert player.player_id == 12345
+        assert player.name == "Test Player"
+        assert player.rating is None
+        assert player.season_goals is None
+        assert player.season_assists is None
+        assert player.season_points is None
+
+    def test_player_is_frozen(self) -> None:
+        """Test that player is immutable."""
+        player = PowerPlayPlayer(
+            player_id=1,
+            name="Test",
+            jersey_number=1,
+            position="sk1",
+        )
+        with pytest.raises(AttributeError):
+            player.name = "Changed"  # type: ignore[misc]
+
+
+class TestPowerPlayUnit:
+    """Tests for PowerPlayUnit dataclass."""
+
+    def test_create_unit(self) -> None:
+        """Test creating a power play unit."""
+        players = tuple(
+            PowerPlayPlayer(
+                player_id=i,
+                name=f"Player {i}",
+                jersey_number=i,
+                position=f"sk{i}",
+            )
+            for i in range(1, 6)
+        )
+        unit = PowerPlayUnit(unit_number=1, players=players)
+        assert unit.unit_number == 1
+        assert len(unit.players) == 5
+
+    def test_unit_too_many_players(self) -> None:
+        """Test that unit rejects more than 5 players."""
+        players = tuple(
+            PowerPlayPlayer(
+                player_id=i,
+                name=f"Player {i}",
+                jersey_number=i,
+                position=f"sk{i}",
+            )
+            for i in range(1, 8)  # 7 players
+        )
+        with pytest.raises(ValueError, match="cannot have more than 5 players"):
+            PowerPlayUnit(unit_number=1, players=players)
+
+    def test_unit_is_frozen(self) -> None:
+        """Test that unit is immutable."""
+        unit = PowerPlayUnit(unit_number=1, players=())
+        with pytest.raises(AttributeError):
+            unit.unit_number = 2  # type: ignore[misc]
+
+
+class TestTeamPowerPlay:
+    """Tests for TeamPowerPlay dataclass."""
+
+    def test_create_team_pp(self) -> None:
+        """Test creating team power play data."""
+        now = datetime.now(UTC)
+        team_pp = TeamPowerPlay(
+            team_id=6,
+            team_abbreviation="BOS",
+            pp1=None,
+            pp2=None,
+            fetched_at=now,
+        )
+        assert team_pp.team_id == 6
+        assert team_pp.team_abbreviation == "BOS"
+        assert team_pp.pp1 is None
+        assert team_pp.pp2 is None
+        assert team_pp.fetched_at == now
+
+    def test_team_pp_with_units(self) -> None:
+        """Test team PP with actual units."""
+        players = tuple(
+            PowerPlayPlayer(
+                player_id=i,
+                name=f"Player {i}",
+                jersey_number=i,
+                position=f"sk{i}",
+            )
+            for i in range(1, 6)
+        )
+        pp1 = PowerPlayUnit(unit_number=1, players=players)
+        pp2 = PowerPlayUnit(unit_number=2, players=players)
+        now = datetime.now(UTC)
+
+        team_pp = TeamPowerPlay(
+            team_id=6,
+            team_abbreviation="BOS",
+            pp1=pp1,
+            pp2=pp2,
+            fetched_at=now,
+        )
+        assert team_pp.pp1 is not None
+        assert team_pp.pp2 is not None
+        assert len(team_pp.pp1.players) == 5
+        assert len(team_pp.pp2.players) == 5
+
+
+class TestPowerPlayDownloader:
+    """Tests for PowerPlayDownloader."""
+
+    def test_data_type(self) -> None:
+        """Test data_type property."""
+        downloader = PowerPlayDownloader()
+        assert downloader.data_type == "power_play"
+
+    def test_page_path(self) -> None:
+        """Test page_path property."""
+        downloader = PowerPlayDownloader()
+        assert downloader.page_path == "line-combinations"
+
+    def test_source_name(self) -> None:
+        """Test source_name property."""
+        downloader = PowerPlayDownloader()
+        assert downloader.source_name == "dailyfaceoff_power_play"
+
+    def test_extract_next_data_valid(self) -> None:
+        """Test extracting __NEXT_DATA__ from valid HTML."""
+        html = """
+        <!DOCTYPE html>
+        <html>
+        <head></head>
+        <body>
+        <script id="__NEXT_DATA__" type="application/json">
+        {"props": {"pageProps": {"test": "data"}}}
+        </script>
+        </body>
+        </html>
+        """
+        soup = BeautifulSoup(html, "lxml")
+        downloader = PowerPlayDownloader()
+        result = downloader._extract_next_data(soup)
+        assert result is not None
+        assert result["props"]["pageProps"]["test"] == "data"
+
+    def test_extract_next_data_missing(self) -> None:
+        """Test extracting __NEXT_DATA__ from HTML without it."""
+        html = "<html><body>No data here</body></html>"
+        soup = BeautifulSoup(html, "lxml")
+        downloader = PowerPlayDownloader()
+        result = downloader._extract_next_data(soup)
+        assert result is None
+
+    def test_extract_next_data_invalid_json(self) -> None:
+        """Test extracting __NEXT_DATA__ with invalid JSON."""
+        html = """
+        <html>
+        <body>
+        <script id="__NEXT_DATA__" type="application/json">
+        {invalid json}
+        </script>
+        </body>
+        </html>
+        """
+        soup = BeautifulSoup(html, "lxml")
+        downloader = PowerPlayDownloader()
+        result = downloader._extract_next_data(soup)
+        assert result is None
+
+    def test_get_players_from_next_data(self) -> None:
+        """Test navigating to players array."""
+        next_data = {
+            "props": {"pageProps": {"combinations": {"players": [{"name": "Test"}]}}}
+        }
+        downloader = PowerPlayDownloader()
+        result = downloader._get_players_from_next_data(next_data)
+        assert len(result) == 1
+        assert result[0]["name"] == "Test"
+
+    def test_get_players_from_next_data_missing_path(self) -> None:
+        """Test navigating when path doesn't exist."""
+        next_data: dict[str, Any] = {"props": {}}
+        downloader = PowerPlayDownloader()
+        result = downloader._get_players_from_next_data(next_data)
+        assert result == []
+
+    def test_get_players_from_next_data_none(self) -> None:
+        """Test navigating with None values in path."""
+        next_data: dict[str, Any] = {"props": None}
+        downloader = PowerPlayDownloader()
+        result = downloader._get_players_from_next_data(next_data)
+        assert result == []
+
+    def test_parse_player_valid(self) -> None:
+        """Test parsing a valid player."""
+        player_data = {
+            "playerId": 28001,
+            "name": "Morgan Geekie",
+            "jerseyNumber": 39,
+            "positionIdentifier": "sk1",
+            "rating": 74.5,
+            "season": {
+                "goals": 25,
+                "assists": 14,
+                "points": 39,
+            },
+        }
+        downloader = PowerPlayDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is not None
+        assert player.player_id == 28001
+        assert player.name == "Morgan Geekie"
+        assert player.jersey_number == 39
+        assert player.position == "sk1"
+        assert player.rating == 74.5
+        assert player.season_goals == 25
+        assert player.season_assists == 14
+        assert player.season_points == 39
+
+    def test_parse_player_missing_name(self) -> None:
+        """Test parsing player without required name field."""
+        player_data = {
+            "playerId": 28001,
+            "jerseyNumber": 39,
+            "positionIdentifier": "sk1",
+        }
+        downloader = PowerPlayDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is None
+
+    def test_parse_player_missing_player_id(self) -> None:
+        """Test parsing player without required playerId field."""
+        player_data = {
+            "name": "Test Player",
+            "jerseyNumber": 39,
+            "positionIdentifier": "sk1",
+        }
+        downloader = PowerPlayDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is None
+
+    def test_parse_player_missing_position(self) -> None:
+        """Test parsing player without required position field."""
+        player_data = {
+            "playerId": 28001,
+            "name": "Test Player",
+            "jerseyNumber": 39,
+        }
+        downloader = PowerPlayDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is None
+
+    def test_parse_player_no_jersey_number(self) -> None:
+        """Test parsing player without jersey number (uses 0)."""
+        player_data = {
+            "playerId": 28001,
+            "name": "Test Player",
+            "positionIdentifier": "sk1",
+        }
+        downloader = PowerPlayDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is not None
+        assert player.jersey_number == 0
+
+    def test_parse_player_no_season_stats(self) -> None:
+        """Test parsing player without season stats."""
+        player_data = {
+            "playerId": 28001,
+            "name": "Test Player",
+            "jerseyNumber": 99,
+            "positionIdentifier": "sk1",
+        }
+        downloader = PowerPlayDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is not None
+        assert player.season_goals is None
+        assert player.season_assists is None
+        assert player.season_points is None
+
+    def test_parse_player_null_season(self) -> None:
+        """Test parsing player with null season object."""
+        player_data = {
+            "playerId": 28001,
+            "name": "Test Player",
+            "jerseyNumber": 99,
+            "positionIdentifier": "sk1",
+            "season": None,
+        }
+        downloader = PowerPlayDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is not None
+        assert player.season_goals is None
+
+    def test_parse_unit_valid(self) -> None:
+        """Test parsing a valid power play unit."""
+        players_data = [
+            {
+                "playerId": i,
+                "name": f"Player {i}",
+                "jerseyNumber": i,
+                "positionIdentifier": f"sk{i}",
+                "groupIdentifier": "pp1",
+            }
+            for i in range(1, 6)
+        ]
+        downloader = PowerPlayDownloader()
+        unit = downloader._parse_unit(players_data, "pp1", 1)
+        assert unit is not None
+        assert unit.unit_number == 1
+        assert len(unit.players) == 5
+
+    def test_parse_unit_empty(self) -> None:
+        """Test parsing when no players match the group."""
+        players_data = [
+            {
+                "playerId": 1,
+                "name": "Player 1",
+                "jerseyNumber": 1,
+                "positionIdentifier": "sk1",
+                "groupIdentifier": "pp2",  # Different group
+            }
+        ]
+        downloader = PowerPlayDownloader()
+        unit = downloader._parse_unit(players_data, "pp1", 1)
+        assert unit is None
+
+    def test_parse_unit_sorted_by_position(self) -> None:
+        """Test that players are sorted by position."""
+        # Add players in reverse order
+        players_data = [
+            {
+                "playerId": 5,
+                "name": "Player 5",
+                "jerseyNumber": 5,
+                "positionIdentifier": "sk5",
+                "groupIdentifier": "pp1",
+            },
+            {
+                "playerId": 1,
+                "name": "Player 1",
+                "jerseyNumber": 1,
+                "positionIdentifier": "sk1",
+                "groupIdentifier": "pp1",
+            },
+            {
+                "playerId": 3,
+                "name": "Player 3",
+                "jerseyNumber": 3,
+                "positionIdentifier": "sk3",
+                "groupIdentifier": "pp1",
+            },
+        ]
+        downloader = PowerPlayDownloader()
+        unit = downloader._parse_unit(players_data, "pp1", 1)
+        assert unit is not None
+        assert unit.players[0].position == "sk1"
+        assert unit.players[1].position == "sk3"
+        assert unit.players[2].position == "sk5"
+
+    def test_to_dict_full(self) -> None:
+        """Test converting TeamPowerPlay to dict."""
+        players = tuple(
+            PowerPlayPlayer(
+                player_id=i,
+                name=f"Player {i}",
+                jersey_number=i,
+                position=f"sk{i}",
+                rating=50.0 + i,
+                season_goals=10 + i,
+                season_assists=20 + i,
+                season_points=30 + i,
+            )
+            for i in range(1, 6)
+        )
+        pp1 = PowerPlayUnit(unit_number=1, players=players)
+        now = datetime.now(UTC)
+        team_pp = TeamPowerPlay(
+            team_id=6,
+            team_abbreviation="BOS",
+            pp1=pp1,
+            pp2=None,
+            fetched_at=now,
+        )
+        downloader = PowerPlayDownloader()
+        result = downloader._to_dict(team_pp)
+
+        assert "pp1" in result
+        assert "pp2" in result
+        assert "fetched_at" in result
+        assert result["pp1"]["unit_number"] == 1
+        assert len(result["pp1"]["players"]) == 5
+        assert result["pp2"] is None
+        assert result["fetched_at"] == now.isoformat()
+
+    def test_to_dict_empty(self) -> None:
+        """Test converting TeamPowerPlay with no units to dict."""
+        now = datetime.now(UTC)
+        team_pp = TeamPowerPlay(
+            team_id=6,
+            team_abbreviation="BOS",
+            pp1=None,
+            pp2=None,
+            fetched_at=now,
+        )
+        downloader = PowerPlayDownloader()
+        result = downloader._to_dict(team_pp)
+
+        assert result["pp1"] is None
+        assert result["pp2"] is None
+
+    def test_player_to_dict(self) -> None:
+        """Test converting player to dict."""
+        player = PowerPlayPlayer(
+            player_id=28001,
+            name="Test Player",
+            jersey_number=39,
+            position="sk1",
+            rating=74.5,
+            season_goals=25,
+            season_assists=14,
+            season_points=39,
+        )
+        downloader = PowerPlayDownloader()
+        result = downloader._player_to_dict(player)
+
+        assert result["player_id"] == 28001
+        assert result["name"] == "Test Player"
+        assert result["jersey_number"] == 39
+        assert result["position"] == "sk1"
+        assert result["rating"] == 74.5
+        assert result["season_goals"] == 25
+        assert result["season_assists"] == 14
+        assert result["season_points"] == 39
+
+    def test_empty_result(self) -> None:
+        """Test creating empty result."""
+        downloader = PowerPlayDownloader()
+        result = downloader._empty_result(6, "BOS")
+
+        assert result["pp1"] is None
+        assert result["pp2"] is None
+        assert "fetched_at" in result
+
+
+class TestPowerPlayDownloaderIntegration:
+    """Integration tests using fixture file."""
+
+    @pytest.fixture
+    def fixture_html(self) -> str:
+        """Load fixture HTML."""
+        fixture_path = FIXTURES_DIR / "line_combinations_boston.html"
+        return fixture_path.read_text()
+
+    @pytest.fixture
+    def fixture_soup(self, fixture_html: str) -> BeautifulSoup:
+        """Parse fixture HTML into BeautifulSoup."""
+        return BeautifulSoup(fixture_html, "lxml")
+
+    @pytest.mark.asyncio
+    async def test_parse_page_full(self, fixture_soup: BeautifulSoup) -> None:
+        """Test parsing full fixture page."""
+        downloader = PowerPlayDownloader()
+        result = await downloader._parse_page(fixture_soup, 6)
+
+        assert result["pp1"] is not None
+        assert result["pp2"] is not None
+
+        # Check PP1
+        pp1 = result["pp1"]
+        assert pp1["unit_number"] == 1
+        assert len(pp1["players"]) == 5
+        assert pp1["players"][0]["name"] == "Morgan Geekie"
+        assert pp1["players"][0]["jersey_number"] == 39
+        assert pp1["players"][0]["rating"] == 74.5
+        assert pp1["players"][0]["season_goals"] == 25
+
+        # Check PP2
+        pp2 = result["pp2"]
+        assert pp2["unit_number"] == 2
+        assert len(pp2["players"]) == 5
+        assert pp2["players"][0]["name"] == "Pavel Zacha"
+
+    @pytest.mark.asyncio
+    async def test_parse_page_filters_non_pp(self, fixture_soup: BeautifulSoup) -> None:
+        """Test that non-PP players are filtered out."""
+        downloader = PowerPlayDownloader()
+        result = await downloader._parse_page(fixture_soup, 6)
+
+        # Elias Lindholm is in l1 (1st line), not PP
+        pp1_names = [p["name"] for p in result["pp1"]["players"]]
+        pp2_names = [p["name"] for p in result["pp2"]["players"]]
+        all_pp_names = pp1_names + pp2_names
+
+        assert "Elias Lindholm" not in all_pp_names
+
+    @pytest.mark.asyncio
+    async def test_parse_page_empty_html(self) -> None:
+        """Test parsing page with no __NEXT_DATA__."""
+        html = "<html><body>Empty</body></html>"
+        soup = BeautifulSoup(html, "lxml")
+        downloader = PowerPlayDownloader()
+        result = await downloader._parse_page(soup, 6)
+
+        assert result["pp1"] is None
+        assert result["pp2"] is None
+
+
+class TestPowerPlayDownloaderDownload:
+    """Tests for download_team method."""
+
+    @pytest.fixture
+    def mock_response(self) -> MagicMock:
+        """Create mock HTTP response."""
+        fixture_path = FIXTURES_DIR / "line_combinations_boston.html"
+        content = fixture_path.read_bytes()
+
+        response = MagicMock()
+        response.is_success = True
+        response.status = 200
+        response.content = content
+        return response
+
+    @pytest.mark.asyncio
+    async def test_download_team_success(self, mock_response: MagicMock) -> None:
+        """Test successful team download."""
+        downloader = PowerPlayDownloader()
+        object.__setattr__(downloader, "_get", AsyncMock(return_value=mock_response))
+
+        result = await downloader.download_team(6)
+
+        assert result.status == DownloadStatus.COMPLETED
+        assert result.source == "dailyfaceoff_power_play"
+        assert result.data["team_id"] == 6
+        assert result.data["team_abbreviation"] == "BOS"
+        assert result.data["pp1"] is not None
+        assert result.data["pp2"] is not None
+
+    @pytest.mark.asyncio
+    async def test_download_team_http_error(self) -> None:
+        """Test handling HTTP error."""
+        response = MagicMock()
+        response.is_success = False
+        response.status = 404
+
+        downloader = PowerPlayDownloader()
+        object.__setattr__(downloader, "_get", AsyncMock(return_value=response))
+
+        from nhl_api.downloaders.base.protocol import DownloadError
+
+        with pytest.raises(DownloadError, match="HTTP 404"):
+            await downloader.download_team(6)
+
+    @pytest.mark.asyncio
+    async def test_download_team_invalid_html(self) -> None:
+        """Test handling invalid HTML response."""
+        response = MagicMock()
+        response.is_success = True
+        response.status = 200
+        response.content = b'{"json": "not html"}'
+
+        downloader = PowerPlayDownloader()
+        object.__setattr__(downloader, "_get", AsyncMock(return_value=response))
+
+        from nhl_api.downloaders.base.protocol import DownloadError
+
+        with pytest.raises(DownloadError, match="not valid HTML"):
+            await downloader.download_team(6)
+
+
+class TestPowerPlayDownloaderBulk:
+    """Tests for download_all_teams method."""
+
+    @pytest.fixture
+    def mock_response(self) -> MagicMock:
+        """Create mock HTTP response."""
+        fixture_path = FIXTURES_DIR / "line_combinations_boston.html"
+        content = fixture_path.read_bytes()
+
+        response = MagicMock()
+        response.is_success = True
+        response.status = 200
+        response.content = content
+        return response
+
+    @pytest.mark.asyncio
+    async def test_download_all_teams(self, mock_response: MagicMock) -> None:
+        """Test downloading all teams."""
+        # Only test with 3 teams for speed
+        downloader = PowerPlayDownloader(team_ids=[6, 10, 1])
+        object.__setattr__(downloader, "_get", AsyncMock(return_value=mock_response))
+
+        results = []
+        async for result in downloader.download_all_teams():
+            results.append(result)
+
+        assert len(results) == 3
+        assert all(r.status == DownloadStatus.COMPLETED for r in results)
+
+    @pytest.mark.asyncio
+    async def test_download_all_teams_with_failure(
+        self, mock_response: MagicMock
+    ) -> None:
+        """Test that failures don't stop iteration."""
+
+        # First call succeeds, second fails, third succeeds
+        async def side_effect(path: str) -> MagicMock:
+            if "new-york-islanders" in path:
+                error_response = MagicMock()
+                error_response.is_success = False
+                error_response.status = 500
+                return error_response
+            return mock_response
+
+        downloader = PowerPlayDownloader(team_ids=[6, 2, 1])  # BOS, NYI, NJD
+        object.__setattr__(downloader, "_get", AsyncMock(side_effect=side_effect))
+
+        results = []
+        async for result in downloader.download_all_teams():
+            results.append(result)
+
+        assert len(results) == 3
+        # BOS and NJD should succeed
+        completed = [r for r in results if r.status == DownloadStatus.COMPLETED]
+        failed = [r for r in results if r.status == DownloadStatus.FAILED]
+        assert len(completed) == 2
+        assert len(failed) == 1


### PR DESCRIPTION
## Summary

Implements Wave 5b.4: DailyFaceoff Power Play Units Downloader

- **PowerPlayDownloader** extending BaseDailyFaceoffDownloader
- Extracts PP1 and PP2 configurations from DailyFaceoff line combinations page
- Parses __NEXT_DATA__ JSON structure for player data
- Dataclasses: `PowerPlayPlayer`, `PowerPlayUnit`, `TeamPowerPlay`

### Features

- Extract power play units from `props.pageProps.combinations.players`
- Filter by `groupIdentifier` (pp1, pp2)
- Sort players by position (sk1-sk5)
- Parse player stats: goals, assists, points, rating
- Handle missing data gracefully

### Files

| File | Lines | Purpose |
|------|-------|---------|
| `power_play.py` | 356 | Downloader implementation |
| `test_power_play.py` | 683 | 39 unit tests |
| `line_combinations_boston.html` | 201 | Fixture data |

## Test plan

- [x] Unit tests for dataclasses (PowerPlayPlayer, PowerPlayUnit, TeamPowerPlay)
- [x] Unit tests for JSON extraction from __NEXT_DATA__
- [x] Unit tests for player parsing with edge cases
- [x] Unit tests for unit parsing and sorting
- [x] Integration tests with fixture HTML
- [x] Tests for download_team success/error handling
- [x] Tests for download_all_teams iteration
- [x] Coverage: 97% for power_play.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)