### PR TITLE
feat(viewer): Add Game Data Browser with tabbed detail views (#142)

### DIFF
--- a/src/nhl_api/viewer/routers/entities.py
+++ b/src/nhl_api/viewer/routers/entities.py
@@ -16,14 +16,24 @@ from nhl_api.viewer.dependencies import get_db
 from nhl_api.viewer.schemas.entities import (
     DivisionTeams,
     GameDetail,
+    GameEventsResponse,
     GameListResponse,
+    GamePlayerStats,
+    GameShiftsResponse,
     GameSummary,
+    GoalieGameStats,
     PaginationMeta,
+    PlayByPlayEvent,
     PlayerDetail,
+    PlayerGameEntry,
+    PlayerGameLogResponse,
     PlayerListResponse,
+    PlayerShiftSummary,
     PlayerSummary,
+    SkaterGameStats,
     TeamDetail,
     TeamListResponse,
+    TeamRecentGamesResponse,
     TeamSummary,
     TeamWithRoster,
 )
@@ -413,3 +423,645 @@ async def get_game(
         )
 
     return GameDetail(**dict(row))
+
+
+@router.get(
+    "/games/{game_id}/events",
+    response_model=GameEventsResponse,
+    summary="Get Game Events",
+    description="Get play-by-play events for a game",
+)
+async def get_game_events(
+    db: DbDep,
+    game_id: int,
+    period: Annotated[int | None, Query(description="Filter by period")] = None,
+    event_type: Annotated[
+        str | None, Query(description="Filter by event type (e.g., 'goal', 'penalty')")
+    ] = None,
+) -> GameEventsResponse:
+    """Get play-by-play events for a specific game.
+
+    Supports filtering by period and event type.
+    """
+    # Build WHERE clauses
+    conditions: list[str] = ["e.game_id = $1"]
+    params: list[object] = [game_id]
+    param_idx = 2
+
+    if period is not None:
+        conditions.append(f"e.period = ${param_idx}")
+        params.append(period)
+        param_idx += 1
+
+    if event_type:
+        conditions.append(f"e.event_type ILIKE ${param_idx}")
+        params.append(f"%{event_type}%")
+        param_idx += 1
+
+    where_clause = " AND ".join(conditions)
+
+    query = f"""
+        SELECT
+            e.event_idx,
+            e.event_type,
+            e.period,
+            e.period_type,
+            e.time_in_period,
+            e.time_remaining,
+            e.description,
+            e.player1_id,
+            COALESCE(p1.first_name || ' ' || p1.last_name, '') as player1_name,
+            e.player1_role,
+            e.player2_id,
+            COALESCE(p2.first_name || ' ' || p2.last_name, '') as player2_name,
+            e.player2_role,
+            e.player3_id,
+            COALESCE(p3.first_name || ' ' || p3.last_name, '') as player3_name,
+            e.player3_role,
+            e.event_owner_team_id as team_id,
+            t.abbreviation as team_abbr,
+            e.home_score,
+            e.away_score,
+            e.shot_type,
+            e.zone,
+            e.x_coord,
+            e.y_coord
+        FROM game_events e
+        LEFT JOIN players p1 ON e.player1_id = p1.player_id
+        LEFT JOIN players p2 ON e.player2_id = p2.player_id
+        LEFT JOIN players p3 ON e.player3_id = p3.player_id
+        LEFT JOIN teams t ON e.event_owner_team_id = t.team_id
+        WHERE {where_clause}
+        ORDER BY e.period, e.event_idx
+    """
+    rows = await db.fetch(query, *params)
+
+    events = [PlayByPlayEvent(**dict(row)) for row in rows]
+
+    return GameEventsResponse(
+        game_id=game_id,
+        events=events,
+        total_events=len(events),
+    )
+
+
+def _format_toi(seconds: int | None) -> str:
+    """Format time on ice from seconds to MM:SS."""
+    if seconds is None or seconds == 0:
+        return "00:00"
+    minutes = seconds // 60
+    secs = seconds % 60
+    return f"{minutes:02d}:{secs:02d}"
+
+
+@router.get(
+    "/games/{game_id}/stats",
+    response_model=GamePlayerStats,
+    summary="Get Game Player Stats",
+    description="Get player statistics for a game",
+)
+async def get_game_stats(
+    db: DbDep,
+    game_id: int,
+) -> GamePlayerStats:
+    """Get player statistics for a specific game.
+
+    Returns skater and goalie stats for both home and away teams.
+    """
+    # First get game info to determine home/away teams
+    game_query = """
+        SELECT home_team_id, away_team_id, home_team_abbr, away_team_abbr
+        FROM mv_game_summary
+        WHERE game_id = $1
+    """
+    game_row = await db.fetchrow(game_query, game_id)
+
+    if not game_row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Game with ID {game_id} not found",
+        )
+
+    home_team_id = game_row["home_team_id"]
+    away_team_id = game_row["away_team_id"]
+    home_team_abbr = game_row["home_team_abbr"]
+    away_team_abbr = game_row["away_team_abbr"]
+
+    # Get skater stats
+    skater_query = """
+        SELECT
+            s.player_id,
+            p.first_name || ' ' || p.last_name as player_name,
+            s.team_id,
+            t.abbreviation as team_abbr,
+            s.position,
+            COALESCE(s.goals, 0) as goals,
+            COALESCE(s.assists, 0) as assists,
+            COALESCE(s.points, 0) as points,
+            COALESCE(s.plus_minus, 0) as plus_minus,
+            COALESCE(s.pim, 0) as pim,
+            COALESCE(s.shots, 0) as shots,
+            COALESCE(s.hits, 0) as hits,
+            COALESCE(s.blocked_shots, 0) as blocked_shots,
+            COALESCE(s.giveaways, 0) as giveaways,
+            COALESCE(s.takeaways, 0) as takeaways,
+            s.faceoff_pct,
+            COALESCE(s.toi_seconds, 0) as toi_seconds,
+            COALESCE(s.shifts, 0) as shifts,
+            COALESCE(s.power_play_goals, 0) as power_play_goals,
+            COALESCE(s.shorthanded_goals, 0) as shorthanded_goals
+        FROM game_skater_stats s
+        JOIN players p ON s.player_id = p.player_id
+        JOIN teams t ON s.team_id = t.team_id
+        WHERE s.game_id = $1
+        ORDER BY s.team_id, s.points DESC, s.goals DESC, s.toi_seconds DESC
+    """
+    skater_rows = await db.fetch(skater_query, game_id)
+
+    home_skaters: list[SkaterGameStats] = []
+    away_skaters: list[SkaterGameStats] = []
+
+    for row in skater_rows:
+        row_dict = dict(row)
+        row_dict["toi_formatted"] = _format_toi(row_dict.get("toi_seconds", 0))
+        skater = SkaterGameStats(**row_dict)
+
+        if row["team_id"] == home_team_id:
+            home_skaters.append(skater)
+        else:
+            away_skaters.append(skater)
+
+    # Get goalie stats
+    goalie_query = """
+        SELECT
+            g.player_id,
+            p.first_name || ' ' || p.last_name as player_name,
+            g.team_id,
+            t.abbreviation as team_abbr,
+            COALESCE(g.saves, 0) as saves,
+            COALESCE(g.shots_against, 0) as shots_against,
+            COALESCE(g.goals_against, 0) as goals_against,
+            g.save_pct,
+            COALESCE(g.toi_seconds, 0) as toi_seconds,
+            COALESCE(g.even_strength_saves, 0) as even_strength_saves,
+            COALESCE(g.even_strength_shots, 0) as even_strength_shots,
+            COALESCE(g.power_play_saves, 0) as power_play_saves,
+            COALESCE(g.power_play_shots, 0) as power_play_shots,
+            COALESCE(g.shorthanded_saves, 0) as shorthanded_saves,
+            COALESCE(g.shorthanded_shots, 0) as shorthanded_shots,
+            COALESCE(g.is_starter, FALSE) as is_starter,
+            g.decision
+        FROM game_goalie_stats g
+        JOIN players p ON g.player_id = p.player_id
+        JOIN teams t ON g.team_id = t.team_id
+        WHERE g.game_id = $1
+        ORDER BY g.team_id, g.toi_seconds DESC
+    """
+    goalie_rows = await db.fetch(goalie_query, game_id)
+
+    home_goalies: list[GoalieGameStats] = []
+    away_goalies: list[GoalieGameStats] = []
+
+    for row in goalie_rows:
+        row_dict = dict(row)
+        row_dict["toi_formatted"] = _format_toi(row_dict.get("toi_seconds", 0))
+        goalie = GoalieGameStats(**row_dict)
+
+        if row["team_id"] == home_team_id:
+            home_goalies.append(goalie)
+        else:
+            away_goalies.append(goalie)
+
+    return GamePlayerStats(
+        game_id=game_id,
+        home_team_id=home_team_id,
+        home_team_abbr=home_team_abbr,
+        away_team_id=away_team_id,
+        away_team_abbr=away_team_abbr,
+        home_skaters=home_skaters,
+        away_skaters=away_skaters,
+        home_goalies=home_goalies,
+        away_goalies=away_goalies,
+    )
+
+
+@router.get(
+    "/games/{game_id}/shifts",
+    response_model=GameShiftsResponse,
+    summary="Get Game Shifts",
+    description="Get shift chart data for a game",
+)
+async def get_game_shifts(
+    db: DbDep,
+    game_id: int,
+) -> GameShiftsResponse:
+    """Get shift data for a specific game.
+
+    Returns per-player TOI breakdown with period-by-period details.
+    """
+    # First get game info to determine home/away teams
+    game_query = """
+        SELECT home_team_id, away_team_id, home_team_abbr, away_team_abbr
+        FROM mv_game_summary
+        WHERE game_id = $1
+    """
+    game_row = await db.fetchrow(game_query, game_id)
+
+    if not game_row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Game with ID {game_id} not found",
+        )
+
+    home_team_id = game_row["home_team_id"]
+    away_team_id = game_row["away_team_id"]
+    home_team_abbr = game_row["home_team_abbr"]
+    away_team_abbr = game_row["away_team_abbr"]
+
+    # Get shift data aggregated by player
+    shifts_query = """
+        SELECT
+            s.player_id,
+            p.first_name || ' ' || p.last_name as player_name,
+            p.sweater_number,
+            p.position_code as position,
+            s.team_id,
+            t.abbreviation as team_abbr,
+            COUNT(*) as total_shifts,
+            SUM(s.duration) as total_toi_seconds,
+            SUM(CASE WHEN s.period = 1 THEN s.duration ELSE 0 END) as period_1_toi,
+            SUM(CASE WHEN s.period = 2 THEN s.duration ELSE 0 END) as period_2_toi,
+            SUM(CASE WHEN s.period = 3 THEN s.duration ELSE 0 END) as period_3_toi,
+            SUM(CASE WHEN s.period > 3 THEN s.duration ELSE 0 END) as ot_toi
+        FROM game_shifts s
+        JOIN players p ON s.player_id = p.player_id
+        JOIN teams t ON s.team_id = t.team_id
+        WHERE s.game_id = $1
+        GROUP BY s.player_id, p.first_name, p.last_name, p.sweater_number,
+                 p.position_code, s.team_id, t.abbreviation
+        ORDER BY s.team_id, SUM(s.duration) DESC
+    """
+    shift_rows = await db.fetch(shifts_query, game_id)
+
+    home_players: list[PlayerShiftSummary] = []
+    away_players: list[PlayerShiftSummary] = []
+
+    for row in shift_rows:
+        total_toi = row["total_toi_seconds"] or 0
+        total_shifts = row["total_shifts"] or 0
+        avg_shift = total_toi / total_shifts if total_shifts > 0 else 0.0
+
+        player_summary = PlayerShiftSummary(
+            player_id=row["player_id"],
+            player_name=row["player_name"],
+            sweater_number=row["sweater_number"],
+            position=row["position"],
+            team_id=row["team_id"],
+            team_abbr=row["team_abbr"],
+            total_toi_seconds=total_toi,
+            total_toi_display=_format_toi(total_toi),
+            total_shifts=total_shifts,
+            avg_shift_seconds=round(avg_shift, 1),
+            period_1_toi=row["period_1_toi"] or 0,
+            period_2_toi=row["period_2_toi"] or 0,
+            period_3_toi=row["period_3_toi"] or 0,
+            ot_toi=row["ot_toi"] or 0,
+        )
+
+        if row["team_id"] == home_team_id:
+            home_players.append(player_summary)
+        else:
+            away_players.append(player_summary)
+
+    return GameShiftsResponse(
+        game_id=game_id,
+        home_team_id=home_team_id,
+        home_team_abbr=home_team_abbr,
+        away_team_id=away_team_id,
+        away_team_abbr=away_team_abbr,
+        home_players=home_players,
+        away_players=away_players,
+    )
+
+
+# =============================================================================
+# Player Game Log
+# =============================================================================
+
+
+@router.get(
+    "/players/{player_id}/games",
+    response_model=PlayerGameLogResponse,
+    summary="Get Player Game Log",
+    description="Get a player's recent games with stats",
+)
+async def get_player_games(
+    db: DbDep,
+    player_id: int,
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 25,
+    season: Annotated[
+        str | None, Query(description="Filter by season (e.g., '20242025')")
+    ] = None,
+) -> PlayerGameLogResponse:
+    """Get a player's game log with per-game statistics.
+
+    Returns recent games with stats, clickable to navigate to game details.
+    """
+    # Get player info
+    player_query = """
+        SELECT player_id, full_name, position_type
+        FROM mv_player_summary
+        WHERE player_id = $1
+    """
+    player_row = await db.fetchrow(player_query, player_id)
+
+    if not player_row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Player with ID {player_id} not found",
+        )
+
+    player_name = player_row["full_name"]
+    position_type = player_row["position_type"]
+
+    # Build WHERE clauses for game log
+    conditions: list[str] = []
+    params: list[object] = [player_id]
+    param_idx = 2
+
+    if season:
+        conditions.append(f"g.season_name = ${param_idx}")
+        params.append(season)
+        param_idx += 1
+
+    where_clause = " AND ".join(conditions) if conditions else "TRUE"
+
+    # Determine if player is a goalie
+    is_goalie = position_type == "G"
+
+    if is_goalie:
+        # Get goalie game log
+        count_query = f"""
+            SELECT COUNT(*)
+            FROM game_goalie_stats gs
+            JOIN mv_game_summary g ON gs.game_id = g.game_id
+            WHERE gs.player_id = $1 AND {where_clause}
+        """
+        total_items = await db.fetchval(count_query, *params)
+
+        total_pages = (total_items + per_page - 1) // per_page if total_items > 0 else 0
+        offset = (page - 1) * per_page
+
+        games_query = f"""
+            SELECT
+                g.game_id,
+                g.game_date,
+                g.season_id,
+                CASE
+                    WHEN gs.team_id = g.home_team_id THEN g.away_team_id
+                    ELSE g.home_team_id
+                END as opponent_team_id,
+                CASE
+                    WHEN gs.team_id = g.home_team_id THEN g.away_team_abbr
+                    ELSE g.home_team_abbr
+                END as opponent_abbr,
+                CASE
+                    WHEN gs.team_id = g.home_team_id THEN g.away_team_name
+                    ELSE g.home_team_name
+                END as opponent_name,
+                gs.team_id = g.home_team_id as is_home,
+                CASE
+                    WHEN g.winner_team_id = gs.team_id THEN 'W'
+                    WHEN g.is_overtime THEN 'OTL'
+                    WHEN g.is_shootout THEN 'SOL'
+                    ELSE 'L'
+                END as result,
+                CASE
+                    WHEN gs.team_id = g.home_team_id THEN g.home_score
+                    ELSE g.away_score
+                END as player_team_score,
+                CASE
+                    WHEN gs.team_id = g.home_team_id THEN g.away_score
+                    ELSE g.home_score
+                END as opponent_score,
+                gs.saves,
+                gs.shots_against,
+                gs.save_pct,
+                gs.decision
+            FROM game_goalie_stats gs
+            JOIN mv_game_summary g ON gs.game_id = g.game_id
+            WHERE gs.player_id = $1 AND {where_clause}
+            ORDER BY g.game_date DESC
+            LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """
+        params.extend([per_page, offset])
+        game_rows = await db.fetch(games_query, *params)
+
+        games = [
+            PlayerGameEntry(
+                game_id=row["game_id"],
+                game_date=row["game_date"],
+                season_id=row["season_id"],
+                opponent_team_id=row["opponent_team_id"],
+                opponent_abbr=row["opponent_abbr"],
+                opponent_name=row["opponent_name"],
+                is_home=row["is_home"],
+                result=row["result"],
+                player_team_score=row["player_team_score"],
+                opponent_score=row["opponent_score"],
+                saves=row["saves"],
+                shots_against=row["shots_against"],
+                save_pct=row["save_pct"],
+                decision=row["decision"],
+            )
+            for row in game_rows
+        ]
+    else:
+        # Get skater game log
+        count_query = f"""
+            SELECT COUNT(*)
+            FROM game_skater_stats ss
+            JOIN mv_game_summary g ON ss.game_id = g.game_id
+            WHERE ss.player_id = $1 AND {where_clause}
+        """
+        total_items = await db.fetchval(count_query, *params)
+
+        total_pages = (total_items + per_page - 1) // per_page if total_items > 0 else 0
+        offset = (page - 1) * per_page
+
+        games_query = f"""
+            SELECT
+                g.game_id,
+                g.game_date,
+                g.season_id,
+                CASE
+                    WHEN ss.team_id = g.home_team_id THEN g.away_team_id
+                    ELSE g.home_team_id
+                END as opponent_team_id,
+                CASE
+                    WHEN ss.team_id = g.home_team_id THEN g.away_team_abbr
+                    ELSE g.home_team_abbr
+                END as opponent_abbr,
+                CASE
+                    WHEN ss.team_id = g.home_team_id THEN g.away_team_name
+                    ELSE g.home_team_name
+                END as opponent_name,
+                ss.team_id = g.home_team_id as is_home,
+                CASE
+                    WHEN g.winner_team_id = ss.team_id THEN 'W'
+                    WHEN g.is_overtime THEN 'OTL'
+                    WHEN g.is_shootout THEN 'SOL'
+                    ELSE 'L'
+                END as result,
+                CASE
+                    WHEN ss.team_id = g.home_team_id THEN g.home_score
+                    ELSE g.away_score
+                END as player_team_score,
+                CASE
+                    WHEN ss.team_id = g.home_team_id THEN g.away_score
+                    ELSE g.home_score
+                END as opponent_score,
+                ss.goals,
+                ss.assists,
+                ss.points,
+                ss.plus_minus,
+                ss.pim,
+                ss.shots,
+                ss.toi_seconds
+            FROM game_skater_stats ss
+            JOIN mv_game_summary g ON ss.game_id = g.game_id
+            WHERE ss.player_id = $1 AND {where_clause}
+            ORDER BY g.game_date DESC
+            LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """
+        params.extend([per_page, offset])
+        game_rows = await db.fetch(games_query, *params)
+
+        games = [
+            PlayerGameEntry(
+                game_id=row["game_id"],
+                game_date=row["game_date"],
+                season_id=row["season_id"],
+                opponent_team_id=row["opponent_team_id"],
+                opponent_abbr=row["opponent_abbr"],
+                opponent_name=row["opponent_name"],
+                is_home=row["is_home"],
+                result=row["result"],
+                player_team_score=row["player_team_score"],
+                opponent_score=row["opponent_score"],
+                goals=row["goals"],
+                assists=row["assists"],
+                points=row["points"],
+                plus_minus=row["plus_minus"],
+                pim=row["pim"],
+                shots=row["shots"],
+                toi_display=_format_toi(row["toi_seconds"]),
+            )
+            for row in game_rows
+        ]
+
+    return PlayerGameLogResponse(
+        player_id=player_id,
+        player_name=player_name,
+        position_type=position_type,
+        games=games,
+        pagination=PaginationMeta(
+            page=page,
+            per_page=per_page,
+            total_items=total_items,
+            total_pages=total_pages,
+        ),
+    )
+
+
+# =============================================================================
+# Team Recent Games
+# =============================================================================
+
+
+@router.get(
+    "/teams/{team_id}/games",
+    response_model=TeamRecentGamesResponse,
+    summary="Get Team Games",
+    description="Get a team's recent and upcoming games",
+)
+async def get_team_games(
+    db: DbDep,
+    team_id: int,
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 25,
+    season: Annotated[
+        str | None, Query(description="Filter by season (e.g., '20242025')")
+    ] = None,
+) -> TeamRecentGamesResponse:
+    """Get a team's recent and upcoming games.
+
+    Returns games where the team is either home or away.
+    """
+    # Get team info
+    team_query = """
+        SELECT team_id, name, abbreviation
+        FROM teams
+        WHERE team_id = $1
+    """
+    team_row = await db.fetchrow(team_query, team_id)
+
+    if not team_row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Team with ID {team_id} not found",
+        )
+
+    team_name = team_row["name"]
+    team_abbr = team_row["abbreviation"]
+
+    # Build WHERE clauses
+    conditions: list[str] = ["(home_team_id = $1 OR away_team_id = $1)"]
+    params: list[object] = [team_id]
+    param_idx = 2
+
+    if season:
+        conditions.append(f"season_name = ${param_idx}")
+        params.append(season)
+        param_idx += 1
+
+    where_clause = " AND ".join(conditions)
+
+    # Get total count
+    count_query = f"SELECT COUNT(*) FROM mv_game_summary WHERE {where_clause}"
+    total_items = await db.fetchval(count_query, *params)
+
+    total_pages = (total_items + per_page - 1) // per_page if total_items > 0 else 0
+    offset = (page - 1) * per_page
+
+    # Get games
+    games_query = f"""
+        SELECT
+            game_id, season_id, season_name, game_type, game_type_name,
+            game_date, game_time, venue_name, home_team_id,
+            home_team_name, home_team_abbr, home_score,
+            away_team_id, away_team_name, away_team_abbr, away_score,
+            game_state, is_overtime, is_shootout, winner_abbr
+        FROM mv_game_summary
+        WHERE {where_clause}
+        ORDER BY game_date DESC, game_time DESC NULLS LAST
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+    """
+    params.extend([per_page, offset])
+    game_rows = await db.fetch(games_query, *params)
+
+    games = [GameSummary(**dict(row)) for row in game_rows]
+
+    return TeamRecentGamesResponse(
+        team_id=team_id,
+        team_name=team_name,
+        team_abbr=team_abbr,
+        games=games,
+        pagination=PaginationMeta(
+            page=page,
+            per_page=per_page,
+            total_items=total_items,
+            total_pages=total_pages,
+        ),
+    )

--- a/src/nhl_api/viewer/schemas/entities.py
+++ b/src/nhl_api/viewer/schemas/entities.py
@@ -220,3 +220,227 @@ class GameListResponse(BaseModel):
 
     games: list[GameSummary]
     pagination: PaginationMeta
+
+
+# =============================================================================
+# Game Events (Play-by-Play)
+# =============================================================================
+
+
+class PlayByPlayEvent(BaseModel):
+    """Individual play-by-play event."""
+
+    event_idx: int
+    event_type: str
+    period: int
+    period_type: str | None = None
+    time_in_period: str | None = None
+    time_remaining: str | None = None
+    description: str | None = None
+    player1_id: int | None = None
+    player1_name: str | None = None
+    player1_role: str | None = None
+    player2_id: int | None = None
+    player2_name: str | None = None
+    player2_role: str | None = None
+    player3_id: int | None = None
+    player3_name: str | None = None
+    player3_role: str | None = None
+    team_id: int | None = None
+    team_abbr: str | None = None
+    home_score: int = 0
+    away_score: int = 0
+    shot_type: str | None = None
+    zone: str | None = None
+    x_coord: float | None = None
+    y_coord: float | None = None
+
+
+class GameEventsResponse(BaseModel):
+    """Response for game events endpoint."""
+
+    game_id: int
+    events: list[PlayByPlayEvent]
+    total_events: int
+
+
+# =============================================================================
+# Game Player Statistics
+# =============================================================================
+
+
+class SkaterGameStats(BaseModel):
+    """Individual skater statistics for a game."""
+
+    player_id: int
+    player_name: str
+    team_id: int
+    team_abbr: str
+    position: str | None = None
+    goals: int = 0
+    assists: int = 0
+    points: int = 0
+    plus_minus: int = 0
+    pim: int = 0
+    shots: int = 0
+    hits: int = 0
+    blocked_shots: int = 0
+    giveaways: int = 0
+    takeaways: int = 0
+    faceoff_pct: float | None = None
+    toi_seconds: int = 0
+    toi_formatted: str = "00:00"
+    shifts: int = 0
+    power_play_goals: int = 0
+    shorthanded_goals: int = 0
+
+
+class GoalieGameStats(BaseModel):
+    """Individual goalie statistics for a game."""
+
+    player_id: int
+    player_name: str
+    team_id: int
+    team_abbr: str
+    saves: int = 0
+    shots_against: int = 0
+    goals_against: int = 0
+    save_pct: float | None = None
+    toi_seconds: int = 0
+    toi_formatted: str = "00:00"
+    even_strength_saves: int = 0
+    even_strength_shots: int = 0
+    power_play_saves: int = 0
+    power_play_shots: int = 0
+    shorthanded_saves: int = 0
+    shorthanded_shots: int = 0
+    is_starter: bool = False
+    decision: str | None = None
+
+
+class GamePlayerStats(BaseModel):
+    """All player statistics for a game."""
+
+    game_id: int
+    home_team_id: int
+    home_team_abbr: str
+    away_team_id: int
+    away_team_abbr: str
+    home_skaters: list[SkaterGameStats]
+    away_skaters: list[SkaterGameStats]
+    home_goalies: list[GoalieGameStats]
+    away_goalies: list[GoalieGameStats]
+
+
+# =============================================================================
+# Game Shifts (TOI Detail)
+# =============================================================================
+
+
+class ShiftDetail(BaseModel):
+    """Individual shift record."""
+
+    shift_number: int
+    period: int
+    start_time: str
+    end_time: str
+    duration_seconds: int
+    is_goal_event: bool = False
+    event_description: str | None = None
+
+
+class PlayerShiftSummary(BaseModel):
+    """Player shift summary with TOI breakdown."""
+
+    player_id: int
+    player_name: str
+    sweater_number: int | None = None
+    position: str | None = None
+    team_id: int
+    team_abbr: str
+
+    # Total TOI
+    total_toi_seconds: int = 0
+    total_toi_display: str = "00:00"
+    total_shifts: int = 0
+    avg_shift_seconds: float = 0.0
+
+    # By period (period number -> seconds)
+    period_1_toi: int = 0
+    period_2_toi: int = 0
+    period_3_toi: int = 0
+    ot_toi: int = 0
+
+
+class GameShiftsResponse(BaseModel):
+    """All shift data for a game."""
+
+    game_id: int
+    home_team_id: int
+    home_team_abbr: str
+    away_team_id: int
+    away_team_abbr: str
+    home_players: list[PlayerShiftSummary]
+    away_players: list[PlayerShiftSummary]
+
+
+# =============================================================================
+# Player Game Log
+# =============================================================================
+
+
+class PlayerGameEntry(BaseModel):
+    """Single game entry in a player's game log (clickable game)."""
+
+    game_id: int
+    game_date: date
+    season_id: int
+    opponent_team_id: int
+    opponent_abbr: str
+    opponent_name: str
+    is_home: bool
+    result: str | None = None  # W, L, OTL
+
+    # Scores
+    player_team_score: int | None = None
+    opponent_score: int | None = None
+
+    # Stats (for skaters)
+    goals: int | None = None
+    assists: int | None = None
+    points: int | None = None
+    plus_minus: int | None = None
+    pim: int | None = None
+    shots: int | None = None
+    toi_display: str | None = None
+
+    # Stats (for goalies)
+    saves: int | None = None
+    shots_against: int | None = None
+    save_pct: float | None = None
+    decision: str | None = None
+
+
+class PlayerGameLogResponse(BaseModel):
+    """Player's game log with recent games."""
+
+    player_id: int
+    player_name: str
+    position_type: str | None = None
+    games: list[PlayerGameEntry]
+    pagination: PaginationMeta
+
+
+# =============================================================================
+# Team Games (Recent Schedule)
+# =============================================================================
+
+
+class TeamRecentGamesResponse(BaseModel):
+    """Team's recent and upcoming games."""
+
+    team_id: int
+    team_name: str
+    team_abbr: str
+    games: list[GameSummary]
+    pagination: PaginationMeta

--- a/viewer-frontend/package-lock.json
+++ b/viewer-frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@tanstack/react-query": "^5.90.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1102,6 +1103,50 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1122,6 +1167,39 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1259,6 +1337,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -1267,6 +1376,51 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/viewer-frontend/package.json
+++ b/viewer-frontend/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@tanstack/react-query": "^5.90.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/viewer-frontend/src/components/EntityLinks.tsx
+++ b/viewer-frontend/src/components/EntityLinks.tsx
@@ -1,0 +1,209 @@
+/**
+ * Reusable clickable link components for navigating between entities.
+ *
+ * These components provide consistent styling and navigation for:
+ * - Players: Navigate to player detail page
+ * - Teams: Navigate to team detail page
+ * - Games: Navigate to game detail page
+ */
+
+import { Link } from 'react-router-dom'
+import { cn } from '@/lib/utils'
+
+interface PlayerLinkProps {
+  playerId: number
+  playerName: string
+  /** Optional team abbreviation to display */
+  teamAbbr?: string
+  /** Optional sweater number to display */
+  sweaterNumber?: number
+  /** Optional CSS class */
+  className?: string
+  /** Show as compact (name only) or full (with team/number) */
+  compact?: boolean
+}
+
+/**
+ * Clickable player name that navigates to player detail page.
+ *
+ * @example
+ * <PlayerLink playerId={8478402} playerName="Nathan MacKinnon" />
+ * <PlayerLink playerId={8478402} playerName="Nathan MacKinnon" sweaterNumber={29} teamAbbr="COL" />
+ */
+export function PlayerLink({
+  playerId,
+  playerName,
+  teamAbbr,
+  sweaterNumber,
+  className,
+  compact = true,
+}: PlayerLinkProps) {
+  const displayText = compact
+    ? playerName
+    : sweaterNumber
+      ? `#${sweaterNumber} ${playerName}${teamAbbr ? ` (${teamAbbr})` : ''}`
+      : `${playerName}${teamAbbr ? ` (${teamAbbr})` : ''}`
+
+  return (
+    <Link
+      to={`/players/${playerId}`}
+      className={cn(
+        'text-primary hover:text-primary/80 hover:underline font-medium transition-colors',
+        className
+      )}
+    >
+      {displayText}
+    </Link>
+  )
+}
+
+interface TeamLinkProps {
+  teamId: number
+  /** Team name or abbreviation to display */
+  teamName: string
+  /** Optional abbreviation (if teamName is full name) */
+  abbreviation?: string
+  /** Optional CSS class */
+  className?: string
+  /** Display mode: 'name' | 'abbr' | 'full' (name + abbr) */
+  display?: 'name' | 'abbr' | 'full'
+}
+
+/**
+ * Clickable team name that navigates to team detail page.
+ *
+ * @example
+ * <TeamLink teamId={21} teamName="Colorado Avalanche" />
+ * <TeamLink teamId={21} teamName="COL" display="abbr" />
+ */
+export function TeamLink({
+  teamId,
+  teamName,
+  abbreviation,
+  className,
+  display = 'name',
+}: TeamLinkProps) {
+  const displayText =
+    display === 'abbr'
+      ? abbreviation || teamName
+      : display === 'full' && abbreviation
+        ? `${teamName} (${abbreviation})`
+        : teamName
+
+  return (
+    <Link
+      to={`/teams/${teamId}`}
+      className={cn(
+        'text-primary hover:text-primary/80 hover:underline font-medium transition-colors',
+        className
+      )}
+    >
+      {displayText}
+    </Link>
+  )
+}
+
+interface GameLinkProps {
+  gameId: number
+  /** What to display for the game link */
+  children: React.ReactNode
+  /** Optional CSS class */
+  className?: string
+}
+
+/**
+ * Clickable game reference that navigates to game detail page.
+ *
+ * @example
+ * <GameLink gameId={2024020500}>COL @ VAN - Dec 15</GameLink>
+ * <GameLink gameId={2024020500}>View Game</GameLink>
+ */
+export function GameLink({ gameId, children, className }: GameLinkProps) {
+  return (
+    <Link
+      to={`/games/${gameId}`}
+      className={cn(
+        'text-primary hover:text-primary/80 hover:underline font-medium transition-colors',
+        className
+      )}
+    >
+      {children}
+    </Link>
+  )
+}
+
+interface GameScoreLinkProps {
+  gameId: number
+  homeTeamId: number
+  homeTeamAbbr: string
+  homeScore: number | null
+  awayTeamId: number
+  awayTeamAbbr: string
+  awayScore: number | null
+  /** Optional CSS class for container */
+  className?: string
+  /** Show final indicator for completed games */
+  isFinal?: boolean
+}
+
+/**
+ * Combined game score display with clickable team names.
+ * Shows: "COL 4 @ VAN 2" with both team names clickable.
+ *
+ * @example
+ * <GameScoreLink
+ *   gameId={2024020500}
+ *   homeTeamId={23}
+ *   homeTeamAbbr="VAN"
+ *   homeScore={2}
+ *   awayTeamId={21}
+ *   awayTeamAbbr="COL"
+ *   awayScore={4}
+ * />
+ */
+export function GameScoreLink({
+  gameId,
+  homeTeamId,
+  homeTeamAbbr,
+  homeScore,
+  awayTeamId,
+  awayTeamAbbr,
+  awayScore,
+  className,
+  isFinal = false,
+}: GameScoreLinkProps) {
+  return (
+    <div className={cn('flex items-center gap-2 text-sm', className)}>
+      <TeamLink teamId={awayTeamId} teamName={awayTeamAbbr} display="abbr" />
+      <span className="font-mono">
+        {awayScore ?? '-'} @ {homeScore ?? '-'}
+      </span>
+      <TeamLink teamId={homeTeamId} teamName={homeTeamAbbr} display="abbr" />
+      {isFinal && <span className="text-muted-foreground text-xs">(Final)</span>}
+      <GameLink gameId={gameId} className="ml-2 text-xs">
+        Details →
+      </GameLink>
+    </div>
+  )
+}
+
+/**
+ * Format a date for display in game context.
+ */
+export function formatGameDate(date: string | Date): string {
+  const d = typeof date === 'string' ? new Date(date) : date
+  return d.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+/**
+ * Format time on ice from seconds to MM:SS display.
+ */
+export function formatTOI(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}

--- a/viewer-frontend/src/components/Layout.tsx
+++ b/viewer-frontend/src/components/Layout.tsx
@@ -1,12 +1,13 @@
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/utils'
-import { Activity, Download, Users, Calendar, CheckCircle } from 'lucide-react'
+import { Activity, Download, Users, Calendar, CheckCircle, Shield } from 'lucide-react'
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: Activity },
   { name: 'Downloads', href: '/downloads', icon: Download },
-  { name: 'Players', href: '/players', icon: Users },
   { name: 'Games', href: '/games', icon: Calendar },
+  { name: 'Teams', href: '/teams', icon: Shield },
+  { name: 'Players', href: '/players', icon: Users },
   { name: 'Validation', href: '/validation', icon: CheckCircle },
 ]
 

--- a/viewer-frontend/src/components/ui/tabs.tsx
+++ b/viewer-frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/viewer-frontend/src/hooks/useGames.ts
+++ b/viewer-frontend/src/hooks/useGames.ts
@@ -1,0 +1,248 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+
+// Types
+
+interface PaginationMeta {
+  page: number
+  per_page: number
+  total_items: number
+  total_pages: number
+}
+
+export interface GameSummary {
+  game_id: number
+  season_id: number
+  season_name: string | null
+  game_type: string
+  game_type_name: string | null
+  game_date: string
+  game_time: string | null
+  venue_name: string | null
+  home_team_id: number
+  home_team_name: string
+  home_team_abbr: string
+  home_score: number | null
+  away_team_id: number
+  away_team_name: string
+  away_team_abbr: string
+  away_score: number | null
+  game_state: string | null
+  is_overtime: boolean
+  is_shootout: boolean
+  winner_abbr: string | null
+}
+
+export interface GameDetail extends GameSummary {
+  venue_id: number | null
+  venue_city: string | null
+  final_period: number | null
+  game_outcome: string | null
+  winner_team_id: number | null
+  goal_differential: number | null
+  attendance: number | null
+  game_duration_minutes: number | null
+  updated_at: string | null
+}
+
+interface GameListResponse {
+  games: GameSummary[]
+  pagination: PaginationMeta
+}
+
+export interface PlayByPlayEvent {
+  event_idx: number
+  event_type: string
+  period: number
+  period_type: string | null
+  time_in_period: string | null
+  time_remaining: string | null
+  description: string | null
+  player1_id: number | null
+  player1_name: string | null
+  player1_role: string | null
+  player2_id: number | null
+  player2_name: string | null
+  player2_role: string | null
+  player3_id: number | null
+  player3_name: string | null
+  player3_role: string | null
+  team_id: number | null
+  team_abbr: string | null
+  home_score: number
+  away_score: number
+  shot_type: string | null
+  zone: string | null
+  x_coord: number | null
+  y_coord: number | null
+}
+
+interface GameEventsResponse {
+  game_id: number
+  events: PlayByPlayEvent[]
+  total_events: number
+}
+
+export interface SkaterGameStats {
+  player_id: number
+  player_name: string
+  team_id: number
+  team_abbr: string
+  position: string | null
+  goals: number
+  assists: number
+  points: number
+  plus_minus: number
+  pim: number
+  shots: number
+  hits: number
+  blocked_shots: number
+  giveaways: number
+  takeaways: number
+  faceoff_pct: number | null
+  toi_seconds: number
+  toi_formatted: string
+  shifts: number
+  power_play_goals: number
+  shorthanded_goals: number
+}
+
+export interface GoalieGameStats {
+  player_id: number
+  player_name: string
+  team_id: number
+  team_abbr: string
+  saves: number
+  shots_against: number
+  goals_against: number
+  save_pct: number | null
+  toi_seconds: number
+  toi_formatted: string
+  even_strength_saves: number
+  even_strength_shots: number
+  power_play_saves: number
+  power_play_shots: number
+  shorthanded_saves: number
+  shorthanded_shots: number
+  is_starter: boolean
+  decision: string | null
+}
+
+export interface GamePlayerStats {
+  game_id: number
+  home_team_id: number
+  home_team_abbr: string
+  away_team_id: number
+  away_team_abbr: string
+  home_skaters: SkaterGameStats[]
+  away_skaters: SkaterGameStats[]
+  home_goalies: GoalieGameStats[]
+  away_goalies: GoalieGameStats[]
+}
+
+// Filter types
+
+export interface GameFilters {
+  page?: number
+  per_page?: number
+  season?: string
+  team_id?: number
+  start_date?: string
+  end_date?: string
+  game_type?: 'PR' | 'R' | 'P' | 'A'
+}
+
+export interface EventFilters {
+  period?: number
+  event_type?: string
+}
+
+// Hooks
+
+export function useGames(filters: GameFilters = {}) {
+  const params: Record<string, string> = {}
+
+  if (filters.page) params.page = String(filters.page)
+  if (filters.per_page) params.per_page = String(filters.per_page)
+  if (filters.season) params.season = filters.season
+  if (filters.team_id) params.team_id = String(filters.team_id)
+  if (filters.start_date) params.start_date = filters.start_date
+  if (filters.end_date) params.end_date = filters.end_date
+  if (filters.game_type) params.game_type = filters.game_type
+
+  return useQuery({
+    queryKey: ['games', filters],
+    queryFn: () => api.get<GameListResponse>('/entities/games', params),
+    staleTime: 60 * 1000, // 1 minute
+  })
+}
+
+export function useGameDetail(gameId: number | null) {
+  return useQuery({
+    queryKey: ['games', gameId],
+    queryFn: () => api.get<GameDetail>(`/entities/games/${gameId}`),
+    enabled: gameId !== null,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+export function useGameEvents(gameId: number | null, filters: EventFilters = {}) {
+  const params: Record<string, string> = {}
+
+  if (filters.period !== undefined) params.period = String(filters.period)
+  if (filters.event_type) params.event_type = filters.event_type
+
+  return useQuery({
+    queryKey: ['games', gameId, 'events', filters],
+    queryFn: () => api.get<GameEventsResponse>(`/entities/games/${gameId}/events`, params),
+    enabled: gameId !== null,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+export function useGameStats(gameId: number | null) {
+  return useQuery({
+    queryKey: ['games', gameId, 'stats'],
+    queryFn: () => api.get<GamePlayerStats>(`/entities/games/${gameId}/stats`),
+    enabled: gameId !== null,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+// Shift types
+
+export interface PlayerShiftSummary {
+  player_id: number
+  player_name: string
+  sweater_number: number | null
+  position: string | null
+  team_id: number
+  team_abbr: string
+  total_toi_seconds: number
+  total_toi_display: string
+  total_shifts: number
+  avg_shift_seconds: number
+  period_1_toi: number
+  period_2_toi: number
+  period_3_toi: number
+  ot_toi: number
+}
+
+export interface GameShiftsResponse {
+  game_id: number
+  home_team_id: number
+  home_team_abbr: string
+  away_team_id: number
+  away_team_abbr: string
+  home_players: PlayerShiftSummary[]
+  away_players: PlayerShiftSummary[]
+}
+
+export function useGameShifts(gameId: number | null) {
+  return useQuery({
+    queryKey: ['games', gameId, 'shifts'],
+    queryFn: () => api.get<GameShiftsResponse>(`/entities/games/${gameId}/shifts`),
+    enabled: gameId !== null,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}

--- a/viewer-frontend/src/pages/Games.tsx
+++ b/viewer-frontend/src/pages/Games.tsx
@@ -1,8 +1,689 @@
+import { useState } from 'react'
+import { ChevronLeft, ChevronRight, Trophy, Clock, MapPin, Users, AlertCircle } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  useGames,
+  useGameDetail,
+  useGameEvents,
+  useGameStats,
+  type GameSummary,
+  type GameFilters,
+} from '@/hooks/useGames'
 
-export function Games() {
+// Format date for display
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr)
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+// Format game type
+function formatGameType(type: string): string {
+  const types: Record<string, string> = {
+    PR: 'Preseason',
+    R: 'Regular',
+    P: 'Playoff',
+    A: 'All-Star',
+  }
+  return types[type] || type
+}
+
+// Get game outcome badge
+function GameOutcomeBadge({ game }: { game: GameSummary }) {
+  if (game.game_state !== 'Final') {
+    return <Badge variant="secondary">{game.game_state || 'Scheduled'}</Badge>
+  }
+
+  const badges = []
+  if (game.is_shootout) {
+    badges.push(<Badge key="so" variant="warning">SO</Badge>)
+  } else if (game.is_overtime) {
+    badges.push(<Badge key="ot" variant="warning">OT</Badge>)
+  }
+
+  return <>{badges}</>
+}
+
+// Games List Component
+function GamesList({
+  games,
+  selectedGameId,
+  onSelectGame,
+  isLoading,
+}: {
+  games: GameSummary[]
+  selectedGameId: number | null
+  onSelectGame: (gameId: number) => void
+  isLoading: boolean
+}) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {[...Array(10)].map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    )
+  }
+
+  if (games.length === 0) {
+    return (
+      <div className="flex h-[200px] items-center justify-center text-muted-foreground">
+        No games found for the selected filters
+      </div>
+    )
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Date</TableHead>
+          <TableHead>Matchup</TableHead>
+          <TableHead className="text-center">Score</TableHead>
+          <TableHead className="text-center">Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {games.map((game) => (
+          <TableRow
+            key={game.game_id}
+            className={`cursor-pointer ${selectedGameId === game.game_id ? 'bg-muted' : ''}`}
+            onClick={() => onSelectGame(game.game_id)}
+          >
+            <TableCell className="font-medium">{formatDate(game.game_date)}</TableCell>
+            <TableCell>
+              <span className="font-medium">{game.away_team_abbr}</span>
+              <span className="text-muted-foreground"> @ </span>
+              <span className="font-medium">{game.home_team_abbr}</span>
+            </TableCell>
+            <TableCell className="text-center">
+              {game.game_state === 'Final' ? (
+                <span>
+                  <span className={game.winner_abbr === game.away_team_abbr ? 'font-bold' : ''}>
+                    {game.away_score}
+                  </span>
+                  <span className="text-muted-foreground"> - </span>
+                  <span className={game.winner_abbr === game.home_team_abbr ? 'font-bold' : ''}>
+                    {game.home_score}
+                  </span>
+                </span>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </TableCell>
+            <TableCell className="text-center">
+              <GameOutcomeBadge game={game} />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+// Game Detail Overview Tab
+function OverviewTab({ gameId }: { gameId: number }) {
+  const { data: game, isLoading, error } = useGameDetail(gameId)
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    )
+  }
+
+  if (error || !game) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        Failed to load game details
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Score Card */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex items-center justify-center gap-8">
+            <div className="text-center">
+              <div className="text-2xl font-bold">{game.away_team_abbr}</div>
+              <div className="text-sm text-muted-foreground">{game.away_team_name}</div>
+              <div className="mt-2 text-4xl font-bold">{game.away_score ?? 0}</div>
+            </div>
+            <div className="text-center">
+              <div className="text-muted-foreground">@</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                {game.game_outcome || 'Final'}
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold">{game.home_team_abbr}</div>
+              <div className="text-sm text-muted-foreground">{game.home_team_name}</div>
+              <div className="mt-2 text-4xl font-bold">{game.home_score ?? 0}</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Game Info */}
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardContent className="flex items-center gap-3 pt-6">
+            <Clock className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <div className="text-sm text-muted-foreground">Date & Time</div>
+              <div className="font-medium">{formatDate(game.game_date)}</div>
+              {game.game_time && (
+                <div className="text-sm text-muted-foreground">{game.game_time}</div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="flex items-center gap-3 pt-6">
+            <MapPin className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <div className="text-sm text-muted-foreground">Venue</div>
+              <div className="font-medium">{game.venue_name || 'TBD'}</div>
+              {game.venue_city && (
+                <div className="text-sm text-muted-foreground">{game.venue_city}</div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="flex items-center gap-3 pt-6">
+            <Users className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <div className="text-sm text-muted-foreground">Attendance</div>
+              <div className="font-medium">
+                {game.attendance?.toLocaleString() || 'N/A'}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {formatGameType(game.game_type)}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+// Play-by-Play Tab
+function PlayByPlayTab({ gameId }: { gameId: number }) {
+  const [periodFilter, setPeriodFilter] = useState<number | undefined>(undefined)
+  const { data, isLoading, error } = useGameEvents(gameId, { period: periodFilter })
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {[...Array(10)].map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        Failed to load events
+      </div>
+    )
+  }
+
+  const periods = [...new Set(data.events.map((e) => e.period))].sort()
+
+  return (
+    <div className="space-y-4">
+      {/* Period Filter */}
+      <div className="flex gap-2">
+        <Button
+          variant={periodFilter === undefined ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setPeriodFilter(undefined)}
+        >
+          All
+        </Button>
+        {periods.map((p) => (
+          <Button
+            key={p}
+            variant={periodFilter === p ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setPeriodFilter(p)}
+          >
+            {p <= 3 ? `P${p}` : p === 4 ? 'OT' : `OT${p - 3}`}
+          </Button>
+        ))}
+      </div>
+
+      {/* Events Table */}
+      <div className="max-h-[400px] overflow-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[60px]">Period</TableHead>
+              <TableHead className="w-[80px]">Time</TableHead>
+              <TableHead className="w-[80px]">Type</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead className="w-[80px] text-center">Score</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.events.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-muted-foreground">
+                  No events found
+                </TableCell>
+              </TableRow>
+            ) : (
+              data.events.map((event) => (
+                <TableRow key={event.event_idx}>
+                  <TableCell>{event.period}</TableCell>
+                  <TableCell>{event.time_in_period || '—'}</TableCell>
+                  <TableCell>
+                    <Badge variant={event.event_type === 'goal' ? 'success' : 'secondary'}>
+                      {event.event_type}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="max-w-[300px] truncate">
+                    {event.description || `${event.player1_name || ''} ${event.event_type}`}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    {event.away_score} - {event.home_score}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="text-sm text-muted-foreground">
+        Total events: {data.total_events}
+      </div>
+    </div>
+  )
+}
+
+// Goals Tab
+function GoalsTab({ gameId }: { gameId: number }) {
+  const { data, isLoading, error } = useGameEvents(gameId, { event_type: 'goal' })
+
+  if (isLoading) {
+    return <Skeleton className="h-[200px] w-full" />
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        Failed to load goals
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {data.events.length === 0 ? (
+        <div className="flex h-[200px] items-center justify-center text-muted-foreground">
+          No goals scored
+        </div>
+      ) : (
+        data.events.map((goal) => (
+          <Card key={goal.event_idx}>
+            <CardContent className="flex items-center gap-4 py-4">
+              <Trophy className="h-6 w-6 text-yellow-500" />
+              <div className="flex-1">
+                <div className="font-medium">
+                  {goal.player1_name || 'Unknown'}
+                  {goal.player2_name && (
+                    <span className="text-muted-foreground"> from {goal.player2_name}</span>
+                  )}
+                  {goal.player3_name && (
+                    <span className="text-muted-foreground"> and {goal.player3_name}</span>
+                  )}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Period {goal.period} • {goal.time_in_period}
+                  {goal.shot_type && ` • ${goal.shot_type}`}
+                </div>
+              </div>
+              <div className="text-right">
+                <Badge>{goal.team_abbr}</Badge>
+                <div className="mt-1 text-sm text-muted-foreground">
+                  {goal.away_score} - {goal.home_score}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))
+      )}
+    </div>
+  )
+}
+
+// Penalties Tab
+function PenaltiesTab({ gameId }: { gameId: number }) {
+  const { data, isLoading, error } = useGameEvents(gameId, { event_type: 'penalty' })
+
+  if (isLoading) {
+    return <Skeleton className="h-[200px] w-full" />
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        Failed to load penalties
+      </div>
+    )
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Period</TableHead>
+          <TableHead>Time</TableHead>
+          <TableHead>Team</TableHead>
+          <TableHead>Player</TableHead>
+          <TableHead>Infraction</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data.events.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={5} className="text-center text-muted-foreground">
+              No penalties called
+            </TableCell>
+          </TableRow>
+        ) : (
+          data.events.map((penalty) => (
+            <TableRow key={penalty.event_idx}>
+              <TableCell>{penalty.period}</TableCell>
+              <TableCell>{penalty.time_in_period || '—'}</TableCell>
+              <TableCell>
+                <Badge variant="outline">{penalty.team_abbr}</Badge>
+              </TableCell>
+              <TableCell>{penalty.player1_name || 'Team'}</TableCell>
+              <TableCell className="max-w-[200px] truncate">
+                {penalty.description || 'Penalty'}
+              </TableCell>
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+    </Table>
+  )
+}
+
+// Player Stats Tab
+function PlayerStatsTab({ gameId }: { gameId: number }) {
+  const { data, isLoading, error } = useGameStats(gameId)
+
+  if (isLoading) {
+    return <Skeleton className="h-[400px] w-full" />
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        Failed to load player stats
+      </div>
+    )
+  }
+
+  const renderSkaterTable = (skaters: typeof data.home_skaters, teamAbbr: string) => (
+    <div className="space-y-2">
+      <h4 className="font-semibold">{teamAbbr} Skaters</h4>
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Player</TableHead>
+              <TableHead className="text-center">G</TableHead>
+              <TableHead className="text-center">A</TableHead>
+              <TableHead className="text-center">P</TableHead>
+              <TableHead className="text-center">+/-</TableHead>
+              <TableHead className="text-center">PIM</TableHead>
+              <TableHead className="text-center">SOG</TableHead>
+              <TableHead className="text-center">TOI</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {skaters.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center text-muted-foreground">
+                  No skater data available
+                </TableCell>
+              </TableRow>
+            ) : (
+              skaters.map((player) => (
+                <TableRow key={player.player_id}>
+                  <TableCell className="font-medium">{player.player_name}</TableCell>
+                  <TableCell className="text-center">{player.goals}</TableCell>
+                  <TableCell className="text-center">{player.assists}</TableCell>
+                  <TableCell className="text-center font-semibold">{player.points}</TableCell>
+                  <TableCell className="text-center">
+                    {player.plus_minus > 0 ? `+${player.plus_minus}` : player.plus_minus}
+                  </TableCell>
+                  <TableCell className="text-center">{player.pim}</TableCell>
+                  <TableCell className="text-center">{player.shots}</TableCell>
+                  <TableCell className="text-center">{player.toi_formatted}</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+
+  const renderGoalieTable = (goalies: typeof data.home_goalies, teamAbbr: string) => (
+    <div className="space-y-2">
+      <h4 className="font-semibold">{teamAbbr} Goalies</h4>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Player</TableHead>
+            <TableHead className="text-center">Dec</TableHead>
+            <TableHead className="text-center">SA</TableHead>
+            <TableHead className="text-center">SV</TableHead>
+            <TableHead className="text-center">SV%</TableHead>
+            <TableHead className="text-center">TOI</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {goalies.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={6} className="text-center text-muted-foreground">
+                No goalie data available
+              </TableCell>
+            </TableRow>
+          ) : (
+            goalies.map((goalie) => (
+              <TableRow key={goalie.player_id}>
+                <TableCell className="font-medium">
+                  {goalie.player_name}
+                  {goalie.is_starter && (
+                    <Badge variant="secondary" className="ml-2">
+                      Start
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-center">
+                  {goalie.decision ? (
+                    <Badge
+                      variant={goalie.decision === 'W' ? 'success' : 'destructive'}
+                    >
+                      {goalie.decision}
+                    </Badge>
+                  ) : (
+                    '—'
+                  )}
+                </TableCell>
+                <TableCell className="text-center">{goalie.shots_against}</TableCell>
+                <TableCell className="text-center">{goalie.saves}</TableCell>
+                <TableCell className="text-center">
+                  {goalie.save_pct ? (goalie.save_pct * 100).toFixed(1) + '%' : '—'}
+                </TableCell>
+                <TableCell className="text-center">{goalie.toi_formatted}</TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+
   return (
     <div className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-4">
+          {renderSkaterTable(data.away_skaters, data.away_team_abbr)}
+          {renderGoalieTable(data.away_goalies, data.away_team_abbr)}
+        </div>
+        <div className="space-y-4">
+          {renderSkaterTable(data.home_skaters, data.home_team_abbr)}
+          {renderGoalieTable(data.home_goalies, data.home_team_abbr)}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Game Detail Component with Tabs
+function GameDetail({
+  gameId,
+  onPrevious,
+  onNext,
+  hasPrevious,
+  hasNext,
+}: {
+  gameId: number
+  onPrevious: () => void
+  onNext: () => void
+  hasPrevious: boolean
+  hasNext: boolean
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle>Game Details</CardTitle>
+          <CardDescription>Game ID: {gameId}</CardDescription>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onPrevious}
+            disabled={!hasPrevious}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onNext}
+            disabled={!hasNext}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="overview">
+          <TabsList className="grid w-full grid-cols-5">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="plays">Play-by-Play</TabsTrigger>
+            <TabsTrigger value="goals">Goals</TabsTrigger>
+            <TabsTrigger value="penalties">Penalties</TabsTrigger>
+            <TabsTrigger value="stats">Stats</TabsTrigger>
+          </TabsList>
+          <TabsContent value="overview">
+            <OverviewTab gameId={gameId} />
+          </TabsContent>
+          <TabsContent value="plays">
+            <PlayByPlayTab gameId={gameId} />
+          </TabsContent>
+          <TabsContent value="goals">
+            <GoalsTab gameId={gameId} />
+          </TabsContent>
+          <TabsContent value="penalties">
+            <PenaltiesTab gameId={gameId} />
+          </TabsContent>
+          <TabsContent value="stats">
+            <PlayerStatsTab gameId={gameId} />
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  )
+}
+
+// Main Games Page
+export function Games() {
+  const [filters, setFilters] = useState<GameFilters>({
+    page: 1,
+    per_page: 25,
+    season: '20242025',
+  })
+  const [selectedGameId, setSelectedGameId] = useState<number | null>(null)
+
+  const { data, isLoading, error } = useGames(filters)
+
+  const games = data?.games || []
+  const pagination = data?.pagination
+
+  // Find selected game index for navigation
+  const selectedIndex = games.findIndex((g) => g.game_id === selectedGameId)
+
+  const handlePreviousGame = () => {
+    if (selectedIndex > 0) {
+      setSelectedGameId(games[selectedIndex - 1].game_id)
+    }
+  }
+
+  const handleNextGame = () => {
+    if (selectedIndex < games.length - 1) {
+      setSelectedGameId(games[selectedIndex + 1].game_id)
+    }
+  }
+
+  const handlePageChange = (newPage: number) => {
+    setFilters((prev) => ({ ...prev, page: newPage }))
+    setSelectedGameId(null)
+  }
+
+  const handleSeasonChange = (season: string) => {
+    setFilters((prev) => ({ ...prev, season, page: 1 }))
+    setSelectedGameId(null)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Games</h1>
         <p className="text-muted-foreground">
@@ -10,19 +691,124 @@ export function Games() {
         </p>
       </div>
 
+      {/* Filters */}
       <Card>
         <CardHeader>
-          <CardTitle>Game Explorer</CardTitle>
-          <CardDescription>
-            Filter games by date range, team, or season
-          </CardDescription>
+          <CardTitle>Filters</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex h-[400px] items-center justify-center text-muted-foreground">
-            <p>Waiting for Entity API (#44) and Data Explorer (#48)</p>
+          <div className="flex flex-wrap gap-4">
+            <div className="space-y-1">
+              <label className="text-sm text-muted-foreground">Season</label>
+              <div className="flex gap-2">
+                {['20242025', '20232024', '20222023'].map((season) => (
+                  <Button
+                    key={season}
+                    variant={filters.season === season ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => handleSeasonChange(season)}
+                  >
+                    {season.slice(0, 4)}-{season.slice(4)}
+                  </Button>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm text-muted-foreground">Game Type</label>
+              <div className="flex gap-2">
+                {[
+                  { value: undefined, label: 'All' },
+                  { value: 'R' as const, label: 'Regular' },
+                  { value: 'P' as const, label: 'Playoff' },
+                  { value: 'PR' as const, label: 'Preseason' },
+                ].map((type) => (
+                  <Button
+                    key={type.label}
+                    variant={filters.game_type === type.value ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() =>
+                      setFilters((prev) => ({ ...prev, game_type: type.value, page: 1 }))
+                    }
+                  >
+                    {type.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
           </div>
         </CardContent>
       </Card>
+
+      {/* Error State */}
+      {error && (
+        <Card>
+          <CardContent className="flex items-center gap-2 py-6 text-destructive">
+            <AlertCircle className="h-5 w-5" />
+            <span>Failed to load games. Please try again.</span>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Games List */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Games</CardTitle>
+            <CardDescription>
+              {pagination
+                ? `Showing ${(pagination.page - 1) * pagination.per_page + 1}-${Math.min(
+                    pagination.page * pagination.per_page,
+                    pagination.total_items
+                  )} of ${pagination.total_items} games`
+                : 'Loading...'}
+            </CardDescription>
+          </div>
+          {pagination && pagination.total_pages > 1 && (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handlePageChange(pagination.page - 1)}
+                disabled={pagination.page <= 1}
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {pagination.page} of {pagination.total_pages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handlePageChange(pagination.page + 1)}
+                disabled={pagination.page >= pagination.total_pages}
+              >
+                Next
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </CardHeader>
+        <CardContent>
+          <GamesList
+            games={games}
+            selectedGameId={selectedGameId}
+            onSelectGame={setSelectedGameId}
+            isLoading={isLoading}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Game Detail */}
+      {selectedGameId && (
+        <GameDetail
+          gameId={selectedGameId}
+          onPrevious={handlePreviousGame}
+          onNext={handleNextGame}
+          hasPrevious={selectedIndex > 0}
+          hasNext={selectedIndex < games.length - 1}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Implements a comprehensive Game Data Browser for the NHL viewer, allowing users to browse games and explore detailed data through tabbed views.

### Features

**Game List**
- Browse games by season (2024-25, 2023-24, 2022-23)
- Filter by game type (Regular, Playoff, Preseason)
- Paginated list with date, matchup, score, and status
- Click to select game for detail view

**Game Detail Tabs**
1. **Overview** - Score card, venue, date/time, attendance
2. **Play-by-Play** - Filterable event list by period, shows all game events
3. **Goals** - Goal cards with scorer, assists, shot type, and period
4. **Penalties** - Penalty table with player, team, and infraction
5. **Stats** - Full skater and goalie statistics for both teams

**Navigation**
- Previous/Next game buttons to navigate within current page
- Keyboard-friendly with button navigation

### API Endpoints Added

| Endpoint | Description |
|----------|-------------|
| `GET /entities/games/{game_id}/events` | Play-by-play events with period/type filters |
| `GET /entities/games/{game_id}/stats` | Player statistics (skaters + goalies) |

### Files Changed

**Backend**
- `src/nhl_api/viewer/schemas/entities.py` - New schemas for events and stats
- `src/nhl_api/viewer/routers/entities.py` - New API endpoints

**Frontend**
- `viewer-frontend/src/pages/Games.tsx` - Full Games page implementation
- `viewer-frontend/src/hooks/useGames.ts` - React Query hooks for game data
- `viewer-frontend/src/components/ui/tabs.tsx` - Radix UI Tabs component
- `viewer-frontend/package.json` - Added @radix-ui/react-tabs

## Test Plan

- [x] Backend type checks pass (mypy)
- [x] Frontend builds successfully (npm run build)
- [x] All viewer unit tests pass (55 tests)
- [x] Pre-commit hooks pass (ruff, format, pytest)

## Screenshots

*Game list and detail views with tabbed interface*

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)