### PR TITLE
feat(downloaders): Add DailyFaceoff Line Combinations Downloader (#103)

### DIFF
--- a/src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/__init__.py
@@ -5,29 +5,35 @@ information from DailyFaceoff.com.
 
 Available downloaders:
 - BaseDailyFaceoffDownloader: Base class for all DailyFaceoff downloaders
+- LineCombinationsDownloader: Line combinations (forward lines, defensive pairs, goalies)
 - PenaltyKillDownloader: Penalty kill unit configurations (PK1, PK2)
 - PowerPlayDownloader: Download power play unit configurations (PP1, PP2)
 
 Example usage:
     from nhl_api.downloaders.sources.dailyfaceoff import (
+        LineCombinationsDownloader,
         PenaltyKillDownloader,
         PowerPlayDownloader,
         DailyFaceoffConfig,
     )
 
-    config = DailyFaceoffConfig()
-    async with PenaltyKillDownloader(config) as downloader:
-        result = await downloader.download_team(10)  # Toronto
-
-    async with PowerPlayDownloader() as downloader:
+    async with LineCombinationsDownloader() as downloader:
         result = await downloader.download_team(6)  # Boston Bruins
-        print(result.data["pp1"])
+        print(result.data["forward_lines"])
 """
 
 from nhl_api.downloaders.sources.dailyfaceoff.base_dailyfaceoff_downloader import (
     DAILYFACEOFF_CONFIG,
     BaseDailyFaceoffDownloader,
     DailyFaceoffConfig,
+)
+from nhl_api.downloaders.sources.dailyfaceoff.line_combinations import (
+    DefensivePair,
+    ForwardLine,
+    GoalieDepth,
+    LineCombinationsDownloader,
+    PlayerInfo,
+    TeamLineup,
 )
 from nhl_api.downloaders.sources.dailyfaceoff.penalty_kill import (
     PenaltyKillDownloader,
@@ -53,6 +59,13 @@ __all__ = [
     "BaseDailyFaceoffDownloader",
     "DAILYFACEOFF_CONFIG",
     "DailyFaceoffConfig",
+    # Line Combinations
+    "LineCombinationsDownloader",
+    "ForwardLine",
+    "DefensivePair",
+    "GoalieDepth",
+    "PlayerInfo",
+    "TeamLineup",
     # Penalty Kill
     "PenaltyKillDownloader",
     "PenaltyKillUnit",

--- a/src/nhl_api/downloaders/sources/dailyfaceoff/line_combinations.py
+++ b/src/nhl_api/downloaders/sources/dailyfaceoff/line_combinations.py
@@ -1,0 +1,477 @@
+"""DailyFaceoff Line Combinations Downloader.
+
+This module provides a downloader for extracting even-strength line combinations
+(forward lines, defensive pairs, and goalie depth) from DailyFaceoff.com.
+
+Example usage:
+    config = DailyFaceoffConfig()
+    async with LineCombinationsDownloader(config) as downloader:
+        result = await downloader.download_team(6)  # Boston Bruins
+        print(result.data["forward_lines"])
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+
+from nhl_api.downloaders.sources.dailyfaceoff.base_dailyfaceoff_downloader import (
+    BaseDailyFaceoffDownloader,
+)
+
+if TYPE_CHECKING:
+    from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PlayerInfo:
+    """Basic player information.
+
+    Attributes:
+        player_id: DailyFaceoff player ID
+        name: Player's full name
+        jersey_number: Player's jersey number
+        position: Position identifier (lw, c, rw, ld, rd, g1, g2)
+    """
+
+    player_id: int
+    name: str
+    jersey_number: int
+    position: str
+
+
+@dataclass(frozen=True, slots=True)
+class ForwardLine:
+    """A forward line with three players.
+
+    Attributes:
+        line_number: Line number (1-4)
+        left_wing: Left wing player or None if empty
+        center: Center player or None if empty
+        right_wing: Right wing player or None if empty
+    """
+
+    line_number: int
+    left_wing: PlayerInfo | None
+    center: PlayerInfo | None
+    right_wing: PlayerInfo | None
+
+
+@dataclass(frozen=True, slots=True)
+class DefensivePair:
+    """A defensive pairing with two players.
+
+    Attributes:
+        pair_number: Pair number (1-3)
+        left_defense: Left defenseman or None if empty
+        right_defense: Right defenseman or None if empty
+    """
+
+    pair_number: int
+    left_defense: PlayerInfo | None
+    right_defense: PlayerInfo | None
+
+
+@dataclass(frozen=True, slots=True)
+class GoalieDepth:
+    """Goaltender depth chart.
+
+    Attributes:
+        starter: Starting goalie or None if empty
+        backup: Backup goalie or None if empty
+    """
+
+    starter: PlayerInfo | None
+    backup: PlayerInfo | None
+
+
+@dataclass(frozen=True, slots=True)
+class TeamLineup:
+    """Complete team lineup configuration.
+
+    Attributes:
+        team_id: NHL team ID
+        team_abbreviation: Team abbreviation (e.g., "BOS")
+        forward_lines: List of 4 forward lines
+        defensive_pairs: List of 3 defensive pairs
+        goalies: Goalie depth chart
+        fetched_at: Timestamp when data was fetched
+    """
+
+    team_id: int
+    team_abbreviation: str
+    forward_lines: tuple[ForwardLine, ...]
+    defensive_pairs: tuple[DefensivePair, ...]
+    goalies: GoalieDepth
+    fetched_at: datetime
+
+
+class LineCombinationsDownloader(BaseDailyFaceoffDownloader):
+    """Downloader for DailyFaceoff line combinations data.
+
+    This downloader extracts even-strength line combinations including:
+    - 4 forward lines (LW, C, RW)
+    - 3 defensive pairs (LD, RD)
+    - Goalie depth (starter, backup)
+
+    The data is embedded as JSON in the page's __NEXT_DATA__ script tag.
+
+    Example:
+        config = DailyFaceoffConfig()
+        async with LineCombinationsDownloader(config) as downloader:
+            # Download single team
+            result = await downloader.download_team(6)  # Boston
+            lineup = result.data
+            print(lineup["forward_lines"])
+
+            # Download all teams
+            async for result in downloader.download_all_teams():
+                print(result.data["team_abbreviation"])
+    """
+
+    @property
+    def data_type(self) -> str:
+        """Return data type identifier."""
+        return "line_combinations"
+
+    @property
+    def page_path(self) -> str:
+        """Return URL path for line combinations page."""
+        return "line-combinations"
+
+    async def _parse_page(self, soup: BeautifulSoup, team_id: int) -> dict[str, Any]:
+        """Parse line combinations data from DailyFaceoff page.
+
+        Args:
+            soup: Parsed BeautifulSoup document
+            team_id: NHL team ID
+
+        Returns:
+            Dictionary containing parsed lineup data
+        """
+        abbreviation = self._get_team_abbreviation(team_id)
+
+        # Extract __NEXT_DATA__ script content
+        next_data = self._extract_next_data(soup)
+        if next_data is None:
+            logger.warning(
+                "%s: No __NEXT_DATA__ found for team %s",
+                self.source_name,
+                abbreviation,
+            )
+            return self._empty_result(team_id, abbreviation)
+
+        # Navigate to players array
+        players_data = self._get_players_from_next_data(next_data)
+        if not players_data:
+            logger.warning(
+                "%s: No players data found for team %s",
+                self.source_name,
+                abbreviation,
+            )
+            return self._empty_result(team_id, abbreviation)
+
+        # Parse forward lines (f1, f2, f3, f4)
+        forward_lines = tuple(
+            self._parse_forward_line(players_data, f"f{i}", i) for i in range(1, 5)
+        )
+
+        # Parse defensive pairs (d1, d2, d3)
+        defensive_pairs = tuple(
+            self._parse_defensive_pair(players_data, f"d{i}", i) for i in range(1, 4)
+        )
+
+        # Parse goalies
+        goalies = self._parse_goalies(players_data)
+
+        lineup = TeamLineup(
+            team_id=team_id,
+            team_abbreviation=abbreviation,
+            forward_lines=forward_lines,
+            defensive_pairs=defensive_pairs,
+            goalies=goalies,
+            fetched_at=datetime.now(UTC),
+        )
+
+        return self._to_dict(lineup)
+
+    def _extract_next_data(self, soup: BeautifulSoup) -> dict[str, Any] | None:
+        """Extract JSON from __NEXT_DATA__ script tag.
+
+        Args:
+            soup: Parsed BeautifulSoup document
+
+        Returns:
+            Parsed JSON data or None if not found
+        """
+        script_tag = soup.find("script", {"id": "__NEXT_DATA__"})
+        if not script_tag or not script_tag.string:
+            return None
+
+        try:
+            return cast(dict[str, Any], json.loads(script_tag.string))
+        except json.JSONDecodeError as e:
+            logger.warning("Failed to parse __NEXT_DATA__ JSON: %s", e)
+            return None
+
+    def _get_players_from_next_data(
+        self, next_data: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Navigate to players array in NEXT_DATA structure.
+
+        The path is: props.pageProps.combinations.players
+
+        Args:
+            next_data: Parsed __NEXT_DATA__ JSON
+
+        Returns:
+            List of player dictionaries or empty list
+        """
+        try:
+            players = (
+                next_data.get("props", {})
+                .get("pageProps", {})
+                .get("combinations", {})
+                .get("players", [])
+            )
+            return cast(list[dict[str, Any]], players)
+        except (AttributeError, TypeError):
+            return []
+
+    def _parse_player(self, player_data: dict[str, Any]) -> PlayerInfo | None:
+        """Parse a single player from player data.
+
+        Args:
+            player_data: Player dictionary from JSON
+
+        Returns:
+            PlayerInfo or None if required fields missing
+        """
+        player_id = player_data.get("playerId")
+        name = player_data.get("name")
+        jersey_number = player_data.get("jerseyNumber")
+        position = player_data.get("positionIdentifier")
+
+        # Require minimum fields - use isinstance checks for type safety
+        if (
+            not isinstance(player_id, int)
+            or not isinstance(name, str)
+            or not isinstance(position, str)
+        ):
+            return None
+
+        return PlayerInfo(
+            player_id=player_id,
+            name=name,
+            jersey_number=jersey_number if isinstance(jersey_number, int) else 0,
+            position=position,
+        )
+
+    def _get_player_by_position(
+        self,
+        players_data: list[dict[str, Any]],
+        group_id: str,
+        position_id: str,
+    ) -> PlayerInfo | None:
+        """Find a player by group and position.
+
+        Args:
+            players_data: List of all player dictionaries
+            group_id: Group identifier (f1, f2, d1, etc.)
+            position_id: Position identifier (lw, c, rw, ld, rd, g1, g2)
+
+        Returns:
+            PlayerInfo or None if not found
+        """
+        for player_data in players_data:
+            if (
+                player_data.get("groupIdentifier") == group_id
+                and player_data.get("positionIdentifier") == position_id
+            ):
+                return self._parse_player(player_data)
+        return None
+
+    def _parse_forward_line(
+        self,
+        players_data: list[dict[str, Any]],
+        group_id: str,
+        line_number: int,
+    ) -> ForwardLine:
+        """Parse a forward line from players data.
+
+        Args:
+            players_data: List of all player dictionaries
+            group_id: Group identifier (f1, f2, f3, f4)
+            line_number: Line number (1-4)
+
+        Returns:
+            ForwardLine with players in each position
+        """
+        return ForwardLine(
+            line_number=line_number,
+            left_wing=self._get_player_by_position(players_data, group_id, "lw"),
+            center=self._get_player_by_position(players_data, group_id, "c"),
+            right_wing=self._get_player_by_position(players_data, group_id, "rw"),
+        )
+
+    def _parse_defensive_pair(
+        self,
+        players_data: list[dict[str, Any]],
+        group_id: str,
+        pair_number: int,
+    ) -> DefensivePair:
+        """Parse a defensive pair from players data.
+
+        Args:
+            players_data: List of all player dictionaries
+            group_id: Group identifier (d1, d2, d3)
+            pair_number: Pair number (1-3)
+
+        Returns:
+            DefensivePair with players in each position
+        """
+        return DefensivePair(
+            pair_number=pair_number,
+            left_defense=self._get_player_by_position(players_data, group_id, "ld"),
+            right_defense=self._get_player_by_position(players_data, group_id, "rd"),
+        )
+
+    def _parse_goalies(self, players_data: list[dict[str, Any]]) -> GoalieDepth:
+        """Parse goalie depth from players data.
+
+        Args:
+            players_data: List of all player dictionaries
+
+        Returns:
+            GoalieDepth with starter and backup
+        """
+        return GoalieDepth(
+            starter=self._get_player_by_position(players_data, "g", "g1"),
+            backup=self._get_player_by_position(players_data, "g", "g2"),
+        )
+
+    def _empty_result(self, team_id: int, abbreviation: str) -> dict[str, Any]:
+        """Create empty result when parsing fails.
+
+        Args:
+            team_id: NHL team ID
+            abbreviation: Team abbreviation
+
+        Returns:
+            Dictionary with empty lineup data
+        """
+        empty_lines = tuple(
+            ForwardLine(line_number=i, left_wing=None, center=None, right_wing=None)
+            for i in range(1, 5)
+        )
+        empty_pairs = tuple(
+            DefensivePair(pair_number=i, left_defense=None, right_defense=None)
+            for i in range(1, 4)
+        )
+        empty_goalies = GoalieDepth(starter=None, backup=None)
+
+        lineup = TeamLineup(
+            team_id=team_id,
+            team_abbreviation=abbreviation,
+            forward_lines=empty_lines,
+            defensive_pairs=empty_pairs,
+            goalies=empty_goalies,
+            fetched_at=datetime.now(UTC),
+        )
+        return self._to_dict(lineup)
+
+    def _to_dict(self, lineup: TeamLineup) -> dict[str, Any]:
+        """Convert TeamLineup to dictionary.
+
+        Args:
+            lineup: TeamLineup dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "forward_lines": [
+                self._forward_line_to_dict(fl) for fl in lineup.forward_lines
+            ],
+            "defensive_pairs": [
+                self._defensive_pair_to_dict(dp) for dp in lineup.defensive_pairs
+            ],
+            "goalies": self._goalies_to_dict(lineup.goalies),
+            "fetched_at": lineup.fetched_at.isoformat(),
+        }
+
+    def _forward_line_to_dict(self, line: ForwardLine) -> dict[str, Any]:
+        """Convert ForwardLine to dictionary.
+
+        Args:
+            line: ForwardLine dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "line_number": line.line_number,
+            "left_wing": self._player_to_dict(line.left_wing)
+            if line.left_wing
+            else None,
+            "center": self._player_to_dict(line.center) if line.center else None,
+            "right_wing": self._player_to_dict(line.right_wing)
+            if line.right_wing
+            else None,
+        }
+
+    def _defensive_pair_to_dict(self, pair: DefensivePair) -> dict[str, Any]:
+        """Convert DefensivePair to dictionary.
+
+        Args:
+            pair: DefensivePair dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "pair_number": pair.pair_number,
+            "left_defense": self._player_to_dict(pair.left_defense)
+            if pair.left_defense
+            else None,
+            "right_defense": self._player_to_dict(pair.right_defense)
+            if pair.right_defense
+            else None,
+        }
+
+    def _goalies_to_dict(self, goalies: GoalieDepth) -> dict[str, Any]:
+        """Convert GoalieDepth to dictionary.
+
+        Args:
+            goalies: GoalieDepth dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "starter": self._player_to_dict(goalies.starter)
+            if goalies.starter
+            else None,
+            "backup": self._player_to_dict(goalies.backup) if goalies.backup else None,
+        }
+
+    def _player_to_dict(self, player: PlayerInfo) -> dict[str, Any]:
+        """Convert PlayerInfo to dictionary.
+
+        Args:
+            player: PlayerInfo dataclass
+
+        Returns:
+            Dictionary representation
+        """
+        return {
+            "player_id": player.player_id,
+            "name": player.name,
+            "jersey_number": player.jersey_number,
+            "position": player.position,
+        }

--- a/tests/fixtures/dailyfaceoff/line_combinations_full.html
+++ b/tests/fixtures/dailyfaceoff/line_combinations_full.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Boston Bruins Line Combinations - DailyFaceoff</title>
+</head>
+<body>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "team": {
+        "id": 6,
+        "name": "Boston Bruins",
+        "abbreviation": "BOS"
+      },
+      "combinations": {
+        "players": [
+          {
+            "playerId": 1001,
+            "name": "Brad Marchand",
+            "jerseyNumber": 63,
+            "positionIdentifier": "lw",
+            "positionName": "Left Wing",
+            "groupIdentifier": "f1",
+            "groupName": "1st Line"
+          },
+          {
+            "playerId": 1002,
+            "name": "Elias Lindholm",
+            "jerseyNumber": 28,
+            "positionIdentifier": "c",
+            "positionName": "Center",
+            "groupIdentifier": "f1",
+            "groupName": "1st Line"
+          },
+          {
+            "playerId": 1003,
+            "name": "David Pastrnak",
+            "jerseyNumber": 88,
+            "positionIdentifier": "rw",
+            "positionName": "Right Wing",
+            "groupIdentifier": "f1",
+            "groupName": "1st Line"
+          },
+          {
+            "playerId": 1011,
+            "name": "Pavel Zacha",
+            "jerseyNumber": 18,
+            "positionIdentifier": "lw",
+            "positionName": "Left Wing",
+            "groupIdentifier": "f2",
+            "groupName": "2nd Line"
+          },
+          {
+            "playerId": 1012,
+            "name": "Charlie Coyle",
+            "jerseyNumber": 13,
+            "positionIdentifier": "c",
+            "positionName": "Center",
+            "groupIdentifier": "f2",
+            "groupName": "2nd Line"
+          },
+          {
+            "playerId": 1013,
+            "name": "Morgan Geekie",
+            "jerseyNumber": 39,
+            "positionIdentifier": "rw",
+            "positionName": "Right Wing",
+            "groupIdentifier": "f2",
+            "groupName": "2nd Line"
+          },
+          {
+            "playerId": 1021,
+            "name": "Trent Frederic",
+            "jerseyNumber": 11,
+            "positionIdentifier": "lw",
+            "positionName": "Left Wing",
+            "groupIdentifier": "f3",
+            "groupName": "3rd Line"
+          },
+          {
+            "playerId": 1022,
+            "name": "Mark Kastelic",
+            "jerseyNumber": 47,
+            "positionIdentifier": "c",
+            "positionName": "Center",
+            "groupIdentifier": "f3",
+            "groupName": "3rd Line"
+          },
+          {
+            "playerId": 1023,
+            "name": "Justin Brazeau",
+            "jerseyNumber": 55,
+            "positionIdentifier": "rw",
+            "positionName": "Right Wing",
+            "groupIdentifier": "f3",
+            "groupName": "3rd Line"
+          },
+          {
+            "playerId": 1031,
+            "name": "John Beecher",
+            "jerseyNumber": 19,
+            "positionIdentifier": "lw",
+            "positionName": "Left Wing",
+            "groupIdentifier": "f4",
+            "groupName": "4th Line"
+          },
+          {
+            "playerId": 1032,
+            "name": "Patrick Brown",
+            "jerseyNumber": 38,
+            "positionIdentifier": "c",
+            "positionName": "Center",
+            "groupIdentifier": "f4",
+            "groupName": "4th Line"
+          },
+          {
+            "playerId": 1033,
+            "name": "Cole Koepke",
+            "jerseyNumber": 45,
+            "positionIdentifier": "rw",
+            "positionName": "Right Wing",
+            "groupIdentifier": "f4",
+            "groupName": "4th Line"
+          },
+          {
+            "playerId": 2001,
+            "name": "Charlie McAvoy",
+            "jerseyNumber": 73,
+            "positionIdentifier": "rd",
+            "positionName": "Right Defense",
+            "groupIdentifier": "d1",
+            "groupName": "1st Pair"
+          },
+          {
+            "playerId": 2002,
+            "name": "Hampus Lindholm",
+            "jerseyNumber": 27,
+            "positionIdentifier": "ld",
+            "positionName": "Left Defense",
+            "groupIdentifier": "d1",
+            "groupName": "1st Pair"
+          },
+          {
+            "playerId": 2011,
+            "name": "Mason Lohrei",
+            "jerseyNumber": 6,
+            "positionIdentifier": "ld",
+            "positionName": "Left Defense",
+            "groupIdentifier": "d2",
+            "groupName": "2nd Pair"
+          },
+          {
+            "playerId": 2012,
+            "name": "Brandon Carlo",
+            "jerseyNumber": 25,
+            "positionIdentifier": "rd",
+            "positionName": "Right Defense",
+            "groupIdentifier": "d2",
+            "groupName": "2nd Pair"
+          },
+          {
+            "playerId": 2021,
+            "name": "Nikita Zadorov",
+            "jerseyNumber": 91,
+            "positionIdentifier": "ld",
+            "positionName": "Left Defense",
+            "groupIdentifier": "d3",
+            "groupName": "3rd Pair"
+          },
+          {
+            "playerId": 2022,
+            "name": "Andrew Peeke",
+            "jerseyNumber": 52,
+            "positionIdentifier": "rd",
+            "positionName": "Right Defense",
+            "groupIdentifier": "d3",
+            "groupName": "3rd Pair"
+          },
+          {
+            "playerId": 3001,
+            "name": "Jeremy Swayman",
+            "jerseyNumber": 1,
+            "positionIdentifier": "g1",
+            "positionName": "Starting Goalie",
+            "groupIdentifier": "g",
+            "groupName": "Goalies"
+          },
+          {
+            "playerId": 3002,
+            "name": "Joonas Korpisalo",
+            "jerseyNumber": 70,
+            "positionIdentifier": "g2",
+            "positionName": "Backup Goalie",
+            "groupIdentifier": "g",
+            "groupName": "Goalies"
+          },
+          {
+            "playerId": 4001,
+            "name": "David Pastrnak",
+            "jerseyNumber": 88,
+            "positionIdentifier": "sk1",
+            "positionName": "Skater 1",
+            "groupIdentifier": "pp1",
+            "groupName": "1st Powerplay Unit"
+          },
+          {
+            "playerId": 4002,
+            "name": "Brad Marchand",
+            "jerseyNumber": 63,
+            "positionIdentifier": "sk2",
+            "positionName": "Skater 2",
+            "groupIdentifier": "pp1",
+            "groupName": "1st Powerplay Unit"
+          }
+        ]
+      }
+    }
+  }
+}
+</script>
+</body>
+</html>

--- a/tests/unit/downloaders/sources/dailyfaceoff/test_line_combinations.py
+++ b/tests/unit/downloaders/sources/dailyfaceoff/test_line_combinations.py
@@ -1,0 +1,688 @@
+"""Unit tests for LineCombinationsDownloader."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bs4 import BeautifulSoup
+
+from nhl_api.downloaders.base.protocol import DownloadStatus
+from nhl_api.downloaders.sources.dailyfaceoff import (
+    DefensivePair,
+    ForwardLine,
+    GoalieDepth,
+    LineCombinationsDownloader,
+    PlayerInfo,
+    TeamLineup,
+)
+
+# Path to fixtures
+FIXTURES_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent / "fixtures" / "dailyfaceoff"
+)
+
+
+class TestPlayerInfo:
+    """Tests for PlayerInfo dataclass."""
+
+    def test_create_player(self) -> None:
+        """Test creating a player info."""
+        player = PlayerInfo(
+            player_id=1001,
+            name="Brad Marchand",
+            jersey_number=63,
+            position="lw",
+        )
+        assert player.player_id == 1001
+        assert player.name == "Brad Marchand"
+        assert player.jersey_number == 63
+        assert player.position == "lw"
+
+    def test_player_is_frozen(self) -> None:
+        """Test that player is immutable."""
+        player = PlayerInfo(
+            player_id=1,
+            name="Test",
+            jersey_number=1,
+            position="c",
+        )
+        with pytest.raises(AttributeError):
+            player.name = "Changed"  # type: ignore[misc]
+
+
+class TestForwardLine:
+    """Tests for ForwardLine dataclass."""
+
+    def test_create_full_line(self) -> None:
+        """Test creating a complete forward line."""
+        lw = PlayerInfo(player_id=1, name="LW", jersey_number=1, position="lw")
+        c = PlayerInfo(player_id=2, name="C", jersey_number=2, position="c")
+        rw = PlayerInfo(player_id=3, name="RW", jersey_number=3, position="rw")
+
+        line = ForwardLine(line_number=1, left_wing=lw, center=c, right_wing=rw)
+        assert line.line_number == 1
+        assert line.left_wing is not None
+        assert line.center is not None
+        assert line.right_wing is not None
+
+    def test_create_partial_line(self) -> None:
+        """Test creating a line with missing players."""
+        line = ForwardLine(line_number=2, left_wing=None, center=None, right_wing=None)
+        assert line.line_number == 2
+        assert line.left_wing is None
+        assert line.center is None
+        assert line.right_wing is None
+
+    def test_line_is_frozen(self) -> None:
+        """Test that line is immutable."""
+        line = ForwardLine(line_number=1, left_wing=None, center=None, right_wing=None)
+        with pytest.raises(AttributeError):
+            line.line_number = 2  # type: ignore[misc]
+
+
+class TestDefensivePair:
+    """Tests for DefensivePair dataclass."""
+
+    def test_create_full_pair(self) -> None:
+        """Test creating a complete defensive pair."""
+        ld = PlayerInfo(player_id=1, name="LD", jersey_number=1, position="ld")
+        rd = PlayerInfo(player_id=2, name="RD", jersey_number=2, position="rd")
+
+        pair = DefensivePair(pair_number=1, left_defense=ld, right_defense=rd)
+        assert pair.pair_number == 1
+        assert pair.left_defense is not None
+        assert pair.right_defense is not None
+
+    def test_create_partial_pair(self) -> None:
+        """Test creating a pair with missing players."""
+        pair = DefensivePair(pair_number=3, left_defense=None, right_defense=None)
+        assert pair.pair_number == 3
+        assert pair.left_defense is None
+        assert pair.right_defense is None
+
+
+class TestGoalieDepth:
+    """Tests for GoalieDepth dataclass."""
+
+    def test_create_full_goalies(self) -> None:
+        """Test creating full goalie depth."""
+        starter = PlayerInfo(
+            player_id=1, name="Starter", jersey_number=30, position="g1"
+        )
+        backup = PlayerInfo(player_id=2, name="Backup", jersey_number=35, position="g2")
+
+        goalies = GoalieDepth(starter=starter, backup=backup)
+        assert goalies.starter is not None
+        assert goalies.backup is not None
+
+    def test_create_empty_goalies(self) -> None:
+        """Test creating empty goalie depth."""
+        goalies = GoalieDepth(starter=None, backup=None)
+        assert goalies.starter is None
+        assert goalies.backup is None
+
+
+class TestTeamLineup:
+    """Tests for TeamLineup dataclass."""
+
+    def test_create_lineup(self) -> None:
+        """Test creating team lineup."""
+        lines = tuple(
+            ForwardLine(line_number=i, left_wing=None, center=None, right_wing=None)
+            for i in range(1, 5)
+        )
+        pairs = tuple(
+            DefensivePair(pair_number=i, left_defense=None, right_defense=None)
+            for i in range(1, 4)
+        )
+        goalies = GoalieDepth(starter=None, backup=None)
+        now = datetime.now(UTC)
+
+        lineup = TeamLineup(
+            team_id=6,
+            team_abbreviation="BOS",
+            forward_lines=lines,
+            defensive_pairs=pairs,
+            goalies=goalies,
+            fetched_at=now,
+        )
+        assert lineup.team_id == 6
+        assert lineup.team_abbreviation == "BOS"
+        assert len(lineup.forward_lines) == 4
+        assert len(lineup.defensive_pairs) == 3
+        assert lineup.goalies is not None
+        assert lineup.fetched_at == now
+
+
+class TestLineCombinationsDownloader:
+    """Tests for LineCombinationsDownloader."""
+
+    def test_data_type(self) -> None:
+        """Test data_type property."""
+        downloader = LineCombinationsDownloader()
+        assert downloader.data_type == "line_combinations"
+
+    def test_page_path(self) -> None:
+        """Test page_path property."""
+        downloader = LineCombinationsDownloader()
+        assert downloader.page_path == "line-combinations"
+
+    def test_source_name(self) -> None:
+        """Test source_name property."""
+        downloader = LineCombinationsDownloader()
+        assert downloader.source_name == "dailyfaceoff_line_combinations"
+
+    def test_extract_next_data_valid(self) -> None:
+        """Test extracting __NEXT_DATA__ from valid HTML."""
+        html = """
+        <!DOCTYPE html>
+        <html>
+        <head></head>
+        <body>
+        <script id="__NEXT_DATA__" type="application/json">
+        {"props": {"pageProps": {"test": "data"}}}
+        </script>
+        </body>
+        </html>
+        """
+        soup = BeautifulSoup(html, "lxml")
+        downloader = LineCombinationsDownloader()
+        result = downloader._extract_next_data(soup)
+        assert result is not None
+        assert result["props"]["pageProps"]["test"] == "data"
+
+    def test_extract_next_data_missing(self) -> None:
+        """Test extracting __NEXT_DATA__ from HTML without it."""
+        html = "<html><body>No data here</body></html>"
+        soup = BeautifulSoup(html, "lxml")
+        downloader = LineCombinationsDownloader()
+        result = downloader._extract_next_data(soup)
+        assert result is None
+
+    def test_extract_next_data_invalid_json(self) -> None:
+        """Test extracting __NEXT_DATA__ with invalid JSON."""
+        html = """
+        <html>
+        <body>
+        <script id="__NEXT_DATA__" type="application/json">
+        {invalid json}
+        </script>
+        </body>
+        </html>
+        """
+        soup = BeautifulSoup(html, "lxml")
+        downloader = LineCombinationsDownloader()
+        result = downloader._extract_next_data(soup)
+        assert result is None
+
+    def test_get_players_from_next_data(self) -> None:
+        """Test navigating to players array."""
+        next_data: dict[str, Any] = {
+            "props": {"pageProps": {"combinations": {"players": [{"name": "Test"}]}}}
+        }
+        downloader = LineCombinationsDownloader()
+        result = downloader._get_players_from_next_data(next_data)
+        assert len(result) == 1
+        assert result[0]["name"] == "Test"
+
+    def test_get_players_from_next_data_missing_path(self) -> None:
+        """Test navigating when path doesn't exist."""
+        next_data: dict[str, Any] = {"props": {}}
+        downloader = LineCombinationsDownloader()
+        result = downloader._get_players_from_next_data(next_data)
+        assert result == []
+
+    def test_parse_player_valid(self) -> None:
+        """Test parsing a valid player."""
+        player_data = {
+            "playerId": 1001,
+            "name": "Brad Marchand",
+            "jerseyNumber": 63,
+            "positionIdentifier": "lw",
+        }
+        downloader = LineCombinationsDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is not None
+        assert player.player_id == 1001
+        assert player.name == "Brad Marchand"
+        assert player.jersey_number == 63
+        assert player.position == "lw"
+
+    def test_parse_player_missing_name(self) -> None:
+        """Test parsing player without required name field."""
+        player_data = {
+            "playerId": 1001,
+            "jerseyNumber": 63,
+            "positionIdentifier": "lw",
+        }
+        downloader = LineCombinationsDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is None
+
+    def test_parse_player_missing_player_id(self) -> None:
+        """Test parsing player without required playerId field."""
+        player_data = {
+            "name": "Test Player",
+            "jerseyNumber": 63,
+            "positionIdentifier": "lw",
+        }
+        downloader = LineCombinationsDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is None
+
+    def test_parse_player_no_jersey_number(self) -> None:
+        """Test parsing player without jersey number (uses 0)."""
+        player_data = {
+            "playerId": 1001,
+            "name": "Test Player",
+            "positionIdentifier": "lw",
+        }
+        downloader = LineCombinationsDownloader()
+        player = downloader._parse_player(player_data)
+        assert player is not None
+        assert player.jersey_number == 0
+
+    def test_get_player_by_position(self) -> None:
+        """Test finding a player by group and position."""
+        players_data = [
+            {
+                "playerId": 1,
+                "name": "LW",
+                "jerseyNumber": 1,
+                "positionIdentifier": "lw",
+                "groupIdentifier": "f1",
+            },
+            {
+                "playerId": 2,
+                "name": "C",
+                "jerseyNumber": 2,
+                "positionIdentifier": "c",
+                "groupIdentifier": "f1",
+            },
+        ]
+        downloader = LineCombinationsDownloader()
+        player = downloader._get_player_by_position(players_data, "f1", "c")
+        assert player is not None
+        assert player.name == "C"
+
+    def test_get_player_by_position_not_found(self) -> None:
+        """Test finding a player that doesn't exist."""
+        players_data = [
+            {
+                "playerId": 1,
+                "name": "LW",
+                "jerseyNumber": 1,
+                "positionIdentifier": "lw",
+                "groupIdentifier": "f1",
+            },
+        ]
+        downloader = LineCombinationsDownloader()
+        player = downloader._get_player_by_position(players_data, "f1", "rw")
+        assert player is None
+
+    def test_parse_forward_line(self) -> None:
+        """Test parsing a forward line."""
+        players_data = [
+            {
+                "playerId": 1,
+                "name": "LW",
+                "jerseyNumber": 1,
+                "positionIdentifier": "lw",
+                "groupIdentifier": "f1",
+            },
+            {
+                "playerId": 2,
+                "name": "C",
+                "jerseyNumber": 2,
+                "positionIdentifier": "c",
+                "groupIdentifier": "f1",
+            },
+            {
+                "playerId": 3,
+                "name": "RW",
+                "jerseyNumber": 3,
+                "positionIdentifier": "rw",
+                "groupIdentifier": "f1",
+            },
+        ]
+        downloader = LineCombinationsDownloader()
+        line = downloader._parse_forward_line(players_data, "f1", 1)
+        assert line.line_number == 1
+        assert line.left_wing is not None
+        assert line.left_wing.name == "LW"
+        assert line.center is not None
+        assert line.center.name == "C"
+        assert line.right_wing is not None
+        assert line.right_wing.name == "RW"
+
+    def test_parse_forward_line_partial(self) -> None:
+        """Test parsing an incomplete forward line."""
+        players_data = [
+            {
+                "playerId": 1,
+                "name": "C",
+                "jerseyNumber": 2,
+                "positionIdentifier": "c",
+                "groupIdentifier": "f2",
+            },
+        ]
+        downloader = LineCombinationsDownloader()
+        line = downloader._parse_forward_line(players_data, "f2", 2)
+        assert line.line_number == 2
+        assert line.left_wing is None
+        assert line.center is not None
+        assert line.right_wing is None
+
+    def test_parse_defensive_pair(self) -> None:
+        """Test parsing a defensive pair."""
+        players_data = [
+            {
+                "playerId": 1,
+                "name": "LD",
+                "jerseyNumber": 27,
+                "positionIdentifier": "ld",
+                "groupIdentifier": "d1",
+            },
+            {
+                "playerId": 2,
+                "name": "RD",
+                "jerseyNumber": 73,
+                "positionIdentifier": "rd",
+                "groupIdentifier": "d1",
+            },
+        ]
+        downloader = LineCombinationsDownloader()
+        pair = downloader._parse_defensive_pair(players_data, "d1", 1)
+        assert pair.pair_number == 1
+        assert pair.left_defense is not None
+        assert pair.left_defense.name == "LD"
+        assert pair.right_defense is not None
+        assert pair.right_defense.name == "RD"
+
+    def test_parse_goalies(self) -> None:
+        """Test parsing goalie depth."""
+        players_data = [
+            {
+                "playerId": 1,
+                "name": "Starter",
+                "jerseyNumber": 1,
+                "positionIdentifier": "g1",
+                "groupIdentifier": "g",
+            },
+            {
+                "playerId": 2,
+                "name": "Backup",
+                "jerseyNumber": 70,
+                "positionIdentifier": "g2",
+                "groupIdentifier": "g",
+            },
+        ]
+        downloader = LineCombinationsDownloader()
+        goalies = downloader._parse_goalies(players_data)
+        assert goalies.starter is not None
+        assert goalies.starter.name == "Starter"
+        assert goalies.backup is not None
+        assert goalies.backup.name == "Backup"
+
+    def test_empty_result(self) -> None:
+        """Test creating empty result."""
+        downloader = LineCombinationsDownloader()
+        result = downloader._empty_result(6, "BOS")
+
+        assert "forward_lines" in result
+        assert "defensive_pairs" in result
+        assert "goalies" in result
+        assert "fetched_at" in result
+        assert len(result["forward_lines"]) == 4
+        assert len(result["defensive_pairs"]) == 3
+
+    def test_to_dict_converts_lineup(self) -> None:
+        """Test converting lineup to dictionary."""
+        lw = PlayerInfo(player_id=1, name="LW", jersey_number=63, position="lw")
+        line = ForwardLine(line_number=1, left_wing=lw, center=None, right_wing=None)
+        lines = (line,) + tuple(
+            ForwardLine(line_number=i, left_wing=None, center=None, right_wing=None)
+            for i in range(2, 5)
+        )
+        pairs = tuple(
+            DefensivePair(pair_number=i, left_defense=None, right_defense=None)
+            for i in range(1, 4)
+        )
+        goalies = GoalieDepth(starter=None, backup=None)
+        now = datetime.now(UTC)
+
+        lineup = TeamLineup(
+            team_id=6,
+            team_abbreviation="BOS",
+            forward_lines=lines,
+            defensive_pairs=pairs,
+            goalies=goalies,
+            fetched_at=now,
+        )
+        downloader = LineCombinationsDownloader()
+        result = downloader._to_dict(lineup)
+
+        assert result["forward_lines"][0]["line_number"] == 1
+        assert result["forward_lines"][0]["left_wing"]["name"] == "LW"
+        assert result["forward_lines"][0]["center"] is None
+        assert result["fetched_at"] == now.isoformat()
+
+    def test_player_to_dict(self) -> None:
+        """Test converting player to dict."""
+        player = PlayerInfo(
+            player_id=1001,
+            name="Brad Marchand",
+            jersey_number=63,
+            position="lw",
+        )
+        downloader = LineCombinationsDownloader()
+        result = downloader._player_to_dict(player)
+
+        assert result["player_id"] == 1001
+        assert result["name"] == "Brad Marchand"
+        assert result["jersey_number"] == 63
+        assert result["position"] == "lw"
+
+
+class TestLineCombinationsDownloaderIntegration:
+    """Integration tests using fixture file."""
+
+    @pytest.fixture
+    def fixture_html(self) -> str:
+        """Load fixture HTML."""
+        fixture_path = FIXTURES_DIR / "line_combinations_full.html"
+        return fixture_path.read_text()
+
+    @pytest.fixture
+    def fixture_soup(self, fixture_html: str) -> BeautifulSoup:
+        """Parse fixture HTML into BeautifulSoup."""
+        return BeautifulSoup(fixture_html, "lxml")
+
+    @pytest.mark.asyncio
+    async def test_parse_page_full(self, fixture_soup: BeautifulSoup) -> None:
+        """Test parsing full fixture page."""
+        downloader = LineCombinationsDownloader()
+        result = await downloader._parse_page(fixture_soup, 6)
+
+        # Check forward lines
+        assert "forward_lines" in result
+        assert len(result["forward_lines"]) == 4
+
+        # First line
+        line1 = result["forward_lines"][0]
+        assert line1["line_number"] == 1
+        assert line1["left_wing"]["name"] == "Brad Marchand"
+        assert line1["center"]["name"] == "Elias Lindholm"
+        assert line1["right_wing"]["name"] == "David Pastrnak"
+
+        # Check defensive pairs
+        assert "defensive_pairs" in result
+        assert len(result["defensive_pairs"]) == 3
+
+        pair1 = result["defensive_pairs"][0]
+        assert pair1["pair_number"] == 1
+        assert pair1["left_defense"]["name"] == "Hampus Lindholm"
+        assert pair1["right_defense"]["name"] == "Charlie McAvoy"
+
+        # Check goalies
+        assert "goalies" in result
+        assert result["goalies"]["starter"]["name"] == "Jeremy Swayman"
+        assert result["goalies"]["backup"]["name"] == "Joonas Korpisalo"
+
+    @pytest.mark.asyncio
+    async def test_parse_page_filters_non_lines(
+        self, fixture_soup: BeautifulSoup
+    ) -> None:
+        """Test that power play players are filtered out from lines."""
+        downloader = LineCombinationsDownloader()
+        result = await downloader._parse_page(fixture_soup, 6)
+
+        # PP players should not appear in line combinations
+        # (they have groupIdentifier pp1/pp2, not f1/f2/f3/f4)
+        for line in result["forward_lines"]:
+            for pos in ["left_wing", "center", "right_wing"]:
+                if line[pos]:
+                    # PP players have position sk1, sk2, etc.
+                    assert line[pos]["position"] in ["lw", "c", "rw"]
+
+    @pytest.mark.asyncio
+    async def test_parse_page_empty_html(self) -> None:
+        """Test parsing page with no __NEXT_DATA__."""
+        html = "<html><body>Empty</body></html>"
+        soup = BeautifulSoup(html, "lxml")
+        downloader = LineCombinationsDownloader()
+        result = await downloader._parse_page(soup, 6)
+
+        # Should return empty lines
+        assert all(
+            line["left_wing"] is None
+            and line["center"] is None
+            and line["right_wing"] is None
+            for line in result["forward_lines"]
+        )
+
+
+class TestLineCombinationsDownloaderDownload:
+    """Tests for download_team method."""
+
+    @pytest.fixture
+    def mock_response(self) -> MagicMock:
+        """Create mock HTTP response."""
+        fixture_path = FIXTURES_DIR / "line_combinations_full.html"
+        content = fixture_path.read_bytes()
+
+        response = MagicMock()
+        response.is_success = True
+        response.status = 200
+        response.content = content
+        return response
+
+    @pytest.mark.asyncio
+    async def test_download_team_success(self, mock_response: MagicMock) -> None:
+        """Test successful team download."""
+        downloader = LineCombinationsDownloader()
+        object.__setattr__(downloader, "_get", AsyncMock(return_value=mock_response))
+
+        result = await downloader.download_team(6)
+
+        assert result.status == DownloadStatus.COMPLETED
+        assert result.source == "dailyfaceoff_line_combinations"
+        assert result.data["team_id"] == 6
+        assert result.data["team_abbreviation"] == "BOS"
+        assert "forward_lines" in result.data
+        assert "defensive_pairs" in result.data
+        assert "goalies" in result.data
+
+    @pytest.mark.asyncio
+    async def test_download_team_http_error(self) -> None:
+        """Test handling HTTP error."""
+        response = MagicMock()
+        response.is_success = False
+        response.status = 404
+
+        downloader = LineCombinationsDownloader()
+        object.__setattr__(downloader, "_get", AsyncMock(return_value=response))
+
+        from nhl_api.downloaders.base.protocol import DownloadError
+
+        with pytest.raises(DownloadError, match="HTTP 404"):
+            await downloader.download_team(6)
+
+    @pytest.mark.asyncio
+    async def test_download_team_invalid_html(self) -> None:
+        """Test handling invalid HTML response."""
+        response = MagicMock()
+        response.is_success = True
+        response.status = 200
+        response.content = b'{"json": "not html"}'
+
+        downloader = LineCombinationsDownloader()
+        object.__setattr__(downloader, "_get", AsyncMock(return_value=response))
+
+        from nhl_api.downloaders.base.protocol import DownloadError
+
+        with pytest.raises(DownloadError, match="not valid HTML"):
+            await downloader.download_team(6)
+
+
+class TestLineCombinationsDownloaderBulk:
+    """Tests for download_all_teams method."""
+
+    @pytest.fixture
+    def mock_response(self) -> MagicMock:
+        """Create mock HTTP response."""
+        fixture_path = FIXTURES_DIR / "line_combinations_full.html"
+        content = fixture_path.read_bytes()
+
+        response = MagicMock()
+        response.is_success = True
+        response.status = 200
+        response.content = content
+        return response
+
+    @pytest.mark.asyncio
+    async def test_download_all_teams(self, mock_response: MagicMock) -> None:
+        """Test downloading all teams."""
+        # Only test with 3 teams for speed
+        downloader = LineCombinationsDownloader(team_ids=[6, 10, 1])
+        object.__setattr__(downloader, "_get", AsyncMock(return_value=mock_response))
+
+        results = []
+        async for result in downloader.download_all_teams():
+            results.append(result)
+
+        assert len(results) == 3
+        assert all(r.status == DownloadStatus.COMPLETED for r in results)
+
+    @pytest.mark.asyncio
+    async def test_download_all_teams_with_failure(
+        self, mock_response: MagicMock
+    ) -> None:
+        """Test that failures don't stop iteration."""
+
+        # First call succeeds, second fails, third succeeds
+        async def side_effect(path: str) -> MagicMock:
+            if "new-york-islanders" in path:
+                error_response = MagicMock()
+                error_response.is_success = False
+                error_response.status = 500
+                return error_response
+            return mock_response
+
+        downloader = LineCombinationsDownloader(team_ids=[6, 2, 1])  # BOS, NYI, NJD
+        object.__setattr__(downloader, "_get", AsyncMock(side_effect=side_effect))
+
+        results = []
+        async for result in downloader.download_all_teams():
+            results.append(result)
+
+        assert len(results) == 3
+        # BOS and NJD should succeed
+        completed = [r for r in results if r.status == DownloadStatus.COMPLETED]
+        failed = [r for r in results if r.status == DownloadStatus.FAILED]
+        assert len(completed) == 2
+        assert len(failed) == 1


### PR DESCRIPTION
## Summary

- Implements Wave 5b.3: DailyFaceoff Line Combinations Downloader
- Parses 4 forward lines (LW, C, RW), 3 defensive pairs (LD, RD), and goalie depth from DailyFaceoff.com
- Extracts __NEXT_DATA__ JSON embedded in the page for player data
- Data classes: `ForwardLine`, `DefensivePair`, `GoalieDepth`, `PlayerInfo`, `TeamLineup`

## Test plan

- [x] 39 unit tests covering dataclasses, parsing methods, integration, and download functionality
- [x] 85% code coverage for `line_combinations.py`
- [x] All pre-commit hooks pass (ruff, mypy, pytest)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)