### PR TITLE
feat(downloaders): Add HTML Downloader Registry & Factory (#83)

### DIFF
--- a/src/nhl_api/downloaders/sources/html/__init__.py
+++ b/src/nhl_api/downloaders/sources/html/__init__.py
@@ -62,6 +62,7 @@ from nhl_api.downloaders.sources.html.play_by_play import (
     PlayByPlayEvent,
     PlayerOnIce,
 )
+from nhl_api.downloaders.sources.html.registry import HTMLDownloaderRegistry
 from nhl_api.downloaders.sources.html.roster import (
     CoachInfo,
     OfficialInfo,
@@ -102,6 +103,7 @@ __all__ = [
     "GoalInfo",
     "HTML_DOWNLOADER_CONFIG",
     "HTMLDownloaderConfig",
+    "HTMLDownloaderRegistry",
     "OfficialInfo",
     "ParsedEventSummary",
     "ParsedFaceoffComparison",

--- a/src/nhl_api/downloaders/sources/html/registry.py
+++ b/src/nhl_api/downloaders/sources/html/registry.py
@@ -1,0 +1,296 @@
+"""HTML Downloader Registry and Factory.
+
+This module provides a registry and factory pattern for managing all HTML
+report downloaders. It supports creating individual downloaders by report type
+or creating all downloaders at once.
+
+Example usage:
+    # Create single downloader
+    gs_downloader = HTMLDownloaderRegistry.create("GS")
+
+    # Create all downloaders
+    all_downloaders = HTMLDownloaderRegistry.create_all()
+
+    # Use with custom config
+    custom_config = HTMLDownloaderConfig(requests_per_second=1.0)
+    downloader = HTMLDownloaderRegistry.create("ES", custom_config)
+
+    # Get source name for database
+    source_name = HTMLDownloaderRegistry.get_source_name("GS")  # "html_gs"
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nhl_api.downloaders.sources.html.base_html_downloader import (
+    HTML_DOWNLOADER_CONFIG,
+    BaseHTMLDownloader,
+    HTMLDownloaderConfig,
+)
+from nhl_api.downloaders.sources.html.event_summary import EventSummaryDownloader
+from nhl_api.downloaders.sources.html.faceoff_comparison import (
+    FaceoffComparisonDownloader,
+)
+from nhl_api.downloaders.sources.html.faceoff_summary import FaceoffSummaryDownloader
+from nhl_api.downloaders.sources.html.game_summary import GameSummaryDownloader
+from nhl_api.downloaders.sources.html.play_by_play import PlayByPlayDownloader
+from nhl_api.downloaders.sources.html.roster import RosterDownloader
+from nhl_api.downloaders.sources.html.shot_summary import ShotSummaryDownloader
+from nhl_api.downloaders.sources.html.time_on_ice import TimeOnIceDownloader
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from nhl_api.downloaders.base.rate_limiter import RateLimiter
+    from nhl_api.downloaders.base.retry_handler import RetryHandler
+    from nhl_api.utils.http_client import HTTPClient
+
+
+class HTMLDownloaderRegistry:
+    """Registry for all HTML report downloaders.
+
+    This class provides factory methods for creating HTML report downloaders.
+    It supports all NHL HTML report types and handles special cases like
+    the TimeOnIce downloader which requires a side parameter.
+
+    Report Types:
+        GS: Game Summary
+        ES: Event Summary
+        PL: Play-by-Play
+        FS: Faceoff Summary
+        FC: Faceoff Comparison
+        RO: Roster Report
+        SS: Shot Summary
+        TH: Home Time on Ice
+        TV: Visitor Time on Ice
+
+    Example:
+        # Create a single downloader
+        downloader = HTMLDownloaderRegistry.create("GS")
+        async with downloader:
+            result = await downloader.download_game(2024020500)
+
+        # Create all downloaders
+        downloaders = HTMLDownloaderRegistry.create_all()
+        for report_type, downloader in downloaders.items():
+            print(f"{report_type}: {downloader.source_name}")
+    """
+
+    # Mapping of report types to downloader classes
+    # TimeOnIce (TH/TV) maps to the same class with different side parameter
+    DOWNLOADERS: dict[str, type[BaseHTMLDownloader]] = {
+        "GS": GameSummaryDownloader,
+        "ES": EventSummaryDownloader,
+        "PL": PlayByPlayDownloader,
+        "FS": FaceoffSummaryDownloader,
+        "FC": FaceoffComparisonDownloader,
+        "RO": RosterDownloader,
+        "SS": ShotSummaryDownloader,
+        "TH": TimeOnIceDownloader,
+        "TV": TimeOnIceDownloader,
+    }
+
+    # All valid report type codes
+    REPORT_TYPES: list[str] = list(DOWNLOADERS.keys())
+
+    # Report types that require special handling
+    TIME_ON_ICE_TYPES: frozenset[str] = frozenset({"TH", "TV"})
+
+    @classmethod
+    def create(
+        cls,
+        report_type: str,
+        config: HTMLDownloaderConfig | None = None,
+        *,
+        http_client: HTTPClient | None = None,
+        rate_limiter: RateLimiter | None = None,
+        retry_handler: RetryHandler | None = None,
+        progress_callback: Callable[..., None] | None = None,
+        game_ids: list[int] | None = None,
+    ) -> BaseHTMLDownloader:
+        """Create a downloader for a specific report type.
+
+        Args:
+            report_type: Report type code (GS, ES, PL, FS, FC, RO, SS, TH, TV)
+            config: Optional downloader configuration. Uses default if not provided.
+            http_client: Optional custom HTTP client
+            rate_limiter: Optional custom rate limiter
+            retry_handler: Optional custom retry handler
+            progress_callback: Optional callback for progress updates
+            game_ids: Optional list of game IDs for season download
+
+        Returns:
+            Configured HTML downloader instance.
+
+        Raises:
+            ValueError: If report_type is not recognized.
+
+        Example:
+            # Create with default config
+            gs = HTMLDownloaderRegistry.create("GS")
+
+            # Create with custom config
+            config = HTMLDownloaderConfig(requests_per_second=1.0)
+            gs = HTMLDownloaderRegistry.create("GS", config)
+
+            # Create Time on Ice for home team
+            toi_home = HTMLDownloaderRegistry.create("TH")
+
+            # Create Time on Ice for away team
+            toi_away = HTMLDownloaderRegistry.create("TV")
+        """
+        report_type = report_type.upper()
+
+        if report_type not in cls.DOWNLOADERS:
+            raise ValueError(
+                f"Unknown report type: {report_type}. Valid types: {cls.REPORT_TYPES}"
+            )
+
+        config = config or cls.default_config()
+        downloader_class = cls.DOWNLOADERS[report_type]
+
+        # TimeOnIce needs special handling for side parameter
+        if report_type in cls.TIME_ON_ICE_TYPES:
+            side = "home" if report_type == "TH" else "away"
+            return TimeOnIceDownloader(
+                config,
+                side=side,
+                http_client=http_client,
+                rate_limiter=rate_limiter,
+                retry_handler=retry_handler,
+                progress_callback=progress_callback,
+                game_ids=game_ids,
+            )
+
+        return downloader_class(
+            config,
+            http_client=http_client,
+            rate_limiter=rate_limiter,
+            retry_handler=retry_handler,
+            progress_callback=progress_callback,
+            game_ids=game_ids,
+        )
+
+    @classmethod
+    def create_all(
+        cls,
+        config: HTMLDownloaderConfig | None = None,
+        *,
+        http_client: HTTPClient | None = None,
+        rate_limiter: RateLimiter | None = None,
+        retry_handler: RetryHandler | None = None,
+        progress_callback: Callable[..., None] | None = None,
+        game_ids: list[int] | None = None,
+    ) -> dict[str, BaseHTMLDownloader]:
+        """Create all HTML downloaders.
+
+        Args:
+            config: Optional downloader configuration. Uses default if not provided.
+            http_client: Optional shared HTTP client
+            rate_limiter: Optional shared rate limiter
+            retry_handler: Optional shared retry handler
+            progress_callback: Optional callback for progress updates
+            game_ids: Optional list of game IDs for season download
+
+        Returns:
+            Dictionary mapping report type to downloader instance.
+
+        Example:
+            downloaders = HTMLDownloaderRegistry.create_all()
+            for report_type, downloader in downloaders.items():
+                print(f"{report_type}: {downloader.source_name}")
+        """
+        return {
+            report_type: cls.create(
+                report_type,
+                config,
+                http_client=http_client,
+                rate_limiter=rate_limiter,
+                retry_handler=retry_handler,
+                progress_callback=progress_callback,
+                game_ids=game_ids,
+            )
+            for report_type in cls.REPORT_TYPES
+        }
+
+    @classmethod
+    def default_config(cls) -> HTMLDownloaderConfig:
+        """Return default configuration for HTML downloaders.
+
+        Returns:
+            Default HTMLDownloaderConfig instance
+        """
+        return HTML_DOWNLOADER_CONFIG
+
+    @classmethod
+    def get_source_name(cls, report_type: str) -> str:
+        """Get the source name for a report type.
+
+        The source name is used for database storage and monitoring.
+
+        Args:
+            report_type: Report type code (GS, ES, PL, etc.)
+
+        Returns:
+            Source name in format 'html_{report_type}' (e.g., 'html_gs')
+
+        Raises:
+            ValueError: If report_type is not recognized.
+
+        Example:
+            name = HTMLDownloaderRegistry.get_source_name("GS")  # "html_gs"
+        """
+        report_type = report_type.upper()
+
+        if report_type not in cls.DOWNLOADERS:
+            raise ValueError(
+                f"Unknown report type: {report_type}. Valid types: {cls.REPORT_TYPES}"
+            )
+
+        return f"html_{report_type.lower()}"
+
+    @classmethod
+    def get_downloader_class(cls, report_type: str) -> type[BaseHTMLDownloader]:
+        """Get the downloader class for a report type.
+
+        This is useful for introspection or when you need the class
+        rather than an instance.
+
+        Args:
+            report_type: Report type code (GS, ES, PL, etc.)
+
+        Returns:
+            Downloader class (not instance)
+
+        Raises:
+            ValueError: If report_type is not recognized.
+
+        Example:
+            cls = HTMLDownloaderRegistry.get_downloader_class("GS")
+            print(cls.__name__)  # "GameSummaryDownloader"
+        """
+        report_type = report_type.upper()
+
+        if report_type not in cls.DOWNLOADERS:
+            raise ValueError(
+                f"Unknown report type: {report_type}. Valid types: {cls.REPORT_TYPES}"
+            )
+
+        return cls.DOWNLOADERS[report_type]
+
+    @classmethod
+    def is_valid_report_type(cls, report_type: str) -> bool:
+        """Check if a report type is valid.
+
+        Args:
+            report_type: Report type code to validate
+
+        Returns:
+            True if the report type is recognized, False otherwise
+
+        Example:
+            HTMLDownloaderRegistry.is_valid_report_type("GS")  # True
+            HTMLDownloaderRegistry.is_valid_report_type("XX")  # False
+        """
+        return report_type.upper() in cls.DOWNLOADERS

--- a/tests/unit/downloaders/sources/html/test_registry.py
+++ b/tests/unit/downloaders/sources/html/test_registry.py
@@ -1,0 +1,362 @@
+"""Unit tests for HTML Downloader Registry.
+
+Tests the registry and factory pattern for creating HTML report downloaders.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nhl_api.downloaders.sources.html import (
+    HTML_DOWNLOADER_CONFIG,
+    BaseHTMLDownloader,
+    EventSummaryDownloader,
+    FaceoffComparisonDownloader,
+    FaceoffSummaryDownloader,
+    GameSummaryDownloader,
+    HTMLDownloaderConfig,
+    HTMLDownloaderRegistry,
+    PlayByPlayDownloader,
+    RosterDownloader,
+    ShotSummaryDownloader,
+    TimeOnIceDownloader,
+)
+
+
+class TestHTMLDownloaderRegistry:
+    """Tests for HTMLDownloaderRegistry class."""
+
+    # =========================================================================
+    # Test DOWNLOADERS mapping
+    # =========================================================================
+
+    def test_downloaders_contains_all_report_types(self) -> None:
+        """Verify all expected report types are registered."""
+        expected_types = {"GS", "ES", "PL", "FS", "FC", "RO", "SS", "TH", "TV"}
+        assert set(HTMLDownloaderRegistry.DOWNLOADERS.keys()) == expected_types
+
+    def test_report_types_list(self) -> None:
+        """Verify REPORT_TYPES list matches DOWNLOADERS keys."""
+        assert set(HTMLDownloaderRegistry.REPORT_TYPES) == set(
+            HTMLDownloaderRegistry.DOWNLOADERS.keys()
+        )
+
+    def test_time_on_ice_types(self) -> None:
+        """Verify TIME_ON_ICE_TYPES contains TH and TV."""
+        assert HTMLDownloaderRegistry.TIME_ON_ICE_TYPES == frozenset({"TH", "TV"})
+
+    # =========================================================================
+    # Test create() - Standard Downloaders
+    # =========================================================================
+
+    def test_create_game_summary(self) -> None:
+        """Create GameSummaryDownloader."""
+        downloader = HTMLDownloaderRegistry.create("GS")
+        assert isinstance(downloader, GameSummaryDownloader)
+        assert downloader.report_type == "GS"
+        assert downloader.source_name == "html_gs"
+
+    def test_create_event_summary(self) -> None:
+        """Create EventSummaryDownloader."""
+        downloader = HTMLDownloaderRegistry.create("ES")
+        assert isinstance(downloader, EventSummaryDownloader)
+        assert downloader.report_type == "ES"
+        assert downloader.source_name == "html_es"
+
+    def test_create_play_by_play(self) -> None:
+        """Create PlayByPlayDownloader."""
+        downloader = HTMLDownloaderRegistry.create("PL")
+        assert isinstance(downloader, PlayByPlayDownloader)
+        assert downloader.report_type == "PL"
+        assert downloader.source_name == "html_pl"
+
+    def test_create_faceoff_summary(self) -> None:
+        """Create FaceoffSummaryDownloader."""
+        downloader = HTMLDownloaderRegistry.create("FS")
+        assert isinstance(downloader, FaceoffSummaryDownloader)
+        assert downloader.report_type == "FS"
+        assert downloader.source_name == "html_fs"
+
+    def test_create_faceoff_comparison(self) -> None:
+        """Create FaceoffComparisonDownloader."""
+        downloader = HTMLDownloaderRegistry.create("FC")
+        assert isinstance(downloader, FaceoffComparisonDownloader)
+        assert downloader.report_type == "FC"
+        assert downloader.source_name == "html_fc"
+
+    def test_create_roster(self) -> None:
+        """Create RosterDownloader."""
+        downloader = HTMLDownloaderRegistry.create("RO")
+        assert isinstance(downloader, RosterDownloader)
+        assert downloader.report_type == "RO"
+        assert downloader.source_name == "html_ro"
+
+    def test_create_shot_summary(self) -> None:
+        """Create ShotSummaryDownloader."""
+        downloader = HTMLDownloaderRegistry.create("SS")
+        assert isinstance(downloader, ShotSummaryDownloader)
+        assert downloader.report_type == "SS"
+        assert downloader.source_name == "html_ss"
+
+    # =========================================================================
+    # Test create() - TimeOnIce Special Cases
+    # =========================================================================
+
+    def test_create_time_on_ice_home(self) -> None:
+        """Create TimeOnIceDownloader for home team (TH)."""
+        downloader = HTMLDownloaderRegistry.create("TH")
+        assert isinstance(downloader, TimeOnIceDownloader)
+        assert downloader.report_type == "TH"
+        assert downloader.source_name == "html_th"
+        assert downloader._side == "home"  # noqa: SLF001
+
+    def test_create_time_on_ice_visitor(self) -> None:
+        """Create TimeOnIceDownloader for visitor team (TV)."""
+        downloader = HTMLDownloaderRegistry.create("TV")
+        assert isinstance(downloader, TimeOnIceDownloader)
+        assert downloader.report_type == "TV"
+        assert downloader.source_name == "html_tv"
+        assert downloader._side == "away"  # noqa: SLF001
+
+    # =========================================================================
+    # Test create() - Case Insensitivity
+    # =========================================================================
+
+    def test_create_lowercase(self) -> None:
+        """Create downloader with lowercase report type."""
+        downloader = HTMLDownloaderRegistry.create("gs")
+        assert isinstance(downloader, GameSummaryDownloader)
+        assert downloader.report_type == "GS"
+
+    def test_create_mixed_case(self) -> None:
+        """Create downloader with mixed case report type."""
+        downloader = HTMLDownloaderRegistry.create("Gs")
+        assert isinstance(downloader, GameSummaryDownloader)
+
+    # =========================================================================
+    # Test create() - Invalid Report Types
+    # =========================================================================
+
+    def test_create_invalid_report_type(self) -> None:
+        """Raise ValueError for unknown report type."""
+        with pytest.raises(ValueError, match="Unknown report type: XX"):
+            HTMLDownloaderRegistry.create("XX")
+
+    def test_create_empty_report_type(self) -> None:
+        """Raise ValueError for empty report type."""
+        with pytest.raises(ValueError, match="Unknown report type:"):
+            HTMLDownloaderRegistry.create("")
+
+    # =========================================================================
+    # Test create() - Custom Configuration
+    # =========================================================================
+
+    def test_create_with_custom_config(self) -> None:
+        """Create downloader with custom configuration."""
+        custom_config = HTMLDownloaderConfig(
+            requests_per_second=1.0,
+            max_retries=5,
+        )
+        downloader = HTMLDownloaderRegistry.create("GS", custom_config)
+        assert downloader.config.requests_per_second == 1.0
+        assert downloader.config.max_retries == 5
+
+    def test_create_with_default_config(self) -> None:
+        """Create downloader uses default config when not specified."""
+        downloader = HTMLDownloaderRegistry.create("GS")
+        # Should use default HTML config
+        assert downloader.config.base_url == HTML_DOWNLOADER_CONFIG.base_url
+        assert (
+            downloader.config.requests_per_second
+            == HTML_DOWNLOADER_CONFIG.requests_per_second
+        )
+
+    def test_create_with_game_ids(self) -> None:
+        """Create downloader with game IDs."""
+        game_ids = [2024020001, 2024020002, 2024020003]
+        downloader = HTMLDownloaderRegistry.create("GS", game_ids=game_ids)
+        assert downloader._game_ids == game_ids  # noqa: SLF001
+
+    # =========================================================================
+    # Test create_all()
+    # =========================================================================
+
+    def test_create_all_returns_all_report_types(self) -> None:
+        """create_all returns all registered report types."""
+        downloaders = HTMLDownloaderRegistry.create_all()
+        assert set(downloaders.keys()) == set(HTMLDownloaderRegistry.REPORT_TYPES)
+
+    def test_create_all_returns_correct_instances(self) -> None:
+        """create_all returns correct downloader instances."""
+        downloaders = HTMLDownloaderRegistry.create_all()
+
+        assert isinstance(downloaders["GS"], GameSummaryDownloader)
+        assert isinstance(downloaders["ES"], EventSummaryDownloader)
+        assert isinstance(downloaders["PL"], PlayByPlayDownloader)
+        assert isinstance(downloaders["FS"], FaceoffSummaryDownloader)
+        assert isinstance(downloaders["FC"], FaceoffComparisonDownloader)
+        assert isinstance(downloaders["RO"], RosterDownloader)
+        assert isinstance(downloaders["SS"], ShotSummaryDownloader)
+        assert isinstance(downloaders["TH"], TimeOnIceDownloader)
+        assert isinstance(downloaders["TV"], TimeOnIceDownloader)
+
+    def test_create_all_time_on_ice_sides(self) -> None:
+        """create_all sets correct side for TimeOnIce downloaders."""
+        downloaders = HTMLDownloaderRegistry.create_all()
+
+        # Cast to TimeOnIceDownloader for type checker
+        toi_home = downloaders["TH"]
+        toi_away = downloaders["TV"]
+        assert isinstance(toi_home, TimeOnIceDownloader)
+        assert isinstance(toi_away, TimeOnIceDownloader)
+        assert toi_home._side == "home"  # noqa: SLF001
+        assert toi_away._side == "away"  # noqa: SLF001
+
+    def test_create_all_with_custom_config(self) -> None:
+        """create_all with custom configuration."""
+        custom_config = HTMLDownloaderConfig(requests_per_second=0.5)
+        downloaders = HTMLDownloaderRegistry.create_all(custom_config)
+
+        for downloader in downloaders.values():
+            assert downloader.config.requests_per_second == 0.5
+
+    def test_create_all_with_game_ids(self) -> None:
+        """create_all with game IDs."""
+        game_ids = [2024020001, 2024020002]
+        downloaders = HTMLDownloaderRegistry.create_all(game_ids=game_ids)
+
+        for downloader in downloaders.values():
+            assert downloader._game_ids == game_ids  # noqa: SLF001
+
+    # =========================================================================
+    # Test default_config()
+    # =========================================================================
+
+    def test_default_config_returns_html_config(self) -> None:
+        """default_config returns HTMLDownloaderConfig instance."""
+        config = HTMLDownloaderRegistry.default_config()
+        assert config is HTML_DOWNLOADER_CONFIG
+
+    def test_default_config_values(self) -> None:
+        """default_config has expected values."""
+        config = HTMLDownloaderRegistry.default_config()
+        assert config.base_url == "https://www.nhl.com/scores/htmlreports"
+        assert config.requests_per_second == 2.0
+        assert config.max_retries == 3
+
+    # =========================================================================
+    # Test get_source_name()
+    # =========================================================================
+
+    @pytest.mark.parametrize(
+        ("report_type", "expected_name"),
+        [
+            ("GS", "html_gs"),
+            ("ES", "html_es"),
+            ("PL", "html_pl"),
+            ("FS", "html_fs"),
+            ("FC", "html_fc"),
+            ("RO", "html_ro"),
+            ("SS", "html_ss"),
+            ("TH", "html_th"),
+            ("TV", "html_tv"),
+        ],
+    )
+    def test_get_source_name(self, report_type: str, expected_name: str) -> None:
+        """get_source_name returns correct source name."""
+        assert HTMLDownloaderRegistry.get_source_name(report_type) == expected_name
+
+    def test_get_source_name_lowercase(self) -> None:
+        """get_source_name handles lowercase input."""
+        assert HTMLDownloaderRegistry.get_source_name("gs") == "html_gs"
+
+    def test_get_source_name_invalid(self) -> None:
+        """get_source_name raises ValueError for invalid type."""
+        with pytest.raises(ValueError, match="Unknown report type"):
+            HTMLDownloaderRegistry.get_source_name("XX")
+
+    # =========================================================================
+    # Test get_downloader_class()
+    # =========================================================================
+
+    @pytest.mark.parametrize(
+        ("report_type", "expected_class"),
+        [
+            ("GS", GameSummaryDownloader),
+            ("ES", EventSummaryDownloader),
+            ("PL", PlayByPlayDownloader),
+            ("FS", FaceoffSummaryDownloader),
+            ("FC", FaceoffComparisonDownloader),
+            ("RO", RosterDownloader),
+            ("SS", ShotSummaryDownloader),
+            ("TH", TimeOnIceDownloader),
+            ("TV", TimeOnIceDownloader),
+        ],
+    )
+    def test_get_downloader_class(
+        self, report_type: str, expected_class: type[BaseHTMLDownloader]
+    ) -> None:
+        """get_downloader_class returns correct class."""
+        assert (
+            HTMLDownloaderRegistry.get_downloader_class(report_type) is expected_class
+        )
+
+    def test_get_downloader_class_lowercase(self) -> None:
+        """get_downloader_class handles lowercase input."""
+        assert (
+            HTMLDownloaderRegistry.get_downloader_class("gs") is GameSummaryDownloader
+        )
+
+    def test_get_downloader_class_invalid(self) -> None:
+        """get_downloader_class raises ValueError for invalid type."""
+        with pytest.raises(ValueError, match="Unknown report type"):
+            HTMLDownloaderRegistry.get_downloader_class("XX")
+
+    # =========================================================================
+    # Test is_valid_report_type()
+    # =========================================================================
+
+    @pytest.mark.parametrize(
+        "report_type",
+        ["GS", "ES", "PL", "FS", "FC", "RO", "SS", "TH", "TV"],
+    )
+    def test_is_valid_report_type_valid(self, report_type: str) -> None:
+        """is_valid_report_type returns True for valid types."""
+        assert HTMLDownloaderRegistry.is_valid_report_type(report_type) is True
+
+    @pytest.mark.parametrize(
+        "report_type",
+        ["gs", "es", "pl", "fs", "fc", "ro", "ss", "th", "tv"],
+    )
+    def test_is_valid_report_type_lowercase(self, report_type: str) -> None:
+        """is_valid_report_type handles lowercase input."""
+        assert HTMLDownloaderRegistry.is_valid_report_type(report_type) is True
+
+    @pytest.mark.parametrize(
+        "report_type",
+        ["XX", "", "INVALID", "G", "GSS"],
+    )
+    def test_is_valid_report_type_invalid(self, report_type: str) -> None:
+        """is_valid_report_type returns False for invalid types."""
+        assert HTMLDownloaderRegistry.is_valid_report_type(report_type) is False
+
+    # =========================================================================
+    # Test all downloaders are BaseHTMLDownloader subclasses
+    # =========================================================================
+
+    def test_all_downloaders_inherit_from_base(self) -> None:
+        """All registered downloaders inherit from BaseHTMLDownloader."""
+        for report_type, downloader_class in HTMLDownloaderRegistry.DOWNLOADERS.items():
+            assert issubclass(downloader_class, BaseHTMLDownloader), (
+                f"{report_type}: {downloader_class.__name__} does not inherit "
+                f"from BaseHTMLDownloader"
+            )
+
+    def test_all_created_downloaders_are_base_instances(self) -> None:
+        """All created downloaders are BaseHTMLDownloader instances."""
+        downloaders = HTMLDownloaderRegistry.create_all()
+        for report_type, downloader in downloaders.items():
+            assert isinstance(downloader, BaseHTMLDownloader), (
+                f"{report_type}: {type(downloader).__name__} is not a "
+                f"BaseHTMLDownloader instance"
+            )


### PR DESCRIPTION
## Summary

- Implements `HTMLDownloaderRegistry` class with factory pattern for managing all HTML report downloaders
- Supports creating single downloader by report type or all downloaders at once
- Handles TimeOnIce special case (TH/TV with side parameter)
- Case-insensitive report type handling
- 73 unit tests with 100% coverage on registry.py

## Report Types Supported

| Code | Report | Downloader |
|------|--------|------------|
| GS | Game Summary | GameSummaryDownloader |
| ES | Event Summary | EventSummaryDownloader |
| PL | Play-by-Play | PlayByPlayDownloader |
| FS | Faceoff Summary | FaceoffSummaryDownloader |
| FC | Faceoff Comparison | FaceoffComparisonDownloader |
| RO | Roster Report | RosterDownloader |
| SS | Shot Summary | ShotSummaryDownloader |
| TH | Home Time on Ice | TimeOnIceDownloader (side="home") |
| TV | Visitor Time on Ice | TimeOnIceDownloader (side="away") |

## Usage Examples

```python
# Create single downloader
gs = HTMLDownloaderRegistry.create("GS")

# Create all downloaders
all_downloaders = HTMLDownloaderRegistry.create_all()

# Get source name for database
name = HTMLDownloaderRegistry.get_source_name("GS")  # "html_gs"
```

## Test plan

- [x] All 73 registry unit tests pass
- [x] 100% test coverage on registry.py
- [x] Ruff and mypy checks pass
- [x] Pre-commit hooks pass

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)