### PR TITLE
feat(downloaders): Add DailyFaceoff Penalty Kill Units Downloader (#105)

### DIFF
--- a/src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py
@@ -5,19 +5,29 @@ information from DailyFaceoff.com.
 
 Available downloaders:
 - BaseDailyFaceoffDownloader: Base class for all DailyFaceoff downloaders
+- PenaltyKillDownloader: Penalty kill unit configurations (PK1, PK2)
 
 Example usage:
     from nhl_api.downloaders.sources.dailyfaceoff import (
-        BaseDailyFaceoffDownloader,
+        PenaltyKillDownloader,
         DailyFaceoffConfig,
-        TEAM_SLUGS,
     )
+
+    config = DailyFaceoffConfig()
+    async with PenaltyKillDownloader(config) as downloader:
+        result = await downloader.download_team(10)  # Toronto
 """
 
 from nhl_api.downloaders.sources.dailyfaceoff.base_dailyfaceoff_downloader import (
     DAILYFACEOFF_CONFIG,
     BaseDailyFaceoffDownloader,
     DailyFaceoffConfig,
+)
+from nhl_api.downloaders.sources.dailyfaceoff.penalty_kill import (
+    PenaltyKillDownloader,
+    PenaltyKillUnit,
+    PKPlayer,
+    TeamPenaltyKill,
 )
 from nhl_api.downloaders.sources.dailyfaceoff.team_mapping import (
     TEAM_ABBREVIATIONS,
@@ -27,9 +37,16 @@ from nhl_api.downloaders.sources.dailyfaceoff.team_mapping import (
 )
 
 __all__ = [
+    # Base
     "BaseDailyFaceoffDownloader",
     "DAILYFACEOFF_CONFIG",
     "DailyFaceoffConfig",
+    # Penalty Kill
+    "PenaltyKillDownloader",
+    "PenaltyKillUnit",
+    "PKPlayer",
+    "TeamPenaltyKill",
+    # Team Mapping
     "TEAM_SLUGS",
     "TEAM_ABBREVIATIONS",
     "get_team_slug",

--- a/src/nhl_api/downloaders/sources/dailyfaceoff/penalty_kill.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/penalty_kill.py
@@ -1,0 +1,705 @@
+"""DailyFaceoff Penalty Kill Units Downloader.
+
+Downloads and parses penalty kill unit configurations from DailyFaceoff.com,
+including PK1 and PK2 units with their forward and defenseman assignments.
+
+URL Pattern: https://www.dailyfaceoff.com/teams/{team-slug}/line-combinations
+
+The penalty kill data is on the same page as line combinations, extracted from
+the data-group="pk1" and data-group="pk2" sections.
+
+Example usage:
+    config = DailyFaceoffConfig()
+    async with PenaltyKillDownloader(config) as downloader:
+        result = await downloader.download_team(10)  # Toronto Maple Leafs
+        pk_data = result.data
+        print(f"PK1 Forwards: {pk_data['pk1']['forwards']}")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from bs4 import BeautifulSoup, Tag
+
+from nhl_api.downloaders.sources.dailyfaceoff.base_dailyfaceoff_downloader import (
+    BaseDailyFaceoffDownloader,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PKPlayer:
+    """Player in a penalty kill unit.
+
+    Attributes:
+        name: Player's full name
+        jersey_number: Jersey number (if available)
+        position: Player position (F for forward, D for defenseman)
+        player_id: DailyFaceoff player ID (if available)
+    """
+
+    name: str
+    jersey_number: int | None = None
+    position: str | None = None
+    player_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PenaltyKillUnit:
+    """A single penalty kill unit (PK1 or PK2).
+
+    Attributes:
+        unit_number: Unit number (1 or 2)
+        forwards: List of forwards on this PK unit (typically 2)
+        defensemen: List of defensemen on this PK unit (typically 2)
+    """
+
+    unit_number: int
+    forwards: tuple[PKPlayer, ...]
+    defensemen: tuple[PKPlayer, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TeamPenaltyKill:
+    """Complete penalty kill configuration for a team.
+
+    Attributes:
+        team_id: NHL team ID
+        team_abbreviation: Team abbreviation (e.g., "TOR")
+        pk1: First penalty kill unit
+        pk2: Second penalty kill unit
+        fetched_at: When the data was fetched
+    """
+
+    team_id: int
+    team_abbreviation: str
+    pk1: PenaltyKillUnit | None
+    pk2: PenaltyKillUnit | None
+    fetched_at: datetime
+
+
+# Pattern to extract player ID from URL
+PLAYER_ID_PATTERN = re.compile(r"/players/[^/]+/[^/]+/(\d+)")
+
+# Pattern to extract jersey number
+JERSEY_PATTERN = re.compile(r"#(\d+)")
+
+
+class PenaltyKillDownloader(BaseDailyFaceoffDownloader):
+    """Downloads penalty kill unit configurations from DailyFaceoff.
+
+    Parses the line combinations page to extract:
+    - PK1: First penalty kill unit (2F + 2D)
+    - PK2: Second penalty kill unit (2F + 2D)
+
+    Example:
+        config = DailyFaceoffConfig()
+        async with PenaltyKillDownloader(config) as downloader:
+            # Download single team
+            result = await downloader.download_team(10)  # Toronto
+
+            # Download all teams
+            async for result in downloader.download_all_teams():
+                print(f"{result.data['team_abbreviation']}: downloaded")
+    """
+
+    @property
+    def data_type(self) -> str:
+        """Return data type identifier."""
+        return "penalty_kill"
+
+    @property
+    def page_path(self) -> str:
+        """Return URL path for line combinations page.
+
+        PK data is on the same page as line combinations.
+        """
+        return "line-combinations"
+
+    async def _parse_page(self, soup: BeautifulSoup, team_id: int) -> dict[str, Any]:
+        """Parse penalty kill units from the line combinations page.
+
+        Args:
+            soup: Parsed BeautifulSoup document
+            team_id: NHL team ID
+
+        Returns:
+            Dictionary containing parsed PK data
+        """
+        abbreviation = self._get_team_abbreviation(team_id)
+
+        # Parse PK units from embedded JSON data or HTML structure
+        pk1 = self._parse_pk_unit(soup, 1)
+        pk2 = self._parse_pk_unit(soup, 2)
+
+        result = TeamPenaltyKill(
+            team_id=team_id,
+            team_abbreviation=abbreviation,
+            pk1=pk1,
+            pk2=pk2,
+            fetched_at=datetime.now(UTC),
+        )
+
+        return self._to_dict(result)
+
+    def _parse_pk_unit(
+        self, soup: BeautifulSoup, unit_number: int
+    ) -> PenaltyKillUnit | None:
+        """Parse a single penalty kill unit.
+
+        Args:
+            soup: BeautifulSoup document
+            unit_number: Unit number (1 or 2)
+
+        Returns:
+            PenaltyKillUnit or None if not found
+        """
+        group_id = f"pk{unit_number}"
+
+        # Strategy 1: Look for embedded JSON data in script tags
+        players = self._parse_from_json(soup, group_id)
+
+        # Strategy 2: Look for data attributes in HTML
+        if not players:
+            players = self._parse_from_html_data(soup, group_id)
+
+        # Strategy 3: Look for table/div structure
+        if not players:
+            players = self._parse_from_structure(soup, group_id)
+
+        if not players:
+            logger.warning("Could not find PK%d unit data", unit_number)
+            return None
+
+        # Separate forwards and defensemen
+        forwards = [p for p in players if self._is_forward(p)]
+        defensemen = [p for p in players if self._is_defenseman(p)]
+
+        return PenaltyKillUnit(
+            unit_number=unit_number,
+            forwards=tuple(forwards),
+            defensemen=tuple(defensemen),
+        )
+
+    def _parse_from_json(self, soup: BeautifulSoup, group_id: str) -> list[PKPlayer]:
+        """Parse PK data from embedded JSON in script tags.
+
+        DailyFaceoff often includes player data in __NEXT_DATA__ or similar.
+
+        Args:
+            soup: BeautifulSoup document
+            group_id: Group identifier (e.g., "pk1")
+
+        Returns:
+            List of PKPlayer objects
+        """
+        players: list[PKPlayer] = []
+
+        # Look for Next.js data
+        script = soup.find("script", id="__NEXT_DATA__")
+        if script and script.string:
+            try:
+                data = json.loads(script.string)
+                players = self._extract_pk_from_next_data(data, group_id)
+                if players:
+                    return players
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+        # Look for other JSON-like script content
+        for script in soup.find_all("script"):
+            if not script.string:
+                continue
+
+            # Search for groupIdentifier pattern
+            if f'"groupIdentifier":"{group_id}"' in script.string:
+                players = self._extract_players_from_script(script.string, group_id)
+                if players:
+                    return players
+
+        return players
+
+    def _extract_pk_from_next_data(
+        self, data: dict[str, Any], group_id: str
+    ) -> list[PKPlayer]:
+        """Extract PK players from Next.js data structure.
+
+        Args:
+            data: Parsed __NEXT_DATA__ JSON
+            group_id: Group identifier
+
+        Returns:
+            List of PKPlayer objects
+        """
+        players: list[PKPlayer] = []
+
+        # Navigate the nested structure - this varies by page
+        try:
+            props = data.get("props", {})
+            page_props = props.get("pageProps", {})
+
+            # Look for lineup or formations data
+            for key in ["lineup", "formations", "penaltyKill", "specialTeams"]:
+                if key in page_props:
+                    section = page_props[key]
+                    players = self._search_for_group(section, group_id)
+                    if players:
+                        return players
+
+            # Deep search for the group
+            players = self._deep_search_group(page_props, group_id)
+
+        except (KeyError, TypeError, AttributeError) as e:
+            logger.debug("Error extracting from Next.js data: %s", e)
+
+        return players
+
+    def _search_for_group(self, data: Any, group_id: str) -> list[PKPlayer]:
+        """Search for a specific group in data structure.
+
+        Args:
+            data: Data structure to search
+            group_id: Group identifier to find
+
+        Returns:
+            List of PKPlayer objects
+        """
+        players: list[PKPlayer] = []
+
+        if isinstance(data, dict):
+            if data.get("groupIdentifier") == group_id:
+                # Found the group, extract players
+                return self._extract_players_from_group(data)
+
+            for value in data.values():
+                result = self._search_for_group(value, group_id)
+                if result:
+                    return result
+
+        elif isinstance(data, list):
+            for item in data:
+                result = self._search_for_group(item, group_id)
+                if result:
+                    return result
+
+        return players
+
+    def _deep_search_group(
+        self, data: Any, group_id: str, max_depth: int = 10
+    ) -> list[PKPlayer]:
+        """Deep search for group data in nested structure.
+
+        Args:
+            data: Data structure to search
+            group_id: Group identifier
+            max_depth: Maximum recursion depth
+
+        Returns:
+            List of PKPlayer objects
+        """
+        if max_depth <= 0:
+            return []
+
+        if isinstance(data, dict):
+            # Check if this dict has the groupIdentifier
+            if data.get("groupIdentifier") == group_id:
+                return self._extract_players_from_group(data)
+
+            # Recurse into values
+            for value in data.values():
+                result = self._deep_search_group(value, group_id, max_depth - 1)
+                if result:
+                    return result
+
+        elif isinstance(data, list):
+            for item in data:
+                result = self._deep_search_group(item, group_id, max_depth - 1)
+                if result:
+                    return result
+
+        return []
+
+    def _extract_players_from_group(self, group: dict[str, Any]) -> list[PKPlayer]:
+        """Extract players from a group dictionary.
+
+        Args:
+            group: Group data containing players
+
+        Returns:
+            List of PKPlayer objects
+        """
+        players: list[PKPlayer] = []
+
+        # Look for players in various possible structures
+        player_data = group.get("players", [])
+        if not player_data:
+            player_data = group.get("skaters", [])
+        if not player_data:
+            # Try looking at position slots
+            for key in ["sk1", "sk2", "sk3", "sk4"]:
+                if key in group:
+                    player_data.append(group[key])
+
+        for p in player_data:
+            if isinstance(p, dict):
+                player = self._dict_to_player(p)
+                if player:
+                    players.append(player)
+
+        return players
+
+    def _dict_to_player(self, p: dict[str, Any]) -> PKPlayer | None:
+        """Convert player dictionary to PKPlayer.
+
+        Args:
+            p: Player data dictionary
+
+        Returns:
+            PKPlayer or None
+        """
+        name = p.get("name") or p.get("playerName") or p.get("fullName", "")
+        if not name:
+            return None
+
+        jersey = p.get("jerseyNumber") or p.get("number")
+        if isinstance(jersey, str) and jersey.isdigit():
+            jersey = int(jersey)
+
+        position = p.get("position") or p.get("positionCode")
+        player_id = p.get("playerId") or p.get("id")
+        if player_id:
+            player_id = str(player_id)
+
+        return PKPlayer(
+            name=name,
+            jersey_number=jersey if isinstance(jersey, int) else None,
+            position=position,
+            player_id=player_id,
+        )
+
+    def _extract_players_from_script(
+        self, script_content: str, group_id: str
+    ) -> list[PKPlayer]:
+        """Extract players from inline script content.
+
+        Args:
+            script_content: Script text content
+            group_id: Group identifier
+
+        Returns:
+            List of PKPlayer objects
+        """
+        players: list[PKPlayer] = []
+
+        # Find the section containing our group
+        pattern = rf'"groupIdentifier"\s*:\s*"{group_id}"[^}}]*'
+        match = re.search(pattern, script_content)
+        if not match:
+            return players
+
+        # Find the containing object - look for player names nearby
+        start_pos = match.start()
+
+        # Look backwards for object start
+        brace_count = 0
+        obj_start = start_pos
+        for i in range(start_pos, max(0, start_pos - 5000), -1):
+            if script_content[i] == "}":
+                brace_count += 1
+            elif script_content[i] == "{":
+                if brace_count == 0:
+                    obj_start = i
+                    break
+                brace_count -= 1
+
+        # Look forwards for object end
+        brace_count = 0
+        obj_end = start_pos
+        for i in range(start_pos, min(len(script_content), start_pos + 5000)):
+            if script_content[i] == "{":
+                brace_count += 1
+            elif script_content[i] == "}":
+                if brace_count == 0:
+                    obj_end = i + 1
+                    break
+                brace_count -= 1
+
+        # Try to parse this section as JSON
+        section = script_content[obj_start:obj_end]
+        try:
+            data = json.loads(section)
+            players = self._extract_players_from_group(data)
+        except json.JSONDecodeError:
+            # Fallback: extract player names with regex
+            players = self._extract_names_from_text(section)
+
+        return players
+
+    def _extract_names_from_text(self, text: str) -> list[PKPlayer]:
+        """Extract player names from text using regex patterns.
+
+        Args:
+            text: Text containing player data
+
+        Returns:
+            List of PKPlayer objects with names only
+        """
+        players: list[PKPlayer] = []
+
+        # Look for playerName or name patterns
+        name_pattern = r'"(?:playerName|name|fullName)"\s*:\s*"([^"]+)"'
+        for match in re.finditer(name_pattern, text):
+            name = match.group(1)
+            if name and len(name) > 2:
+                players.append(PKPlayer(name=name))
+
+        return players
+
+    def _parse_from_html_data(
+        self, soup: BeautifulSoup, group_id: str
+    ) -> list[PKPlayer]:
+        """Parse PK data from HTML data attributes.
+
+        Args:
+            soup: BeautifulSoup document
+            group_id: Group identifier
+
+        Returns:
+            List of PKPlayer objects
+        """
+        players: list[PKPlayer] = []
+
+        # Look for elements with data-group or similar attributes
+        containers = soup.find_all(attrs={"data-group": group_id})
+
+        for container in containers:
+            # Look for player links within this container
+            links = container.find_all("a", href=re.compile(r"/players/"))
+            for link in links:
+                player = self._extract_player_from_element(link)
+                if player:
+                    players.append(player)
+
+            # If no links found, try the container itself
+            if not players:
+                player = self._extract_player_from_element(container)
+                if player:
+                    players.append(player)
+
+        # Also try data-groupidentifier
+        if not players:
+            containers = soup.find_all(attrs={"data-groupidentifier": group_id})
+            for container in containers:
+                # Look for player links within
+                links = container.find_all("a", href=re.compile(r"/players/"))
+                for link in links:
+                    player = self._extract_player_from_element(link)
+                    if player:
+                        players.append(player)
+
+        return players
+
+    def _parse_from_structure(
+        self, soup: BeautifulSoup, group_id: str
+    ) -> list[PKPlayer]:
+        """Parse PK data from page structure (sections, divs, etc.).
+
+        Args:
+            soup: BeautifulSoup document
+            group_id: Group identifier
+
+        Returns:
+            List of PKPlayer objects
+        """
+        players: list[PKPlayer] = []
+
+        # Map group_id to display text patterns
+        unit_num = group_id[-1]  # "pk1" -> "1"
+        patterns = [
+            f"{unit_num}st penalty kill",
+            f"{unit_num}nd penalty kill",
+            f"pk{unit_num}",
+            f"penalty kill {unit_num}",
+            f"pk unit {unit_num}",
+        ]
+
+        # Find section headers or labels
+        for pattern in patterns:
+            header = soup.find(string=re.compile(pattern, re.I))
+            if header:
+                # Look for player links in the containing section
+                parent = header.find_parent(["div", "section", "table", "tr"])
+                if parent:
+                    players = self._extract_players_from_section(parent)
+                    if players:
+                        return players
+
+        return players
+
+    def _extract_players_from_section(self, section: Tag) -> list[PKPlayer]:
+        """Extract players from an HTML section.
+
+        Args:
+            section: BeautifulSoup Tag representing a section
+
+        Returns:
+            List of PKPlayer objects
+        """
+        players: list[PKPlayer] = []
+
+        # Find all player links
+        links = section.find_all("a", href=re.compile(r"/players/"))
+
+        for link in links:
+            player = self._extract_player_from_element(link)
+            if player:
+                players.append(player)
+
+        return players
+
+    def _extract_player_from_element(self, element: Tag) -> PKPlayer | None:
+        """Extract player info from an HTML element.
+
+        Args:
+            element: BeautifulSoup element
+
+        Returns:
+            PKPlayer or None
+        """
+        name = ""
+        jersey_number = None
+        position = None
+        player_id = None
+
+        # Get name from link text or data attribute
+        if isinstance(element, Tag):
+            link = element if element.name == "a" else element.find("a")
+            if link:
+                name = link.get_text(strip=True)
+                href = link.get("href", "")
+                if href:
+                    match = PLAYER_ID_PATTERN.search(str(href))
+                    if match:
+                        player_id = match.group(1)
+            else:
+                name = element.get_text(strip=True)
+
+            # Try data attributes
+            if not name:
+                name = str(element.get("data-name", ""))
+            if not player_id:
+                player_id = str(element.get("data-player-id", "")) or None
+
+            # Get jersey number
+            element_text = str(element)
+            jersey_match = JERSEY_PATTERN.search(element_text)
+            if jersey_match:
+                jersey_number = int(jersey_match.group(1))
+
+            # Get position from data attribute or class
+            position = str(element.get("data-position", "")) or None
+            if not position:
+                class_attr = element.get("class")
+                classes: list[str] = list(class_attr) if class_attr else []
+                for cls in classes:
+                    cls_lower = str(cls).lower()
+                    if cls_lower in ("forward", "f", "lw", "c", "rw"):
+                        position = "F"
+                        break
+                    elif cls_lower in ("defense", "d", "ld", "rd"):
+                        position = "D"
+                        break
+
+        if not name:
+            return None
+
+        return PKPlayer(
+            name=name,
+            jersey_number=jersey_number,
+            position=position,
+            player_id=player_id,
+        )
+
+    def _is_forward(self, player: PKPlayer) -> bool:
+        """Check if player is a forward.
+
+        Args:
+            player: PKPlayer to check
+
+        Returns:
+            True if player appears to be a forward
+        """
+        if player.position:
+            pos_upper = player.position.upper()
+            return pos_upper in ("F", "LW", "C", "RW", "CENTER", "FORWARD")
+        # Default: if we don't know, assume first 2 are forwards
+        return True
+
+    def _is_defenseman(self, player: PKPlayer) -> bool:
+        """Check if player is a defenseman.
+
+        Args:
+            player: PKPlayer to check
+
+        Returns:
+            True if player appears to be a defenseman
+        """
+        if player.position:
+            pos_upper = player.position.upper()
+            return pos_upper in ("D", "LD", "RD", "DEFENSE", "DEFENSEMAN")
+        return False
+
+    def _to_dict(self, pk: TeamPenaltyKill) -> dict[str, Any]:
+        """Convert TeamPenaltyKill to dictionary.
+
+        Args:
+            pk: TeamPenaltyKill dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "team_id": pk.team_id,
+            "team_abbreviation": pk.team_abbreviation,
+            "pk1": self._unit_to_dict(pk.pk1) if pk.pk1 else None,
+            "pk2": self._unit_to_dict(pk.pk2) if pk.pk2 else None,
+            "fetched_at": pk.fetched_at.isoformat(),
+        }
+
+    def _unit_to_dict(self, unit: PenaltyKillUnit) -> dict[str, Any]:
+        """Convert PenaltyKillUnit to dictionary.
+
+        Args:
+            unit: PenaltyKillUnit dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "unit_number": unit.unit_number,
+            "forwards": [self._player_to_dict(p) for p in unit.forwards],
+            "defensemen": [self._player_to_dict(p) for p in unit.defensemen],
+        }
+
+    def _player_to_dict(self, player: PKPlayer) -> dict[str, Any]:
+        """Convert PKPlayer to dictionary.
+
+        Args:
+            player: PKPlayer dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "name": player.name,
+            "jersey_number": player.jersey_number,
+            "position": player.position,
+            "player_id": player.player_id,
+        }

--- a/tests/unit/downloaders/sources/dailyfaceoff/test_penalty_kill.py
+++ b/tests/unit/downloaders/sources/dailyfaceoff/test_penalty_kill.py
@@ -1,0 +1,867 @@
+"""Unit tests for PenaltyKillDownloader.
+
+Tests the parsing of penalty kill unit data from DailyFaceoff.com.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bs4 import BeautifulSoup
+
+from nhl_api.downloaders.sources.dailyfaceoff import (
+    DailyFaceoffConfig,
+    PenaltyKillDownloader,
+    PenaltyKillUnit,
+    PKPlayer,
+    TeamPenaltyKill,
+)
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def config() -> DailyFaceoffConfig:
+    """Create test config."""
+    return DailyFaceoffConfig()
+
+
+@pytest.fixture
+def downloader(config: DailyFaceoffConfig) -> PenaltyKillDownloader:
+    """Create downloader instance."""
+    return PenaltyKillDownloader(config)
+
+
+@pytest.fixture
+def sample_next_data() -> dict[str, Any]:
+    """Sample __NEXT_DATA__ structure with PK data."""
+    return {
+        "props": {
+            "pageProps": {
+                "formations": [
+                    {
+                        "groupIdentifier": "pk1",
+                        "groupName": "1st Penalty Kill Unit",
+                        "players": [
+                            {
+                                "name": "Scott Laughton",
+                                "jerseyNumber": 21,
+                                "position": "C",
+                                "playerId": "12345",
+                            },
+                            {
+                                "name": "Steven Lorentz",
+                                "jerseyNumber": 17,
+                                "position": "F",
+                                "playerId": "12346",
+                            },
+                            {
+                                "name": "Jake McCabe",
+                                "jerseyNumber": 22,
+                                "position": "D",
+                                "playerId": "12347",
+                            },
+                            {
+                                "name": "Henry Thrun",
+                                "jerseyNumber": 3,
+                                "position": "D",
+                                "playerId": "12348",
+                            },
+                        ],
+                    },
+                    {
+                        "groupIdentifier": "pk2",
+                        "groupName": "2nd Penalty Kill Unit",
+                        "players": [
+                            {
+                                "name": "Nicolas Roy",
+                                "jerseyNumber": 10,
+                                "position": "C",
+                                "playerId": "12349",
+                            },
+                            {
+                                "name": "Matthew Knies",
+                                "jerseyNumber": 23,
+                                "position": "LW",
+                                "playerId": "12350",
+                            },
+                            {
+                                "name": "Simon Benoit",
+                                "jerseyNumber": 6,
+                                "position": "D",
+                                "playerId": "12351",
+                            },
+                            {
+                                "name": "Troy Stecher",
+                                "jerseyNumber": 51,
+                                "position": "D",
+                                "playerId": "12352",
+                            },
+                        ],
+                    },
+                ]
+            }
+        }
+    }
+
+
+@pytest.fixture
+def html_with_next_data(sample_next_data: dict[str, Any]) -> str:
+    """Generate HTML with embedded Next.js data."""
+    return f"""
+    <!DOCTYPE html>
+    <html>
+    <head><title>Test</title></head>
+    <body>
+        <script id="__NEXT_DATA__" type="application/json">
+        {json.dumps(sample_next_data)}
+        </script>
+    </body>
+    </html>
+    """
+
+
+@pytest.fixture
+def html_with_data_attributes() -> str:
+    """Generate HTML with data attributes for PK units."""
+    return """
+    <!DOCTYPE html>
+    <html>
+    <head><title>Test</title></head>
+    <body>
+        <div data-group="pk1">
+            <a href="/players/news/scott-laughton/12345" data-position="C">#21 Scott Laughton</a>
+            <a href="/players/news/steven-lorentz/12346" data-position="F">#17 Steven Lorentz</a>
+            <a href="/players/news/jake-mccabe/12347" data-position="D">#22 Jake McCabe</a>
+            <a href="/players/news/henry-thrun/12348" data-position="D">#3 Henry Thrun</a>
+        </div>
+        <div data-group="pk2">
+            <a href="/players/news/nicolas-roy/12349" data-position="C">#10 Nicolas Roy</a>
+            <a href="/players/news/matthew-knies/12350" data-position="LW">#23 Matthew Knies</a>
+            <a href="/players/news/simon-benoit/12351" data-position="D">#6 Simon Benoit</a>
+            <a href="/players/news/troy-stecher/12352" data-position="D">#51 Troy Stecher</a>
+        </div>
+    </body>
+    </html>
+    """
+
+
+@pytest.fixture
+def html_with_section_structure() -> str:
+    """Generate HTML with section-based structure."""
+    return """
+    <!DOCTYPE html>
+    <html>
+    <head><title>Test</title></head>
+    <body>
+        <section>
+            <h3>1st Penalty Kill Unit</h3>
+            <div>
+                <a href="/players/news/player-one/1001">Player One</a>
+                <a href="/players/news/player-two/1002">Player Two</a>
+                <a href="/players/news/player-three/1003">Player Three</a>
+                <a href="/players/news/player-four/1004">Player Four</a>
+            </div>
+        </section>
+        <section>
+            <h3>2nd Penalty Kill Unit</h3>
+            <div>
+                <a href="/players/news/player-five/1005">Player Five</a>
+                <a href="/players/news/player-six/1006">Player Six</a>
+                <a href="/players/news/player-seven/1007">Player Seven</a>
+                <a href="/players/news/player-eight/1008">Player Eight</a>
+            </div>
+        </section>
+    </body>
+    </html>
+    """
+
+
+# --- Data Class Tests ---
+
+
+class TestPKPlayer:
+    """Tests for PKPlayer dataclass."""
+
+    def test_create_minimal(self) -> None:
+        """Test creating player with only name."""
+        player = PKPlayer(name="Test Player")
+        assert player.name == "Test Player"
+        assert player.jersey_number is None
+        assert player.position is None
+        assert player.player_id is None
+
+    def test_create_full(self) -> None:
+        """Test creating player with all fields."""
+        player = PKPlayer(
+            name="Test Player",
+            jersey_number=99,
+            position="D",
+            player_id="12345",
+        )
+        assert player.name == "Test Player"
+        assert player.jersey_number == 99
+        assert player.position == "D"
+        assert player.player_id == "12345"
+
+    def test_frozen(self) -> None:
+        """Test that PKPlayer is immutable."""
+        player = PKPlayer(name="Test")
+        with pytest.raises(AttributeError):
+            player.name = "Changed"  # type: ignore[misc]
+
+
+class TestPenaltyKillUnit:
+    """Tests for PenaltyKillUnit dataclass."""
+
+    def test_create_unit(self) -> None:
+        """Test creating a PK unit."""
+        forwards = (
+            PKPlayer(name="Forward 1", position="C"),
+            PKPlayer(name="Forward 2", position="LW"),
+        )
+        defensemen = (
+            PKPlayer(name="Defenseman 1", position="D"),
+            PKPlayer(name="Defenseman 2", position="D"),
+        )
+        unit = PenaltyKillUnit(
+            unit_number=1,
+            forwards=forwards,
+            defensemen=defensemen,
+        )
+        assert unit.unit_number == 1
+        assert len(unit.forwards) == 2
+        assert len(unit.defensemen) == 2
+
+    def test_frozen(self) -> None:
+        """Test that PenaltyKillUnit is immutable."""
+        unit = PenaltyKillUnit(
+            unit_number=1,
+            forwards=(),
+            defensemen=(),
+        )
+        with pytest.raises(AttributeError):
+            unit.unit_number = 2  # type: ignore[misc]
+
+
+class TestTeamPenaltyKill:
+    """Tests for TeamPenaltyKill dataclass."""
+
+    def test_create_team_pk(self) -> None:
+        """Test creating team PK data."""
+        pk1 = PenaltyKillUnit(unit_number=1, forwards=(), defensemen=())
+        pk2 = PenaltyKillUnit(unit_number=2, forwards=(), defensemen=())
+        now = datetime.now(UTC)
+
+        team_pk = TeamPenaltyKill(
+            team_id=10,
+            team_abbreviation="TOR",
+            pk1=pk1,
+            pk2=pk2,
+            fetched_at=now,
+        )
+
+        assert team_pk.team_id == 10
+        assert team_pk.team_abbreviation == "TOR"
+        assert team_pk.pk1 == pk1
+        assert team_pk.pk2 == pk2
+        assert team_pk.fetched_at == now
+
+
+# --- Downloader Property Tests ---
+
+
+class TestDownloaderProperties:
+    """Tests for PenaltyKillDownloader properties."""
+
+    def test_data_type(self, downloader: PenaltyKillDownloader) -> None:
+        """Test data_type property."""
+        assert downloader.data_type == "penalty_kill"
+
+    def test_page_path(self, downloader: PenaltyKillDownloader) -> None:
+        """Test page_path property."""
+        assert downloader.page_path == "line-combinations"
+
+    def test_source_name(self, downloader: PenaltyKillDownloader) -> None:
+        """Test source_name property."""
+        assert downloader.source_name == "dailyfaceoff_penalty_kill"
+
+
+# --- Parsing Tests ---
+
+
+class TestParseFromJson:
+    """Tests for JSON parsing methods."""
+
+    def test_parse_from_next_data(
+        self,
+        downloader: PenaltyKillDownloader,
+        html_with_next_data: str,
+    ) -> None:
+        """Test parsing from __NEXT_DATA__."""
+        soup = BeautifulSoup(html_with_next_data, "lxml")
+
+        pk1_players = downloader._parse_from_json(soup, "pk1")
+        assert len(pk1_players) == 4
+        assert pk1_players[0].name == "Scott Laughton"
+        assert pk1_players[0].jersey_number == 21
+        assert pk1_players[0].position == "C"
+
+        pk2_players = downloader._parse_from_json(soup, "pk2")
+        assert len(pk2_players) == 4
+        assert pk2_players[0].name == "Nicolas Roy"
+
+    def test_parse_no_next_data(
+        self,
+        downloader: PenaltyKillDownloader,
+    ) -> None:
+        """Test parsing when no __NEXT_DATA__ exists."""
+        html = "<!DOCTYPE html><html><body></body></html>"
+        soup = BeautifulSoup(html, "lxml")
+
+        players = downloader._parse_from_json(soup, "pk1")
+        assert players == []
+
+    def test_parse_invalid_json(
+        self,
+        downloader: PenaltyKillDownloader,
+    ) -> None:
+        """Test parsing with invalid JSON."""
+        html = """
+        <!DOCTYPE html>
+        <html>
+        <body>
+            <script id="__NEXT_DATA__">
+            {invalid json}
+            </script>
+        </body>
+        </html>
+        """
+        soup = BeautifulSoup(html, "lxml")
+
+        players = downloader._parse_from_json(soup, "pk1")
+        assert players == []
+
+
+class TestParseFromHtml:
+    """Tests for HTML attribute parsing."""
+
+    def test_parse_from_data_attributes(
+        self,
+        downloader: PenaltyKillDownloader,
+        html_with_data_attributes: str,
+    ) -> None:
+        """Test parsing from data-group attributes."""
+        soup = BeautifulSoup(html_with_data_attributes, "lxml")
+
+        pk1_players = downloader._parse_from_html_data(soup, "pk1")
+        assert len(pk1_players) == 4
+        # Players are found via links inside the data-group div
+        assert any("Scott Laughton" in p.name for p in pk1_players)
+
+    def test_parse_no_data_attributes(
+        self,
+        downloader: PenaltyKillDownloader,
+    ) -> None:
+        """Test parsing when no data attributes exist."""
+        html = "<!DOCTYPE html><html><body><div>No data</div></body></html>"
+        soup = BeautifulSoup(html, "lxml")
+
+        players = downloader._parse_from_html_data(soup, "pk1")
+        assert players == []
+
+
+class TestParseFromStructure:
+    """Tests for structure-based parsing."""
+
+    def test_parse_from_section_headers(
+        self,
+        downloader: PenaltyKillDownloader,
+        html_with_section_structure: str,
+    ) -> None:
+        """Test parsing from section headers."""
+        soup = BeautifulSoup(html_with_section_structure, "lxml")
+
+        pk1_players = downloader._parse_from_structure(soup, "pk1")
+        assert len(pk1_players) == 4
+        assert pk1_players[0].name == "Player One"
+
+    def test_parse_no_matching_structure(
+        self,
+        downloader: PenaltyKillDownloader,
+    ) -> None:
+        """Test parsing with no matching structure."""
+        html = "<!DOCTYPE html><html><body><p>No PK data</p></body></html>"
+        soup = BeautifulSoup(html, "lxml")
+
+        players = downloader._parse_from_structure(soup, "pk1")
+        assert players == []
+
+
+# --- Helper Method Tests ---
+
+
+class TestHelperMethods:
+    """Tests for helper methods."""
+
+    def test_is_forward_with_position(self, downloader: PenaltyKillDownloader) -> None:
+        """Test _is_forward with position data."""
+        assert downloader._is_forward(PKPlayer(name="Test", position="C"))
+        assert downloader._is_forward(PKPlayer(name="Test", position="LW"))
+        assert downloader._is_forward(PKPlayer(name="Test", position="RW"))
+        assert downloader._is_forward(PKPlayer(name="Test", position="F"))
+        assert not downloader._is_forward(PKPlayer(name="Test", position="D"))
+
+    def test_is_forward_without_position(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test _is_forward defaults to True."""
+        assert downloader._is_forward(PKPlayer(name="Test"))
+
+    def test_is_defenseman_with_position(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test _is_defenseman with position data."""
+        assert downloader._is_defenseman(PKPlayer(name="Test", position="D"))
+        assert downloader._is_defenseman(PKPlayer(name="Test", position="LD"))
+        assert downloader._is_defenseman(PKPlayer(name="Test", position="RD"))
+        assert not downloader._is_defenseman(PKPlayer(name="Test", position="C"))
+
+    def test_is_defenseman_without_position(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test _is_defenseman defaults to False."""
+        assert not downloader._is_defenseman(PKPlayer(name="Test"))
+
+    def test_dict_to_player(self, downloader: PenaltyKillDownloader) -> None:
+        """Test converting dict to PKPlayer."""
+        data = {
+            "name": "Test Player",
+            "jerseyNumber": 99,
+            "position": "C",
+            "playerId": "12345",
+        }
+        player = downloader._dict_to_player(data)
+
+        assert player is not None
+        assert player.name == "Test Player"
+        assert player.jersey_number == 99
+        assert player.position == "C"
+        assert player.player_id == "12345"
+
+    def test_dict_to_player_alternative_keys(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test dict_to_player with alternative key names."""
+        data = {
+            "playerName": "Alt Player",
+            "number": "77",
+            "positionCode": "D",
+            "id": 99999,
+        }
+        player = downloader._dict_to_player(data)
+
+        assert player is not None
+        assert player.name == "Alt Player"
+        assert player.jersey_number == 77
+        assert player.position == "D"
+        assert player.player_id == "99999"
+
+    def test_dict_to_player_no_name(self, downloader: PenaltyKillDownloader) -> None:
+        """Test dict_to_player returns None without name."""
+        data = {"jerseyNumber": 99}
+        player = downloader._dict_to_player(data)
+        assert player is None
+
+
+class TestExtractPlayerFromElement:
+    """Tests for extracting players from HTML elements."""
+
+    def test_extract_from_link(self, downloader: PenaltyKillDownloader) -> None:
+        """Test extracting from player link."""
+        html = '<a href="/players/news/test-player/12345">#99 Test Player</a>'
+        soup = BeautifulSoup(html, "lxml")
+        element = soup.find("a")
+        assert element is not None
+
+        player = downloader._extract_player_from_element(element)
+
+        assert player is not None
+        assert player.name == "#99 Test Player"
+        assert player.player_id == "12345"
+        assert player.jersey_number == 99
+
+    def test_extract_no_link(self, downloader: PenaltyKillDownloader) -> None:
+        """Test extracting from non-link element."""
+        html = "<span>Some Player</span>"
+        soup = BeautifulSoup(html, "lxml")
+        element = soup.find("span")
+        assert element is not None
+
+        player = downloader._extract_player_from_element(element)
+
+        assert player is not None
+        assert player.name == "Some Player"
+
+
+# --- Serialization Tests ---
+
+
+class TestSerialization:
+    """Tests for dictionary conversion."""
+
+    def test_player_to_dict(self, downloader: PenaltyKillDownloader) -> None:
+        """Test converting player to dict."""
+        player = PKPlayer(
+            name="Test Player",
+            jersey_number=99,
+            position="C",
+            player_id="12345",
+        )
+        result = downloader._player_to_dict(player)
+
+        assert result == {
+            "name": "Test Player",
+            "jersey_number": 99,
+            "position": "C",
+            "player_id": "12345",
+        }
+
+    def test_unit_to_dict(self, downloader: PenaltyKillDownloader) -> None:
+        """Test converting unit to dict."""
+        unit = PenaltyKillUnit(
+            unit_number=1,
+            forwards=(PKPlayer(name="Forward 1"),),
+            defensemen=(PKPlayer(name="Defenseman 1"),),
+        )
+        result = downloader._unit_to_dict(unit)
+
+        assert result["unit_number"] == 1
+        assert len(result["forwards"]) == 1
+        assert len(result["defensemen"]) == 1
+
+    def test_to_dict(self, downloader: PenaltyKillDownloader) -> None:
+        """Test converting TeamPenaltyKill to dict."""
+        pk1 = PenaltyKillUnit(unit_number=1, forwards=(), defensemen=())
+        now = datetime.now(UTC)
+
+        team_pk = TeamPenaltyKill(
+            team_id=10,
+            team_abbreviation="TOR",
+            pk1=pk1,
+            pk2=None,
+            fetched_at=now,
+        )
+        result = downloader._to_dict(team_pk)
+
+        assert result["team_id"] == 10
+        assert result["team_abbreviation"] == "TOR"
+        assert result["pk1"] is not None
+        assert result["pk2"] is None
+        assert result["fetched_at"] == now.isoformat()
+
+
+# --- Parse Page Tests ---
+
+
+class TestParsePage:
+    """Tests for the main _parse_page method."""
+
+    @pytest.mark.asyncio
+    async def test_parse_page_with_next_data(
+        self,
+        downloader: PenaltyKillDownloader,
+        html_with_next_data: str,
+    ) -> None:
+        """Test _parse_page with Next.js data."""
+        soup = BeautifulSoup(html_with_next_data, "lxml")
+
+        result = await downloader._parse_page(soup, 10)
+
+        assert result["team_id"] == 10
+        assert result["team_abbreviation"] == "TOR"
+        assert result["pk1"] is not None
+        assert result["pk2"] is not None
+        assert len(result["pk1"]["forwards"]) >= 0
+        assert len(result["pk1"]["defensemen"]) >= 0
+
+    @pytest.mark.asyncio
+    async def test_parse_page_no_data(
+        self,
+        downloader: PenaltyKillDownloader,
+    ) -> None:
+        """Test _parse_page with no PK data."""
+        html = "<!DOCTYPE html><html><body></body></html>"
+        soup = BeautifulSoup(html, "lxml")
+
+        result = await downloader._parse_page(soup, 10)
+
+        assert result["team_id"] == 10
+        assert result["pk1"] is None
+        assert result["pk2"] is None
+
+
+# --- Integration Tests ---
+
+
+class TestDownloadTeam:
+    """Tests for download_team method."""
+
+    @pytest.mark.asyncio
+    async def test_download_team_success(
+        self,
+        downloader: PenaltyKillDownloader,
+        html_with_next_data: str,
+    ) -> None:
+        """Test successful team download."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.status = 200
+        mock_response.content = html_with_next_data.encode("utf-8")
+
+        with patch.object(downloader, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            result = await downloader.download_team(10)
+
+            assert result.status.value == "completed"
+            assert result.data["team_id"] == 10
+            assert result.data["team_abbreviation"] == "TOR"
+
+    @pytest.mark.asyncio
+    async def test_download_team_failure(
+        self,
+        downloader: PenaltyKillDownloader,
+    ) -> None:
+        """Test failed team download."""
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.status = 404
+
+        with patch.object(downloader, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            with pytest.raises(
+                Exception,
+                match="Failed to fetch team page|download",
+            ):
+                await downloader.download_team(10)
+
+
+# --- Edge Cases ---
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_parse_pk_unit_no_players(self, downloader: PenaltyKillDownloader) -> None:
+        """Test parsing unit with no players found."""
+        html = "<!DOCTYPE html><html><body></body></html>"
+        soup = BeautifulSoup(html, "lxml")
+
+        result = downloader._parse_pk_unit(soup, 1)
+        assert result is None
+
+    def test_extract_names_from_text(self, downloader: PenaltyKillDownloader) -> None:
+        """Test extracting names via regex."""
+        text = '"playerName": "John Doe", "name": "Jane Smith"'
+        players = downloader._extract_names_from_text(text)
+
+        assert len(players) == 2
+        assert players[0].name == "John Doe"
+        assert players[1].name == "Jane Smith"
+
+    def test_extract_names_from_text_short_names_filtered(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test that very short names are filtered out."""
+        text = '"name": "AB", "name": "Joe Smith"'
+        players = downloader._extract_names_from_text(text)
+
+        # "AB" should be filtered (len <= 2)
+        assert len(players) == 1
+        assert players[0].name == "Joe Smith"
+
+    def test_search_for_group_nested(self, downloader: PenaltyKillDownloader) -> None:
+        """Test deep search for group data."""
+        data = {
+            "level1": {
+                "level2": {
+                    "items": [{"groupIdentifier": "pk1", "players": [{"name": "Test"}]}]
+                }
+            }
+        }
+        players = downloader._search_for_group(data, "pk1")
+        assert len(players) == 1
+        assert players[0].name == "Test"
+
+    def test_search_for_group_in_list(self, downloader: PenaltyKillDownloader) -> None:
+        """Test search for group when data is in a list."""
+        data = [
+            {"groupIdentifier": "other"},
+            {"groupIdentifier": "pk1", "players": [{"name": "Test Player"}]},
+        ]
+        players = downloader._search_for_group(data, "pk1")
+        assert len(players) == 1
+        assert players[0].name == "Test Player"
+
+    def test_deep_search_max_depth(self, downloader: PenaltyKillDownloader) -> None:
+        """Test deep search respects max depth."""
+        # Create deeply nested structure
+        data: dict[str, Any] = {"groupIdentifier": "pk1", "players": []}
+        for _ in range(15):
+            data = {"nested": data}
+
+        # Should not find with shallow depth
+        players = downloader._deep_search_group(data, "pk1", max_depth=5)
+        assert players == []
+
+    def test_deep_search_in_list(self, downloader: PenaltyKillDownloader) -> None:
+        """Test deep search through lists."""
+        data = {
+            "formations": [
+                {"groupIdentifier": "other"},
+                {"groupIdentifier": "pk1", "players": [{"name": "Found"}]},
+            ]
+        }
+        players = downloader._deep_search_group(data, "pk1")
+        assert len(players) == 1
+        assert players[0].name == "Found"
+
+    def test_extract_players_from_group_with_skaters(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test extracting players from group with 'skaters' key."""
+        group = {
+            "groupIdentifier": "pk1",
+            "skaters": [
+                {"name": "Skater One", "position": "C"},
+                {"name": "Skater Two", "position": "D"},
+            ],
+        }
+        players = downloader._extract_players_from_group(group)
+        assert len(players) == 2
+        assert players[0].name == "Skater One"
+
+    def test_extract_players_from_group_with_position_slots(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test extracting players from position slot keys."""
+        group = {
+            "groupIdentifier": "pk1",
+            "sk1": {"name": "Player One"},
+            "sk2": {"name": "Player Two"},
+            "sk3": {"name": "Player Three"},
+            "sk4": {"name": "Player Four"},
+        }
+        players = downloader._extract_players_from_group(group)
+        assert len(players) == 4
+
+    def test_extract_player_script_with_groupidentifier(
+        self,
+        downloader: PenaltyKillDownloader,
+    ) -> None:
+        """Test parsing from script with groupIdentifier pattern."""
+        html = """
+        <!DOCTYPE html>
+        <html>
+        <body>
+            <script>
+            var data = {"groupIdentifier":"pk1","players":[{"name":"Script Player"}]};
+            </script>
+        </body>
+        </html>
+        """
+        soup = BeautifulSoup(html, "lxml")
+        players = downloader._parse_from_json(soup, "pk1")
+        assert len(players) == 1
+        assert players[0].name == "Script Player"
+
+    def test_extract_player_from_element_with_position_class(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test extracting player with position from CSS class."""
+        html = '<div class="forward"><a href="/players/news/test/123">Test Forward</a></div>'
+        soup = BeautifulSoup(html, "lxml")
+        element = soup.find("div")
+        assert element is not None
+
+        player = downloader._extract_player_from_element(element)
+        assert player is not None
+        assert player.name == "Test Forward"
+        assert player.position == "F"
+
+    def test_extract_player_from_element_with_defense_class(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test extracting player with defense position from CSS class."""
+        html = '<div class="defense"><a href="/players/news/test/456">Test Defense</a></div>'
+        soup = BeautifulSoup(html, "lxml")
+        element = soup.find("div")
+        assert element is not None
+
+        player = downloader._extract_player_from_element(element)
+        assert player is not None
+        assert player.name == "Test Defense"
+        assert player.position == "D"
+
+    def test_extract_player_from_element_with_data_position(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test extracting player with data-position attribute."""
+        html = '<a href="/players/news/test/789" data-position="LW">Left Winger</a>'
+        soup = BeautifulSoup(html, "lxml")
+        element = soup.find("a")
+        assert element is not None
+
+        player = downloader._extract_player_from_element(element)
+        assert player is not None
+        assert player.name == "Left Winger"
+        assert player.position == "LW"
+
+    def test_parse_from_html_data_with_groupidentifier(
+        self,
+        downloader: PenaltyKillDownloader,
+    ) -> None:
+        """Test parsing from data-groupidentifier attribute."""
+        html = """
+        <!DOCTYPE html>
+        <html>
+        <body>
+            <div data-groupidentifier="pk1">
+                <a href="/players/news/player1/111">Player One</a>
+                <a href="/players/news/player2/222">Player Two</a>
+            </div>
+        </body>
+        </html>
+        """
+        soup = BeautifulSoup(html, "lxml")
+        players = downloader._parse_from_html_data(soup, "pk1")
+        assert len(players) == 2
+
+    def test_dict_to_player_with_fullname(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test dict_to_player with fullName key."""
+        data = {"fullName": "Full Name Player"}
+        player = downloader._dict_to_player(data)
+        assert player is not None
+        assert player.name == "Full Name Player"
+
+    def test_is_forward_uppercase_positions(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test _is_forward with uppercase position names."""
+        assert downloader._is_forward(PKPlayer(name="Test", position="CENTER"))
+        assert downloader._is_forward(PKPlayer(name="Test", position="FORWARD"))
+
+    def test_is_defenseman_uppercase_positions(
+        self, downloader: PenaltyKillDownloader
+    ) -> None:
+        """Test _is_defenseman with uppercase position names."""
+        assert downloader._is_defenseman(PKPlayer(name="Test", position="DEFENSE"))
+        assert downloader._is_defenseman(PKPlayer(name="Test", position="DEFENSEMAN"))


### PR DESCRIPTION
## Summary
- Implement PenaltyKillDownloader for parsing NHL penalty kill unit data
- Parse PK1 and PK2 units from DailyFaceoff line combinations page
- Multiple parsing strategies: JSON (__NEXT_DATA__), data attributes, HTML structure
- Separate forwards and defensemen in each unit
- Handle various DailyFaceoff page structures

## Data Classes
- `PKPlayer`: name, jersey_number, position, player_id
- `PenaltyKillUnit`: unit_number, forwards, defensemen
- `TeamPenaltyKill`: team_id, pk1, pk2, fetched_at

## Test Plan
- [x] Unit tests for PK parsing (49 tests)
- [x] Test coverage: 95% for penalty_kill.py

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)