### PR TITLE
feat(downloaders): Add database persistence to Player Game Log Downloader (#124)

### DIFF
--- a/migrations/019_player_game_logs.sql
+++ b/migrations/019_player_game_logs.sql
@@ -1,0 +1,81 @@
+-- Migration: 019_player_game_logs.sql
+-- Description: Create player_game_logs table for per-game player statistics
+-- Author: Claude Code
+-- Date: 2025-12-21
+-- Issue: #124
+
+-- Player game logs table - individual game statistics for each player
+CREATE TABLE IF NOT EXISTS player_game_logs (
+    id SERIAL PRIMARY KEY,
+    player_id INTEGER NOT NULL,
+    game_id INTEGER NOT NULL,
+    season_id INTEGER NOT NULL,
+    game_type VARCHAR(5),  -- R (regular), P (playoff)
+    team_abbrev VARCHAR(5),
+    opponent_abbrev VARCHAR(5),
+    home_road_flag VARCHAR(1),  -- H or R
+    game_date DATE,
+
+    -- Common stats for all players
+    goals INTEGER,
+    assists INTEGER,
+    pim INTEGER,
+    toi_seconds INTEGER,
+
+    -- Skater-specific stats (null for goalies)
+    points INTEGER,
+    plus_minus INTEGER,
+    shots INTEGER,
+    shifts INTEGER,
+    power_play_goals INTEGER,
+    power_play_points INTEGER,
+    shorthanded_goals INTEGER,
+    shorthanded_points INTEGER,
+    game_winning_goals INTEGER,
+    ot_goals INTEGER,
+
+    -- Goalie-specific stats (null for skaters)
+    games_started INTEGER,
+    decision VARCHAR(2),  -- W, L, O (overtime loss)
+    shots_against INTEGER,
+    goals_against INTEGER,
+    save_pct FLOAT,
+    shutouts INTEGER,
+
+    -- Track whether this is a goalie record
+    is_goalie BOOLEAN DEFAULT FALSE,
+
+    -- Metadata
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+
+    -- Unique constraint per player per game
+    UNIQUE(player_id, game_id)
+);
+
+-- Create indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_player_game_logs_player_id ON player_game_logs(player_id);
+CREATE INDEX IF NOT EXISTS idx_player_game_logs_game_id ON player_game_logs(game_id);
+CREATE INDEX IF NOT EXISTS idx_player_game_logs_season_id ON player_game_logs(season_id);
+CREATE INDEX IF NOT EXISTS idx_player_game_logs_game_date ON player_game_logs(game_date);
+CREATE INDEX IF NOT EXISTS idx_player_game_logs_team ON player_game_logs(team_abbrev);
+
+-- Composite index for player season queries
+CREATE INDEX IF NOT EXISTS idx_player_game_logs_player_season
+ON player_game_logs(player_id, season_id, game_type);
+
+-- Add comments
+COMMENT ON TABLE player_game_logs IS 'Per-game statistics for individual players';
+COMMENT ON COLUMN player_game_logs.player_id IS 'NHL player ID';
+COMMENT ON COLUMN player_game_logs.game_id IS 'NHL game ID';
+COMMENT ON COLUMN player_game_logs.season_id IS 'Season ID (e.g., 20242025)';
+COMMENT ON COLUMN player_game_logs.game_type IS 'R for regular season, P for playoffs';
+COMMENT ON COLUMN player_game_logs.home_road_flag IS 'H for home, R for road';
+COMMENT ON COLUMN player_game_logs.toi_seconds IS 'Time on ice in seconds';
+COMMENT ON COLUMN player_game_logs.is_goalie IS 'True if this is a goalie record';
+COMMENT ON COLUMN player_game_logs.decision IS 'Goalie decision: W (win), L (loss), O (OT loss)';
+
+-- Add data source for player game logs
+INSERT INTO data_sources (name, source_type, base_url, description)
+VALUES ('nhl_player_game_log', 'nhl_json', 'https://api-web.nhle.com/v1/player', 'NHL player game log API')
+ON CONFLICT (name) DO NOTHING;

--- a/src/nhl_api/viewer/services/download_service.py
+++ b/src/nhl_api/viewer/services/download_service.py
@@ -32,7 +32,8 @@ SOURCE_NAME_TO_ID = {
     "nhl_roster": 4,
     "nhl_standings": 5,
     "nhl_player": 6,
-    # HTML sources (7-15) will be added when implemented
+    "nhl_player_game_log": 7,  # Player game logs
+    # HTML sources (8-15) will be added when implemented
     "shift_chart": 16,  # NHL Stats API shift charts
 }
 
@@ -257,6 +258,7 @@ class DownloadService:
         from nhl_api.downloaders.sources.nhl_json import (
             BoxscoreDownloader,
             PlayByPlayDownloader,
+            PlayerGameLogDownloader,
             PlayerLandingDownloader,
             RosterDownloader,
             ScheduleDownloader,
@@ -273,6 +275,7 @@ class DownloadService:
             "nhl_roster": RosterDownloader,
             "nhl_standings": StandingsDownloader,
             "nhl_player": PlayerLandingDownloader,
+            "nhl_player_game_log": PlayerGameLogDownloader,
         }
 
         downloader_cls = downloader_map.get(source_name)
@@ -301,6 +304,10 @@ class DownloadService:
                 )
             elif source_name == "nhl_player":
                 await self._download_player_landing(
+                    db, batch_id, downloader, season_id, active_download
+                )
+            elif source_name == "nhl_player_game_log":
+                await self._download_player_game_logs(
                     db, batch_id, downloader, season_id, active_download
                 )
 
@@ -671,6 +678,83 @@ class DownloadService:
             persisted = await downloader.persist(db, successful_results)
             logger.info(
                 "Persisted landing data for %d players for season %d",
+                persisted,
+                season_id,
+            )
+
+    async def _download_player_game_logs(
+        self,
+        db: DatabaseService,
+        batch_id: int,
+        downloader: Any,
+        season_id: int,
+        active_download: ActiveDownloadTask | None,
+    ) -> None:
+        """Download player game logs and persist to database."""
+        # Get player IDs from rosters
+        from nhl_api.downloaders.sources.nhl_json import (
+            NHL_TEAM_ABBREVS,
+            RosterDownloader,
+        )
+        from nhl_api.downloaders.sources.nhl_json.player_game_log import REGULAR_SEASON
+
+        roster_config = DownloaderConfig(base_url=NHL_API_BASE_URL)
+        player_ids: set[int] = set()
+
+        roster_dl = RosterDownloader(roster_config)
+        async with roster_dl:
+            for team_abbrev in NHL_TEAM_ABBREVS:
+                try:
+                    roster = await roster_dl.get_roster_for_season(
+                        team_abbrev, season_id
+                    )
+                    for player in roster.forwards + roster.defensemen + roster.goalies:
+                        player_ids.add(player.player_id)
+                except Exception as e:
+                    logger.warning("Failed to get roster for %s: %s", team_abbrev, e)
+
+        # Set players for game log download (player_id, season_id, game_type)
+        players_list = [(pid, season_id, REGULAR_SEASON) for pid in player_ids]
+        downloader.set_players(players_list)
+
+        if active_download:
+            active_download.items_total = len(player_ids)
+
+        await db.execute(
+            "UPDATE import_batches SET items_total = $1 WHERE batch_id = $2",
+            len(player_ids),
+            batch_id,
+        )
+
+        # Collect successful results for persistence
+        successful_results: list[dict[str, Any]] = []
+
+        # Download each player's game log
+        async for result in downloader.download_all():
+            if active_download and active_download.cancel_requested:
+                raise asyncio.CancelledError()
+
+            if result.is_successful:
+                successful_results.append(result.data)
+                if active_download:
+                    active_download.items_completed += 1
+                await db.execute(
+                    "UPDATE import_batches SET items_success = items_success + 1 WHERE batch_id = $1",
+                    batch_id,
+                )
+            else:
+                if active_download:
+                    active_download.items_failed += 1
+                await db.execute(
+                    "UPDATE import_batches SET items_failed = items_failed + 1 WHERE batch_id = $1",
+                    batch_id,
+                )
+
+        # Persist collected game logs
+        if successful_results:
+            persisted = await downloader.persist(db, successful_results)
+            logger.info(
+                "Persisted %d game log entries for season %d",
                 persisted,
                 season_id,
             )


### PR DESCRIPTION
## Summary

- Add migration to create `player_game_logs` table for per-game player statistics
- Implement `persist()` method in `PlayerGameLogDownloader` to upsert game log data
- Integrate persistence into `DownloadService` to call persist after download completes
- Add 22 unit tests for persist functionality and helper functions

## Changes

### Migration (019_player_game_logs.sql)
- Create `player_game_logs` table with:
  - Common fields: player_id, game_id, season_id, game_type, game_date, toi_seconds
  - Skater-specific: points, plus_minus, shots, shifts, PP/SH goals, GWG, OT goals
  - Goalie-specific: games_started, decision, shots_against, goals_against, save_pct, shutouts
- Indexes for player, game, season, date, and team queries
- Add `nhl_player_game_log` data source entry

### PlayerGameLogDownloader.persist()
- Helper functions: `_toi_to_seconds()`, `_game_type_to_string()`
- Upserts game log entries with different SQL for skaters vs goalies
- Converts TOI from MM:SS string to seconds
- Maps game_type (2=R, 3=P)
- Handles invalid dates gracefully (stores NULL)
- Continues processing on individual game errors

### DownloadService Integration
- Add `nhl_player_game_log` to SOURCE_NAME_TO_ID
- Add `_download_player_game_logs()` method
- Gets player IDs from rosters, downloads game logs for each
- Calls `persist()` after all players downloaded
- Logs total persisted count

## Test Plan

- [x] 22 new unit tests (all passing)
- [x] `_toi_to_seconds`: valid TOI, zero, overtime, empty, invalid
- [x] `_game_type_to_string`: regular season, playoffs, unknown
- [x] `persist()`: empty list, skater, goalie, multiple game logs
- [x] Playoff game type mapping
- [x] TOI conversion (22:15 → 1335 seconds)
- [x] Missing game_id skipped
- [x] Invalid date handled (stores NULL)
- [x] Continues on individual errors
- [x] SQL structure verification for skater and goalie
- [x] All 1522 tests pass with 92% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)