### PR TITLE
feat(utils): Add Player Name Matching Utilities (#97)

### DIFF
--- a/src/nhl_api/utils/__init__.py
+++ b/src/nhl_api/utils/__init__.py
@@ -11,8 +11,16 @@ from nhl_api.utils.http_client import (
     create_nhl_api_client,
     create_nhl_html_client,
 )
+from nhl_api.utils.name_matching import (
+    MatchResult,
+    PlayerNameMatcher,
+    find_best_match,
+    name_similarity,
+    normalize_name,
+)
 
 __all__ = [
+    # HTTP Client
     "ConnectionError",
     "ContentType",
     "HTTPClient",
@@ -22,4 +30,10 @@ __all__ = [
     "TimeoutError",
     "create_nhl_api_client",
     "create_nhl_html_client",
+    # Name Matching
+    "MatchResult",
+    "PlayerNameMatcher",
+    "find_best_match",
+    "name_similarity",
+    "normalize_name",
 ]

--- a/src/nhl_api/utils/name_matching.py
+++ b/src/nhl_api/utils/name_matching.py
@@ -1,0 +1,435 @@
+"""Player name matching utilities for cross-source data linking.
+
+Handles variations in player names across different data sources:
+- NHL API: "Nathan MacKinnon"
+- QuantHockey: "N. MacKinnon"
+- DailyFaceoff: "Nate MacKinnon"
+
+Supports:
+- First initial vs full name matching
+- Accented character normalization
+- Suffix removal (Jr., Sr., III, etc.)
+- Hyphenated name handling
+- Middle name/initial handling
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from functools import lru_cache
+
+# Suffixes to strip from names
+_SUFFIXES = frozenset(
+    {
+        "jr",
+        "jr.",
+        "sr",
+        "sr.",
+        "i",
+        "ii",
+        "iii",
+        "iv",
+        "v",
+    }
+)
+
+# Pattern to match initials like "J." or "J.T."
+_INITIAL_PATTERN = re.compile(r"^([A-Z])\.$")
+
+# Pattern to split names on whitespace and hyphens (keeping hyphens)
+_NAME_SPLIT_PATTERN = re.compile(r"[\s]+")
+
+
+def normalize_name(name: str) -> str:
+    """Normalize a player name for comparison.
+
+    Performs:
+    - Unicode normalization (NFD) and accent removal
+    - Lowercase conversion
+    - Suffix removal (Jr., Sr., III, etc.)
+    - Hyphen-to-space conversion
+    - Multiple space collapse
+    - Strip leading/trailing whitespace
+
+    Args:
+        name: The player name to normalize.
+
+    Returns:
+        Normalized name suitable for comparison.
+
+    Examples:
+        >>> normalize_name("Zdeno Chára")
+        'zdeno chara'
+        >>> normalize_name("Alex Ovechkin Jr.")
+        'alex ovechkin'
+        >>> normalize_name("Pierre-Luc Dubois")
+        'pierre luc dubois'
+    """
+    if not name:
+        return ""
+
+    # Unicode normalize (NFD) and remove combining characters (accents)
+    normalized = unicodedata.normalize("NFD", name)
+    normalized = "".join(c for c in normalized if unicodedata.category(c) != "Mn")
+
+    # Lowercase
+    normalized = normalized.lower()
+
+    # Replace hyphens with spaces
+    normalized = normalized.replace("-", " ")
+
+    # Remove periods (common in initials like "J.T." or "N.")
+    normalized = normalized.replace(".", "")
+
+    # Split into parts and filter suffixes
+    parts = _NAME_SPLIT_PATTERN.split(normalized)
+    parts = [p.strip() for p in parts if p.strip()]
+    parts = [p for p in parts if p not in _SUFFIXES]
+
+    # Rejoin and collapse multiple spaces
+    result = " ".join(parts)
+
+    return result
+
+
+def _extract_name_parts(name: str) -> tuple[str, list[str]]:
+    """Extract last name and first/middle name parts from a normalized name.
+
+    Args:
+        name: Normalized player name.
+
+    Returns:
+        Tuple of (last_name, [first_name, middle_names...])
+    """
+    parts = name.split()
+    if len(parts) == 0:
+        return "", []
+    if len(parts) == 1:
+        return parts[0], []
+
+    # Last name is the last part, everything else is first/middle
+    return parts[-1], parts[:-1]
+
+
+def _first_name_matches(name1_parts: list[str], name2_parts: list[str]) -> bool:
+    """Check if first name parts match, handling initials.
+
+    Handles cases like:
+    - "nathan" matches "nathan"
+    - "n" matches "nathan" (initial)
+    - "n" matches "nate" (initial)
+    - "jt" matches ["jonathan", "tanner"] (combined initials)
+
+    Args:
+        name1_parts: First/middle name parts from first name.
+        name2_parts: First/middle name parts from second name.
+
+    Returns:
+        True if the first names are considered a match.
+    """
+    if not name1_parts or not name2_parts:
+        return True  # If either has no first name, consider it a match
+
+    # Get first parts
+    first1 = name1_parts[0]
+    first2 = name2_parts[0]
+
+    # Check for exact match
+    if first1 == first2:
+        return True
+
+    # Check for initial match (single letter matches beginning of name)
+    if len(first1) == 1 and first2.startswith(first1):
+        return True
+    if len(first2) == 1 and first1.startswith(first2):
+        return True
+
+    # Check if names share common beginning (handles Nate/Nathan)
+    # Both names must be at least 3 chars and share a 3-char prefix
+    if len(first1) >= 3 and len(first2) >= 3 and first1[:3] == first2[:3]:
+        return True
+
+    # Handle combined initials like "jt" matching ["jonathan", "tanner"]
+    # Check if first1 is initials that match first letters of name2_parts
+    if len(first1) <= 3 and len(first1) == len(name2_parts):
+        if all(first1[i] == name2_parts[i][0] for i in range(len(first1))):
+            return True
+
+    # Check reverse: name1_parts initials match combined first2
+    if len(first2) <= 3 and len(first2) == len(name1_parts):
+        if all(first2[i] == name1_parts[i][0] for i in range(len(first2))):
+            return True
+
+    return False
+
+
+def name_similarity(name1: str, name2: str) -> float:
+    """Calculate similarity score between two player names.
+
+    Uses a combination of:
+    - Exact match detection
+    - Last name matching
+    - First name/initial matching
+    - Levenshtein-based similarity for fuzzy matching
+
+    Args:
+        name1: First player name (raw, not normalized).
+        name2: Second player name (raw, not normalized).
+
+    Returns:
+        Similarity score from 0.0 (no match) to 1.0 (exact match).
+
+    Examples:
+        >>> name_similarity("Nathan MacKinnon", "Nathan MacKinnon")
+        1.0
+        >>> name_similarity("N. MacKinnon", "Nathan MacKinnon")
+        0.95
+        >>> name_similarity("Zdeno Chára", "Zdeno Chara")
+        1.0
+    """
+    # Normalize both names
+    norm1 = normalize_name(name1)
+    norm2 = normalize_name(name2)
+
+    # Handle empty names
+    if not norm1 or not norm2:
+        return 0.0
+
+    # Exact match after normalization
+    if norm1 == norm2:
+        return 1.0
+
+    # Extract name parts
+    last1, first1_parts = _extract_name_parts(norm1)
+    last2, first2_parts = _extract_name_parts(norm2)
+
+    # Last names must be similar
+    last_name_sim = _string_similarity(last1, last2)
+    if last_name_sim < 0.8:
+        return last_name_sim * 0.5  # Heavily penalize last name mismatch
+
+    # Check first name matching
+    if _first_name_matches(first1_parts, first2_parts):
+        # Good first name match + good last name match
+        if last_name_sim >= 0.95:
+            return 0.95
+        return 0.85 + (last_name_sim - 0.8) * 0.5
+
+    # Fall back to overall string similarity
+    overall_sim = _string_similarity(norm1, norm2)
+    return overall_sim
+
+
+@lru_cache(maxsize=10000)
+def _string_similarity(s1: str, s2: str) -> float:
+    """Calculate string similarity using Levenshtein distance.
+
+    Uses a simple implementation that's sufficient for name matching.
+    Results are cached for performance.
+
+    Args:
+        s1: First string.
+        s2: Second string.
+
+    Returns:
+        Similarity score from 0.0 to 1.0.
+    """
+    if s1 == s2:
+        return 1.0
+    if not s1 or not s2:
+        return 0.0
+
+    # Calculate Levenshtein distance
+    len1, len2 = len(s1), len(s2)
+
+    # Use two-row approach for memory efficiency
+    prev_row = list(range(len2 + 1))
+    curr_row = [0] * (len2 + 1)
+
+    for i in range(1, len1 + 1):
+        curr_row[0] = i
+        for j in range(1, len2 + 1):
+            cost = 0 if s1[i - 1] == s2[j - 1] else 1
+            curr_row[j] = min(
+                prev_row[j] + 1,  # deletion
+                curr_row[j - 1] + 1,  # insertion
+                prev_row[j - 1] + cost,  # substitution
+            )
+        prev_row, curr_row = curr_row, prev_row
+
+    distance = prev_row[len2]
+    max_len = max(len1, len2)
+
+    return 1.0 - (distance / max_len)
+
+
+def find_best_match(
+    name: str,
+    candidates: list[str],
+    threshold: float = 0.85,
+) -> str | None:
+    """Find the best matching name from a list of candidates.
+
+    Args:
+        name: The name to match.
+        candidates: List of candidate names to search.
+        threshold: Minimum similarity score to accept (0.0 to 1.0).
+
+    Returns:
+        The best matching candidate name, or None if no match meets threshold.
+
+    Examples:
+        >>> candidates = ["Nathan MacKinnon", "Cale Makar", "Mikko Rantanen"]
+        >>> find_best_match("N. MacKinnon", candidates)
+        'Nathan MacKinnon'
+        >>> find_best_match("Sidney Crosby", candidates)  # No match
+        None
+    """
+    if not name or not candidates:
+        return None
+
+    best_match: str | None = None
+    best_score = threshold
+
+    for candidate in candidates:
+        score = name_similarity(name, candidate)
+        if score > best_score:
+            best_score = score
+            best_match = candidate
+
+    return best_match
+
+
+@dataclass
+class MatchResult:
+    """Result of a name matching operation."""
+
+    matched_name: str | None
+    """The matched candidate name, or None if no match."""
+
+    score: float
+    """Similarity score (0.0 to 1.0)."""
+
+    @property
+    def is_match(self) -> bool:
+        """Whether a match was found."""
+        return self.matched_name is not None
+
+
+@dataclass
+class PlayerNameMatcher:
+    """Batch player name matching with caching for performance.
+
+    Designed for matching player names across data sources where the same
+    candidates are matched against many input names.
+
+    Attributes:
+        threshold: Minimum similarity score to accept a match (default 0.85).
+        candidates: List of candidate names to match against.
+
+    Example:
+        >>> matcher = PlayerNameMatcher(threshold=0.85)
+        >>> matcher.set_candidates(["Nathan MacKinnon", "Cale Makar"])
+        >>> result = matcher.match("N. MacKinnon")
+        >>> result.matched_name
+        'Nathan MacKinnon'
+        >>> result.score
+        0.95
+    """
+
+    threshold: float = 0.85
+    candidates: list[str] = field(default_factory=list)
+    _normalized_candidates: dict[str, str] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _cache: dict[str, MatchResult] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize normalized candidates mapping."""
+        if self.candidates:
+            self._build_candidate_index()
+
+    def set_candidates(self, candidates: list[str]) -> None:
+        """Set the list of candidate names to match against.
+
+        Clears any cached results and rebuilds the candidate index.
+
+        Args:
+            candidates: List of candidate names.
+        """
+        self.candidates = candidates
+        self._cache.clear()
+        self._build_candidate_index()
+
+    def _build_candidate_index(self) -> None:
+        """Build normalized name to original name mapping."""
+        self._normalized_candidates = {}
+        for candidate in self.candidates:
+            norm = normalize_name(candidate)
+            self._normalized_candidates[norm] = candidate
+
+    def match(self, name: str) -> MatchResult:
+        """Find the best match for a name among candidates.
+
+        Results are cached for repeated lookups of the same name.
+
+        Args:
+            name: The name to match.
+
+        Returns:
+            MatchResult with the matched name and score.
+        """
+        # Check cache first
+        norm_name = normalize_name(name)
+        if norm_name in self._cache:
+            return self._cache[norm_name]
+
+        # Check for exact normalized match first (fast path)
+        if norm_name in self._normalized_candidates:
+            result = MatchResult(
+                matched_name=self._normalized_candidates[norm_name],
+                score=1.0,
+            )
+            self._cache[norm_name] = result
+            return result
+
+        # Find best match
+        best_match: str | None = None
+        best_score = 0.0
+
+        for candidate in self.candidates:
+            score = name_similarity(name, candidate)
+            if score > best_score:
+                best_score = score
+                best_match = candidate
+
+        # Apply threshold
+        if best_score < self.threshold:
+            result = MatchResult(matched_name=None, score=best_score)
+        else:
+            result = MatchResult(matched_name=best_match, score=best_score)
+
+        self._cache[norm_name] = result
+        return result
+
+    def match_all(self, names: list[str]) -> list[MatchResult]:
+        """Match multiple names against candidates.
+
+        Args:
+            names: List of names to match.
+
+        Returns:
+            List of MatchResult objects in the same order as input names.
+        """
+        return [self.match(name) for name in names]
+
+    def clear_cache(self) -> None:
+        """Clear the match result cache."""
+        self._cache.clear()
+
+    @property
+    def cache_size(self) -> int:
+        """Number of cached match results."""
+        return len(self._cache)

--- a/tests/unit/utils/__init__.py
+++ b/tests/unit/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for utility functions."""

--- a/tests/unit/utils/test_name_matching.py
+++ b/tests/unit/utils/test_name_matching.py
@@ -1,0 +1,463 @@
+"""Unit tests for player name matching utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from nhl_api.utils.name_matching import (
+    MatchResult,
+    PlayerNameMatcher,
+    _extract_name_parts,
+    _first_name_matches,
+    _string_similarity,
+    find_best_match,
+    name_similarity,
+    normalize_name,
+)
+
+
+class TestNormalizeName:
+    """Tests for normalize_name function."""
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty string."""
+        assert normalize_name("") == ""
+
+    def test_simple_name(self) -> None:
+        """Simple name is lowercased."""
+        assert normalize_name("Nathan MacKinnon") == "nathan mackinnon"
+
+    def test_accented_characters(self) -> None:
+        """Accents are removed."""
+        assert normalize_name("Zdeno Chára") == "zdeno chara"
+        assert normalize_name("Patrice Bergeron") == "patrice bergeron"
+        assert normalize_name("André Burakovsky") == "andre burakovsky"
+
+    def test_suffix_junior(self) -> None:
+        """Jr. suffix is removed."""
+        assert normalize_name("Alex Ovechkin Jr.") == "alex ovechkin"
+        assert normalize_name("Alex Ovechkin Jr") == "alex ovechkin"
+
+    def test_suffix_senior(self) -> None:
+        """Sr. suffix is removed."""
+        assert normalize_name("Gordie Howe Sr.") == "gordie howe"
+        assert normalize_name("Gordie Howe Sr") == "gordie howe"
+
+    def test_suffix_roman_numerals(self) -> None:
+        """Roman numeral suffixes are removed."""
+        assert normalize_name("Henrik Lundqvist III") == "henrik lundqvist"
+        assert normalize_name("Player Name II") == "player name"
+        assert normalize_name("Player Name IV") == "player name"
+        assert normalize_name("Player Name V") == "player name"
+
+    def test_hyphenated_names(self) -> None:
+        """Hyphens are converted to spaces."""
+        assert normalize_name("Pierre-Luc Dubois") == "pierre luc dubois"
+        assert normalize_name("Jean-Gabriel Pageau") == "jean gabriel pageau"
+
+    def test_multiple_spaces(self) -> None:
+        """Multiple spaces are collapsed."""
+        assert normalize_name("Nathan   MacKinnon") == "nathan mackinnon"
+        assert normalize_name("  Nathan  MacKinnon  ") == "nathan mackinnon"
+
+    def test_combined_normalizations(self) -> None:
+        """Multiple normalizations work together."""
+        assert normalize_name("André-Pierre Côté Jr.") == "andre pierre cote"
+
+
+class TestExtractNameParts:
+    """Tests for _extract_name_parts helper function."""
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty parts."""
+        assert _extract_name_parts("") == ("", [])
+
+    def test_single_name(self) -> None:
+        """Single name is treated as last name."""
+        assert _extract_name_parts("mackinnon") == ("mackinnon", [])
+
+    def test_two_part_name(self) -> None:
+        """Two-part name splits correctly."""
+        assert _extract_name_parts("nathan mackinnon") == ("mackinnon", ["nathan"])
+
+    def test_three_part_name(self) -> None:
+        """Three-part name includes middle name."""
+        assert _extract_name_parts("jonathan tanner miller") == (
+            "miller",
+            ["jonathan", "tanner"],
+        )
+
+    def test_hyphenated_normalized(self) -> None:
+        """Pre-normalized hyphenated names split correctly."""
+        assert _extract_name_parts("pierre luc dubois") == (
+            "dubois",
+            ["pierre", "luc"],
+        )
+
+
+class TestFirstNameMatches:
+    """Tests for _first_name_matches helper function."""
+
+    def test_empty_parts(self) -> None:
+        """Empty parts are considered a match."""
+        assert _first_name_matches([], []) is True
+        assert _first_name_matches(["nathan"], []) is True
+        assert _first_name_matches([], ["nathan"]) is True
+
+    def test_exact_match(self) -> None:
+        """Exact first names match."""
+        assert _first_name_matches(["nathan"], ["nathan"]) is True
+        assert _first_name_matches(["nathan", "cole"], ["nathan", "cole"]) is True
+
+    def test_initial_match(self) -> None:
+        """Single letter initial matches full name."""
+        assert _first_name_matches(["n"], ["nathan"]) is True
+        assert _first_name_matches(["nathan"], ["n"]) is True
+
+    def test_nickname_match(self) -> None:
+        """Common beginning matches (Nate/Nathan)."""
+        assert _first_name_matches(["nate"], ["nathan"]) is True
+        assert _first_name_matches(["nathan"], ["nate"]) is True
+
+    def test_no_match(self) -> None:
+        """Different first names don't match."""
+        assert _first_name_matches(["alex"], ["nathan"]) is False
+        assert _first_name_matches(["cale"], ["nathan"]) is False
+
+
+class TestStringSimilarity:
+    """Tests for _string_similarity helper function."""
+
+    def test_identical_strings(self) -> None:
+        """Identical strings have similarity 1.0."""
+        assert _string_similarity("mackinnon", "mackinnon") == 1.0
+
+    def test_empty_strings(self) -> None:
+        """Empty strings have similarity 0.0."""
+        assert _string_similarity("", "") == 1.0  # Both empty = identical
+        assert _string_similarity("test", "") == 0.0
+        assert _string_similarity("", "test") == 0.0
+
+    def test_single_character_difference(self) -> None:
+        """Single character difference reduces similarity."""
+        sim = _string_similarity("mackinnon", "mackinon")  # Missing 'n'
+        assert 0.8 < sim < 1.0
+
+    def test_completely_different(self) -> None:
+        """Completely different strings have low similarity."""
+        sim = _string_similarity("abcd", "wxyz")
+        assert sim < 0.5
+
+    def test_caching(self) -> None:
+        """Results are cached for repeated calls."""
+        # First call
+        sim1 = _string_similarity("test", "tset")
+        # Second call should use cache
+        sim2 = _string_similarity("test", "tset")
+        assert sim1 == sim2
+
+
+class TestNameSimilarity:
+    """Tests for name_similarity function."""
+
+    def test_exact_match(self) -> None:
+        """Exact match returns 1.0."""
+        assert name_similarity("Nathan MacKinnon", "Nathan MacKinnon") == 1.0
+
+    def test_case_insensitive(self) -> None:
+        """Matching is case insensitive."""
+        assert name_similarity("Nathan MacKinnon", "nathan mackinnon") == 1.0
+
+    def test_accent_insensitive(self) -> None:
+        """Matching ignores accents."""
+        assert name_similarity("Zdeno Chára", "Zdeno Chara") == 1.0
+
+    def test_initial_match(self) -> None:
+        """Initial matches full first name."""
+        sim = name_similarity("N. MacKinnon", "Nathan MacKinnon")
+        assert sim >= 0.95
+
+    def test_suffix_ignored(self) -> None:
+        """Suffixes are ignored in matching."""
+        sim = name_similarity("Alex Ovechkin Jr.", "Alex Ovechkin")
+        assert sim >= 0.95
+
+    def test_different_last_names(self) -> None:
+        """Different last names have low similarity."""
+        sim = name_similarity("Nathan MacKinnon", "Nathan Crosby")
+        assert sim < 0.5
+
+    def test_empty_names(self) -> None:
+        """Empty names return 0.0 similarity."""
+        assert name_similarity("", "Nathan MacKinnon") == 0.0
+        assert name_similarity("Nathan MacKinnon", "") == 0.0
+        assert name_similarity("", "") == 0.0
+
+    def test_hyphenated_name(self) -> None:
+        """Hyphenated names match non-hyphenated."""
+        sim = name_similarity("Pierre-Luc Dubois", "Pierre Luc Dubois")
+        assert sim >= 0.95
+
+    def test_middle_initial(self) -> None:
+        """Names with middle initials match when initials match name parts."""
+        # J.T. Miller = Jonathan Tanner Miller (J and T are first+middle initials)
+        sim = name_similarity("J.T. Miller", "Jonathan Tanner Miller")
+        assert sim >= 0.85
+
+        # Single initial still works
+        sim = name_similarity("J. Miller", "Jonathan Miller")
+        assert sim >= 0.85
+
+
+class TestFindBestMatch:
+    """Tests for find_best_match function."""
+
+    @pytest.fixture
+    def nhl_players(self) -> list[str]:
+        """Sample NHL player names."""
+        return [
+            "Nathan MacKinnon",
+            "Cale Makar",
+            "Mikko Rantanen",
+            "Sidney Crosby",
+            "Alex Ovechkin",
+            "Pierre-Luc Dubois",
+        ]
+
+    def test_exact_match(self, nhl_players: list[str]) -> None:
+        """Exact match is found."""
+        result = find_best_match("Nathan MacKinnon", nhl_players)
+        assert result == "Nathan MacKinnon"
+
+    def test_initial_match(self, nhl_players: list[str]) -> None:
+        """Initial matches full name."""
+        result = find_best_match("N. MacKinnon", nhl_players)
+        assert result == "Nathan MacKinnon"
+
+    def test_no_match_below_threshold(self, nhl_players: list[str]) -> None:
+        """No match returns None when below threshold."""
+        result = find_best_match("Wayne Gretzky", nhl_players)
+        assert result is None
+
+    def test_custom_threshold(self, nhl_players: list[str]) -> None:
+        """Custom threshold affects matching."""
+        # Very low threshold should match more
+        result = find_best_match("MacKinnon", nhl_players, threshold=0.5)
+        assert result == "Nathan MacKinnon"
+
+    def test_empty_candidates(self) -> None:
+        """Empty candidates returns None."""
+        result = find_best_match("Nathan MacKinnon", [])
+        assert result is None
+
+    def test_empty_name(self, nhl_players: list[str]) -> None:
+        """Empty name returns None."""
+        result = find_best_match("", nhl_players)
+        assert result is None
+
+    def test_hyphenated_match(self, nhl_players: list[str]) -> None:
+        """Hyphenated name matches."""
+        result = find_best_match("Pierre Luc Dubois", nhl_players)
+        assert result == "Pierre-Luc Dubois"
+
+
+class TestMatchResult:
+    """Tests for MatchResult dataclass."""
+
+    def test_successful_match(self) -> None:
+        """Successful match has is_match True."""
+        result = MatchResult(matched_name="Nathan MacKinnon", score=0.95)
+        assert result.is_match is True
+        assert result.matched_name == "Nathan MacKinnon"
+        assert result.score == 0.95
+
+    def test_no_match(self) -> None:
+        """No match has is_match False."""
+        result = MatchResult(matched_name=None, score=0.5)
+        assert result.is_match is False
+        assert result.matched_name is None
+
+
+class TestPlayerNameMatcher:
+    """Tests for PlayerNameMatcher class."""
+
+    @pytest.fixture
+    def matcher(self) -> PlayerNameMatcher:
+        """Create a matcher with sample candidates."""
+        candidates = [
+            "Nathan MacKinnon",
+            "Cale Makar",
+            "Mikko Rantanen",
+            "Sidney Crosby",
+            "Alex Ovechkin",
+        ]
+        return PlayerNameMatcher(threshold=0.85, candidates=candidates)
+
+    def test_exact_match(self, matcher: PlayerNameMatcher) -> None:
+        """Exact match returns 1.0 score."""
+        result = matcher.match("Nathan MacKinnon")
+        assert result.matched_name == "Nathan MacKinnon"
+        assert result.score == 1.0
+
+    def test_initial_match(self, matcher: PlayerNameMatcher) -> None:
+        """Initial matches full name."""
+        result = matcher.match("N. MacKinnon")
+        assert result.matched_name == "Nathan MacKinnon"
+        assert result.score >= 0.95
+
+    def test_no_match(self, matcher: PlayerNameMatcher) -> None:
+        """No match when below threshold."""
+        result = matcher.match("Wayne Gretzky")
+        assert result.matched_name is None
+        assert result.is_match is False
+
+    def test_caching(self, matcher: PlayerNameMatcher) -> None:
+        """Results are cached."""
+        # First call
+        result1 = matcher.match("N. MacKinnon")
+        cache_size1 = matcher.cache_size
+
+        # Second call should use cache
+        result2 = matcher.match("N. MacKinnon")
+        cache_size2 = matcher.cache_size
+
+        assert result1.matched_name == result2.matched_name
+        assert result1.score == result2.score
+        assert cache_size1 == cache_size2  # No new cache entry
+
+    def test_set_candidates(self) -> None:
+        """set_candidates updates candidates and clears cache."""
+        matcher = PlayerNameMatcher(threshold=0.85)
+        matcher.set_candidates(["Nathan MacKinnon", "Cale Makar"])
+
+        result = matcher.match("Nathan MacKinnon")
+        assert result.matched_name == "Nathan MacKinnon"
+        assert matcher.cache_size == 1
+
+        # Set new candidates should clear cache
+        matcher.set_candidates(["Sidney Crosby"])
+        assert matcher.cache_size == 0
+
+        result = matcher.match("Nathan MacKinnon")
+        assert result.matched_name is None
+
+    def test_match_all(self, matcher: PlayerNameMatcher) -> None:
+        """match_all returns results for all names."""
+        names = ["Nathan MacKinnon", "N. MacKinnon", "Wayne Gretzky"]
+        results = matcher.match_all(names)
+
+        assert len(results) == 3
+        assert results[0].matched_name == "Nathan MacKinnon"
+        assert results[1].matched_name == "Nathan MacKinnon"
+        assert results[2].matched_name is None
+
+    def test_clear_cache(self, matcher: PlayerNameMatcher) -> None:
+        """clear_cache empties the cache."""
+        matcher.match("Nathan MacKinnon")
+        assert matcher.cache_size > 0
+
+        matcher.clear_cache()
+        assert matcher.cache_size == 0
+
+    def test_empty_candidates(self) -> None:
+        """Empty candidates list works."""
+        matcher = PlayerNameMatcher()
+        result = matcher.match("Nathan MacKinnon")
+        assert result.matched_name is None
+
+    def test_custom_threshold(self) -> None:
+        """Custom threshold affects matching."""
+        candidates = ["Nathan MacKinnon"]
+
+        # High threshold - initial might not match
+        high_matcher = PlayerNameMatcher(threshold=0.99, candidates=candidates)
+        result = high_matcher.match("N. MacKinnon")
+        assert result.matched_name is None  # 0.95 < 0.99
+
+        # Lower threshold - should match
+        low_matcher = PlayerNameMatcher(threshold=0.85, candidates=candidates)
+        result = low_matcher.match("N. MacKinnon")
+        assert result.matched_name == "Nathan MacKinnon"
+
+
+class TestRealWorldExamples:
+    """Integration tests with real NHL player name variations."""
+
+    @pytest.fixture
+    def nhl_roster(self) -> list[str]:
+        """A sample of real NHL API player names."""
+        return [
+            "Nathan MacKinnon",
+            "Sidney Crosby",
+            "Alex Ovechkin",
+            "Connor McDavid",
+            "Auston Matthews",
+            "Pierre-Luc Dubois",
+            "Jean-Gabriel Pageau",
+            "Zdeno Chara",
+            "Jonathan Tanner Miller",
+            "Patrick Kane",
+            "Leon Draisaitl",
+            "Artemi Panarin",
+        ]
+
+    def test_quanthockey_format(self, nhl_roster: list[str]) -> None:
+        """QuantHockey uses first initial format."""
+        matcher = PlayerNameMatcher(threshold=0.85, candidates=nhl_roster)
+
+        # QuantHockey format: "N. MacKinnon"
+        result = matcher.match("N. MacKinnon")
+        assert result.matched_name == "Nathan MacKinnon"
+
+        result = matcher.match("S. Crosby")
+        assert result.matched_name == "Sidney Crosby"
+
+        result = matcher.match("C. McDavid")
+        assert result.matched_name == "Connor McDavid"
+
+    def test_accented_names(self, nhl_roster: list[str]) -> None:
+        """Accented characters in names."""
+        matcher = PlayerNameMatcher(threshold=0.85, candidates=nhl_roster)
+
+        # With accent
+        result = matcher.match("Zdeno Chára")
+        assert result.matched_name == "Zdeno Chara"
+
+    def test_hyphenated_names(self, nhl_roster: list[str]) -> None:
+        """Hyphenated names match both formats."""
+        matcher = PlayerNameMatcher(threshold=0.85, candidates=nhl_roster)
+
+        # Without hyphen
+        result = matcher.match("Pierre Luc Dubois")
+        assert result.matched_name == "Pierre-Luc Dubois"
+
+        result = matcher.match("Jean Gabriel Pageau")
+        assert result.matched_name == "Jean-Gabriel Pageau"
+
+    def test_jt_miller(self, nhl_roster: list[str]) -> None:
+        """J.T. Miller matches Jonathan Tanner Miller."""
+        matcher = PlayerNameMatcher(threshold=0.85, candidates=nhl_roster)
+
+        result = matcher.match("J.T. Miller")
+        assert result.matched_name == "Jonathan Tanner Miller"
+
+    def test_batch_matching(self, nhl_roster: list[str]) -> None:
+        """Batch matching works for multiple names."""
+        matcher = PlayerNameMatcher(threshold=0.85, candidates=nhl_roster)
+
+        # DailyFaceoff format names
+        df_names = [
+            "N. MacKinnon",
+            "P. Kane",
+            "L. Draisaitl",
+            "A. Panarin",
+            "Unknown Player",
+        ]
+
+        results = matcher.match_all(df_names)
+
+        assert results[0].matched_name == "Nathan MacKinnon"
+        assert results[1].matched_name == "Patrick Kane"
+        assert results[2].matched_name == "Leon Draisaitl"
+        assert results[3].matched_name == "Artemi Panarin"
+        assert results[4].matched_name is None


### PR DESCRIPTION
## Summary

- Add `normalize_name()` - remove accents, suffixes, periods, lowercase for comparison
- Add `name_similarity()` - calculate 0.0-1.0 similarity score between names
- Add `find_best_match()` - find best matching name from candidates above threshold
- Add `PlayerNameMatcher` class - batch matching with caching for performance

## Name Variations Handled

| Variation | Example |
|-----------|---------|
| First initial vs full | N. MacKinnon ↔ Nathan MacKinnon |
| Accented characters | Zdeno Chára ↔ Zdeno Chara |
| Suffixes | Alex Ovechkin Jr. ↔ Alex Ovechkin |
| Roman numerals | Henrik Lundqvist III ↔ Henrik Lundqvist |
| Hyphenated names | Pierre-Luc Dubois ↔ Pierre Luc Dubois |
| Combined initials | J.T. Miller ↔ Jonathan Tanner Miller |

## Test Plan

- [x] 56 unit tests covering all functions and edge cases
- [x] 97% code coverage on name_matching.py
- [x] mypy strict mode passes
- [x] Real-world examples: QuantHockey format, accented names, J.T. Miller

## Notes

This is a foundational utility for Wave 5a (QuantHockey) and Wave 5b (DailyFaceoff) downloaders. Name matching alone cannot disambiguate players with the same name (e.g., two Petterssons on Vancouver) - higher-level code will need to use team/position/jersey number for disambiguation.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)