### PR TITLE
feat(downloaders): Add database persistence to Player Landing Downloader (#123)

### DIFF
--- a/migrations/018_player_landing_fields.sql
+++ b/migrations/018_player_landing_fields.sql
@@ -1,0 +1,60 @@
+-- Migration: 018_player_landing_fields.sql
+-- Description: Add player landing page fields for extended biographical and career data
+-- Author: Claude Code
+-- Date: 2025-12-21
+-- Issue: #123
+
+-- Add draft information columns
+ALTER TABLE players ADD COLUMN IF NOT EXISTS draft_year INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS draft_round INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS draft_pick INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS draft_overall INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS draft_team_abbrev VARCHAR(5);
+
+-- Add hero image URL (already have headshot_url)
+ALTER TABLE players ADD COLUMN IF NOT EXISTS hero_image_url VARCHAR(500);
+
+-- Add career NHL totals (regular season)
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_gp INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_goals INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_assists INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_points INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_plus_minus INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_pim INTEGER;
+
+-- Goalie career stats (null for skaters)
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_wins INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_losses INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_ot_losses INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_shutouts INTEGER;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_gaa FLOAT;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS career_save_pct FLOAT;
+
+-- Add special honors
+ALTER TABLE players ADD COLUMN IF NOT EXISTS in_top_100_all_time BOOLEAN DEFAULT FALSE;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS in_hhof BOOLEAN DEFAULT FALSE;
+
+-- Create index on draft year for historical queries
+CREATE INDEX IF NOT EXISTS idx_players_draft_year ON players(draft_year) WHERE draft_year IS NOT NULL;
+
+-- Add comments
+COMMENT ON COLUMN players.draft_year IS 'Year player was drafted';
+COMMENT ON COLUMN players.draft_round IS 'Draft round (1-7)';
+COMMENT ON COLUMN players.draft_pick IS 'Pick number within round';
+COMMENT ON COLUMN players.draft_overall IS 'Overall pick number';
+COMMENT ON COLUMN players.draft_team_abbrev IS 'Team that drafted the player';
+COMMENT ON COLUMN players.hero_image_url IS 'Large action photo from landing page';
+COMMENT ON COLUMN players.career_gp IS 'Career NHL regular season games played';
+COMMENT ON COLUMN players.career_goals IS 'Career NHL regular season goals';
+COMMENT ON COLUMN players.career_assists IS 'Career NHL regular season assists';
+COMMENT ON COLUMN players.career_points IS 'Career NHL regular season points';
+COMMENT ON COLUMN players.career_plus_minus IS 'Career NHL regular season plus/minus';
+COMMENT ON COLUMN players.career_pim IS 'Career NHL regular season penalty minutes';
+COMMENT ON COLUMN players.career_wins IS 'Goalie career NHL wins';
+COMMENT ON COLUMN players.career_losses IS 'Goalie career NHL losses';
+COMMENT ON COLUMN players.career_ot_losses IS 'Goalie career NHL OT losses';
+COMMENT ON COLUMN players.career_shutouts IS 'Goalie career NHL shutouts';
+COMMENT ON COLUMN players.career_gaa IS 'Goalie career goals against average';
+COMMENT ON COLUMN players.career_save_pct IS 'Goalie career save percentage';
+COMMENT ON COLUMN players.in_top_100_all_time IS 'Whether player is in NHL Top 100 All-Time list';
+COMMENT ON COLUMN players.in_hhof IS 'Whether player is in Hockey Hall of Fame';


### PR DESCRIPTION
## Summary

- Add migration to extend `players` table with landing page fields (draft, career stats, honors)
- Implement `persist()` method in `PlayerLandingDownloader` to upsert player data
- Integrate persistence into `DownloadService` to call persist after download completes
- Add 13 unit tests for persist functionality

## Changes

### Migration (018_player_landing_fields.sql)
- Draft info: `draft_year`, `draft_round`, `draft_pick`, `draft_overall`, `draft_team_abbrev`
- Hero image URL
- Career skater stats: `career_gp`, `career_goals`, `career_assists`, `career_points`, `career_plus_minus`, `career_pim`
- Career goalie stats: `career_wins`, `career_losses`, `career_ot_losses`, `career_shutouts`, `career_gaa`, `career_save_pct`
- Honors: `in_top_100_all_time`, `in_hhof`

### PlayerLandingDownloader.persist()
- Upserts extended player data from landing API
- Handles both skaters and goalies with different career stat extraction
- Extracts draft details from nested `draft_details` object
- Converts zero height/weight to NULL

### DownloadService Integration
- Collects results during download loop into `successful_results` list
- Calls `persist()` after all players downloaded
- Logs persisted count

## Test Plan

- [x] 13 new unit tests for persist method (all passing)
- [x] Empty list returns 0
- [x] Single skater persists correctly
- [x] Single goalie persists correctly with goalie-specific stats
- [x] Multiple players persisted
- [x] Undrafted player (draft_details=None) handled
- [x] Zero height/weight converted to None
- [x] Skater career stats correctly extracted
- [x] Goalie career stats correctly extracted
- [x] Single player exception doesn't stop other players
- [x] SQL structure validates INSERT...ON CONFLICT
- [x] HHOF and Top 100 flags persisted
- [x] All 1500 tests pass with 92% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)