### PR TITLE
feat(downloaders): Add QuantHockey All-Time Career Statistics Downloader (#99)

### DIFF
--- a/src/nhl_api/downloaders/sources/external/quanthockey/__init__.py
+++ b/src/nhl_api/downloaders/sources/external/quanthockey/__init__.py
@@ -6,10 +6,16 @@ quanthockey.com, including:
 - Career/all-time player statistics
 """
 
+from nhl_api.downloaders.sources.external.quanthockey.career_stats import (
+    CareerStatCategory,
+    QuantHockeyCareerStatsDownloader,
+)
 from nhl_api.downloaders.sources.external.quanthockey.player_stats import (
     QuantHockeyPlayerStatsDownloader,
 )
 
 __all__ = [
+    "CareerStatCategory",
+    "QuantHockeyCareerStatsDownloader",
     "QuantHockeyPlayerStatsDownloader",
 ]

--- a/src/nhl_api/downloaders/sources/external/quanthockey/career_stats.py
+++ b/src/nhl_api/downloaders/sources/external/quanthockey/career_stats.py
@@ -1,0 +1,486 @@
+"""QuantHockey All-Time Career Statistics Downloader.
+
+This module provides the downloader for fetching all-time career player
+statistics from quanthockey.com records pages. It supports multiple
+leaderboard categories (points, goals, assists, etc.) and pagination.
+
+QuantHockey URL patterns:
+    https://www.quanthockey.com/nhl/records/nhl-players-all-time-points-leaders.html
+    https://www.quanthockey.com/nhl/records/nhl-players-all-time-goals-leaders.html
+    https://www.quanthockey.com/nhl/records/nhl-players-all-time-assists-leaders.html
+
+Example usage:
+    config = QuantHockeyConfig(
+        base_url="https://www.quanthockey.com",
+        requests_per_second=0.5,  # 1 request every 2 seconds
+    )
+    async with QuantHockeyCareerStatsDownloader(config) as downloader:
+        leaders = await downloader.download_leaders(
+            CareerStatCategory.POINTS,
+            top_n=100
+        )
+        for player in leaders:
+            print(f"{player.name}: {player.points} points")
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from bs4 import BeautifulSoup, Tag
+
+from nhl_api.downloaders.sources.external.base_external_downloader import (
+    BaseExternalDownloader,
+    ContentParsingError,
+)
+from nhl_api.downloaders.sources.external.quanthockey.player_stats import (
+    QuantHockeyConfig,
+)
+from nhl_api.models.quanthockey import (
+    QuantHockeyPlayerCareerStats,
+    _safe_float,
+    _safe_int,
+)
+
+if TYPE_CHECKING:
+    from nhl_api.utils.http_client import HTTPResponse
+
+logger = logging.getLogger(__name__)
+
+# Number of players per page on QuantHockey
+PLAYERS_PER_PAGE = 20
+
+# Maximum pages to fetch (20 pages = 400 players)
+MAX_PAGES = 20
+
+
+class CareerStatCategory(Enum):
+    """Categories for career statistics leaderboards.
+
+    Each category corresponds to a specific all-time leaders page on QuantHockey.
+    """
+
+    POINTS = "points"
+    GOALS = "goals"
+    ASSISTS = "assists"
+    GAMES_PLAYED = "games-played"
+    PENALTY_MINUTES = "penalty-minutes"
+    PLUS_MINUS = "plus-minus"
+    POWER_PLAY_GOALS = "power-play-goals"
+    GAME_WINNING_GOALS = "game-winning-goals"
+    SHOTS_ON_GOAL = "shots-on-goal"
+
+
+# Mapping of category to URL path segment
+CATEGORY_URL_MAP: dict[CareerStatCategory, str] = {
+    CareerStatCategory.POINTS: "nhl-players-all-time-points-leaders",
+    CareerStatCategory.GOALS: "nhl-players-all-time-goals-leaders",
+    CareerStatCategory.ASSISTS: "nhl-players-all-time-assists-leaders",
+    CareerStatCategory.GAMES_PLAYED: "nhl-players-all-time-games-played-leaders",
+    CareerStatCategory.PENALTY_MINUTES: "nhl-players-all-time-penalty-minutes-leaders",
+    CareerStatCategory.PLUS_MINUS: "nhl-players-all-time-plus-minus-leaders",
+    CareerStatCategory.POWER_PLAY_GOALS: "nhl-players-all-time-power-play-goals-leaders",
+    CareerStatCategory.GAME_WINNING_GOALS: "nhl-players-all-time-game-winning-goals-leaders",
+    CareerStatCategory.SHOTS_ON_GOAL: "nhl-players-all-time-shots-on-goal-leaders",
+}
+
+
+class QuantHockeyCareerStatsDownloader(BaseExternalDownloader):
+    """Downloader for QuantHockey all-time career statistics.
+
+    Fetches and parses career statistics from QuantHockey's all-time records pages.
+    Supports multiple leaderboard categories and pagination.
+
+    Features:
+    - Multiple category support (points, goals, assists, etc.)
+    - Pagination support (20 players per page)
+    - Configurable top_n limit
+    - Conservative rate limiting (1 req per 2 sec)
+    - Robust HTML parsing with BeautifulSoup
+
+    Example:
+        config = QuantHockeyConfig()
+        async with QuantHockeyCareerStatsDownloader(config) as downloader:
+            # Get top 100 all-time points leaders
+            leaders = await downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=100
+            )
+    """
+
+    config: QuantHockeyConfig  # Type hint for IDE support
+
+    def __init__(
+        self,
+        config: QuantHockeyConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the QuantHockey career stats downloader.
+
+        Args:
+            config: Downloader configuration (uses defaults if None)
+            **kwargs: Additional arguments for BaseExternalDownloader
+        """
+        super().__init__(config or QuantHockeyConfig(), **kwargs)
+
+    @property
+    def source_name(self) -> str:
+        """Unique identifier for this data source."""
+        return "quanthockey_career_stats"
+
+    # =========================================================================
+    # URL Building
+    # =========================================================================
+
+    def _build_category_url(
+        self,
+        category: CareerStatCategory,
+        page: int = 1,
+    ) -> str:
+        """Build URL for a career statistics category page.
+
+        Args:
+            category: Statistics category to fetch
+            page: Page number (1-indexed)
+
+        Returns:
+            Full URL for the category page
+        """
+        url_segment = CATEGORY_URL_MAP[category]
+        path = f"/nhl/records/{url_segment}.html"
+
+        if page > 1:
+            path = f"{path}?page={page}"
+
+        return f"{self.config.base_url}{path}"
+
+    # =========================================================================
+    # HTML Parsing
+    # =========================================================================
+
+    def _extract_player_row(
+        self,
+        row: Tag,
+        category: CareerStatCategory,
+    ) -> QuantHockeyPlayerCareerStats | None:
+        """Extract career statistics from a table row.
+
+        Args:
+            row: BeautifulSoup Tag for the table row (<tr>)
+            category: The category being parsed (affects column interpretation)
+
+        Returns:
+            QuantHockeyPlayerCareerStats or None if row is invalid
+        """
+        cells = row.find_all("td")
+        if len(cells) < 10:
+            # Not a valid player row
+            return None
+
+        try:
+            # Extract text from each cell
+            row_data: list[str] = []
+            for cell in cells:
+                text = cell.get_text(strip=True)
+                row_data.append(text)
+
+            # Career tables have this structure (may vary slightly by category):
+            # 0: Rank
+            # 1: Name
+            # 2: Team(s) - may have multiple
+            # 3: Born/Birth Year
+            # 4: Position
+            # 5: GP (Games Played)
+            # 6: G (Goals)
+            # 7: A (Assists)
+            # 8: P (Points)
+            # 9: PIM (Penalty Minutes)
+            # 10+: Additional stats depending on category
+
+            # Parse birth year to extract first/last season estimates
+            birth_year = _safe_int(row_data[3]) if len(row_data) > 3 else 0
+            # Estimate career span (players typically debut at ~20 and play ~15 seasons)
+            first_season = birth_year + 20 if birth_year > 1900 else 0
+            last_season = birth_year + 40 if birth_year > 1900 else 0
+
+            # Calculate seasons from GP if possible (rough estimate: ~60 GP/season)
+            gp = _safe_int(row_data[5]) if len(row_data) > 5 else 0
+            seasons_played = max(1, gp // 60) if gp > 0 else 0
+
+            # Parse core stats
+            stats = QuantHockeyPlayerCareerStats(
+                name=row_data[1].strip() if len(row_data) > 1 else "",
+                position=row_data[4].strip().upper() if len(row_data) > 4 else "",
+                nationality="",  # Not typically on career pages
+                first_season=first_season,
+                last_season=last_season,
+                seasons_played=seasons_played,
+                games_played=gp,
+                goals=_safe_int(row_data[6]) if len(row_data) > 6 else 0,
+                assists=_safe_int(row_data[7]) if len(row_data) > 7 else 0,
+                points=_safe_int(row_data[8]) if len(row_data) > 8 else 0,
+                pim=_safe_int(row_data[9]) if len(row_data) > 9 else 0,
+                plus_minus=_safe_int(row_data[10]) if len(row_data) > 10 else 0,
+                # Additional stats parsed based on available columns
+                pp_goals=_safe_int(row_data[11]) if len(row_data) > 11 else 0,
+                gw_goals=_safe_int(row_data[12]) if len(row_data) > 12 else 0,
+                shots_on_goal=_safe_int(row_data[13]) if len(row_data) > 13 else 0,
+                shooting_pct=_safe_float(row_data[14]) if len(row_data) > 14 else 0.0,
+            )
+
+            return stats
+
+        except (ValueError, IndexError) as e:
+            logger.warning("Failed to parse career player row: %s", e)
+            return None
+
+    def _parse_career_table(
+        self,
+        html_content: str,
+        category: CareerStatCategory,
+    ) -> list[QuantHockeyPlayerCareerStats]:
+        """Parse career statistics from HTML content.
+
+        Args:
+            html_content: Raw HTML content
+            category: Statistics category being parsed
+
+        Returns:
+            List of player career statistics
+        """
+        soup = BeautifulSoup(html_content, "lxml")
+        players: list[QuantHockeyPlayerCareerStats] = []
+
+        # Find the main statistics table
+        stats_table = soup.find("table", {"id": "stats"})
+        if not stats_table:
+            stats_table = soup.find("table", class_=re.compile(r"stats|sortable"))
+        if not stats_table:
+            # Try finding any table with many columns
+            for table in soup.find_all("table"):
+                if isinstance(table, Tag):
+                    first_row = table.find("tr")
+                    if first_row and isinstance(first_row, Tag):
+                        cells = first_row.find_all(["th", "td"])
+                        if len(cells) >= 8:  # Career table has at least 8 columns
+                            stats_table = table
+                            break
+
+        if not stats_table:
+            logger.warning("Could not find career statistics table in HTML")
+            return players
+
+        # Find table body
+        tbody = stats_table.find("tbody")
+        if tbody and isinstance(tbody, Tag):
+            rows = tbody.find_all("tr")
+        else:
+            rows = stats_table.find_all("tr")
+
+        # Parse each row
+        for row in rows:
+            if isinstance(row, Tag):
+                # Skip header rows
+                if row.find("th"):
+                    continue
+
+                player = self._extract_player_row(row, category)
+                if player:
+                    players.append(player)
+
+        return players
+
+    def _has_next_page(self, html_content: str, current_page: int) -> bool:
+        """Check if there's a next page of results.
+
+        Args:
+            html_content: Current page HTML content
+            current_page: Current page number
+
+        Returns:
+            True if next page exists
+        """
+        soup = BeautifulSoup(html_content, "lxml")
+
+        # Look for pagination links
+        next_page = current_page + 1
+
+        # Check for page=N links
+        page_link = soup.find("a", href=re.compile(rf"page={next_page}"))
+        if page_link:
+            return True
+
+        # Check for "Next" link
+        for link in soup.find_all("a"):
+            if isinstance(link, Tag):
+                link_text = link.get_text(strip=True)
+                if re.search(r"Next|►|>>", link_text):
+                    return True
+
+        # Check for numbered pagination
+        pagination = soup.find(class_=re.compile(r"pagination|pager"))
+        if pagination and isinstance(pagination, Tag):
+            links = pagination.find_all("a")
+            for link in links:
+                try:
+                    page_num = int(link.get_text(strip=True))
+                    if page_num > current_page:
+                        return True
+                except ValueError:
+                    continue
+
+        return False
+
+    # =========================================================================
+    # Abstract Method Implementation
+    # =========================================================================
+
+    async def _parse_response(
+        self,
+        response: HTTPResponse,
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Parse QuantHockey response into structured data.
+
+        Args:
+            response: HTTP response
+            context: Request context (category, page)
+
+        Returns:
+            Dictionary with parsed player data
+        """
+        html_content = response.text()
+        category = context.get("category", CareerStatCategory.POINTS)
+
+        players = self._parse_career_table(html_content, category)
+        has_next = self._has_next_page(html_content, context.get("page", 1))
+
+        return {
+            "players": [p.to_dict() for p in players],
+            "player_count": len(players),
+            "has_next_page": has_next,
+        }
+
+    # =========================================================================
+    # Download Methods
+    # =========================================================================
+
+    async def download_leaders(
+        self,
+        category: CareerStatCategory,
+        *,
+        top_n: int = 100,
+        max_pages: int = MAX_PAGES,
+    ) -> list[QuantHockeyPlayerCareerStats]:
+        """Download career statistics leaders for a category.
+
+        Fetches all pages of career statistics up to the specified limits.
+        Uses rate limiting and retries for robust operation.
+
+        Args:
+            category: Statistics category to fetch (points, goals, etc.)
+            top_n: Maximum number of players to fetch
+            max_pages: Maximum number of pages to fetch (default 20)
+
+        Returns:
+            List of player career statistics, sorted by the category
+
+        Raises:
+            ExternalSourceError: If download fails
+            ContentParsingError: If parsing fails
+        """
+        all_players: list[QuantHockeyPlayerCareerStats] = []
+        page = 1
+
+        logger.info(
+            "Starting QuantHockey career stats download for %s (top_n=%d, max_pages=%d)",
+            category.value,
+            top_n,
+            max_pages,
+        )
+
+        while page <= max_pages:
+            url = self._build_category_url(category, page)
+            context = {"category": category, "page": page}
+
+            logger.debug("Fetching page %d: %s", page, url)
+
+            # Fetch and parse page
+            result = await self.fetch_resource(
+                url.replace(self.config.base_url, ""),
+                context=context,
+            )
+
+            data = result.data
+            if not isinstance(data, dict):
+                raise ContentParsingError(
+                    "Unexpected response format",
+                    source=self.source_name,
+                    url=url,
+                )
+
+            # Convert player dicts back to dataclass objects
+            players_data = data.get("players", [])
+            for p_dict in players_data:
+                player = QuantHockeyPlayerCareerStats.from_dict(p_dict, validate=True)
+                all_players.append(player)
+
+            logger.debug(
+                "Page %d: fetched %d players (total: %d)",
+                page,
+                len(players_data),
+                len(all_players),
+            )
+
+            # Check if we've reached limits
+            if len(all_players) >= top_n:
+                all_players = all_players[:top_n]
+                logger.info("Reached top_n limit (%d)", top_n)
+                break
+
+            # Check for more pages
+            if not data.get("has_next_page", False):
+                logger.debug("No more pages available")
+                break
+
+            if len(players_data) == 0:
+                logger.debug("Empty page, stopping")
+                break
+
+            page += 1
+
+        logger.info(
+            "QuantHockey career stats download complete: %d players fetched for %s",
+            len(all_players),
+            category.value,
+        )
+
+        return all_players
+
+    async def download_all_categories(
+        self,
+        *,
+        top_n: int = 100,
+    ) -> dict[CareerStatCategory, list[QuantHockeyPlayerCareerStats]]:
+        """Download leaders for all career stat categories.
+
+        Convenience method to fetch top players across all categories.
+        Note: This makes multiple requests with rate limiting.
+
+        Args:
+            top_n: Maximum number of players per category
+
+        Returns:
+            Dictionary mapping category to list of players
+        """
+        results: dict[CareerStatCategory, list[QuantHockeyPlayerCareerStats]] = {}
+
+        for category in CareerStatCategory:
+            logger.info("Downloading %s leaders...", category.value)
+            leaders = await self.download_leaders(category, top_n=top_n)
+            results[category] = leaders
+
+        return results

--- a/tests/unit/downloaders/sources/external/quanthockey/test_career_stats.py
+++ b/tests/unit/downloaders/sources/external/quanthockey/test_career_stats.py
@@ -1,0 +1,742 @@
+"""Unit tests for QuantHockeyCareerStatsDownloader."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nhl_api.downloaders.sources.external.quanthockey.career_stats import (
+    CATEGORY_URL_MAP,
+    MAX_PAGES,
+    PLAYERS_PER_PAGE,
+    CareerStatCategory,
+    QuantHockeyCareerStatsDownloader,
+)
+from nhl_api.downloaders.sources.external.quanthockey.player_stats import (
+    QuantHockeyConfig,
+)
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def config() -> QuantHockeyConfig:
+    """Create a test configuration."""
+    return QuantHockeyConfig()
+
+
+@pytest.fixture
+def downloader(config: QuantHockeyConfig) -> QuantHockeyCareerStatsDownloader:
+    """Create a test downloader instance."""
+    return QuantHockeyCareerStatsDownloader(config)
+
+
+@pytest.fixture
+def sample_career_html_row() -> str:
+    """Sample HTML table row for a career stats player."""
+    return """
+    <tr>
+        <td>1</td>
+        <td><a href="/player/8447400">Wayne Gretzky</a></td>
+        <td>EDM, LAK, STL, NYR</td>
+        <td>1961</td>
+        <td>C</td>
+        <td>1487</td>
+        <td>894</td>
+        <td>1963</td>
+        <td>2857</td>
+        <td>577</td>
+        <td>520</td>
+        <td>204</td>
+        <td>91</td>
+        <td>5088</td>
+        <td>17.6</td>
+    </tr>
+    """
+
+
+@pytest.fixture
+def sample_career_html_page(sample_career_html_row: str) -> str:
+    """Sample HTML page with career statistics table."""
+    return f"""
+    <!DOCTYPE html>
+    <html>
+    <head><title>NHL All-Time Points Leaders</title></head>
+    <body>
+        <table id="stats" class="sortable">
+            <thead>
+                <tr>
+                    <th>Rk</th>
+                    <th>Name</th>
+                    <th>Team</th>
+                    <th>Born</th>
+                    <th>Pos</th>
+                    <th>GP</th>
+                    <th>G</th>
+                    <th>A</th>
+                    <th>P</th>
+                    <th>PIM</th>
+                    <th>+/-</th>
+                    <th>PPG</th>
+                    <th>GWG</th>
+                    <th>SOG</th>
+                    <th>S%</th>
+                </tr>
+            </thead>
+            <tbody>
+                {sample_career_html_row}
+            </tbody>
+        </table>
+        <div class="pagination">
+            <a href="?page=1">1</a>
+            <a href="?page=2">2</a>
+            <a href="?page=3">3</a>
+        </div>
+    </body>
+    </html>
+    """
+
+
+@pytest.fixture
+def sample_career_html_page_no_next() -> str:
+    """Sample HTML page without pagination (last page)."""
+    return """
+    <!DOCTYPE html>
+    <html>
+    <body>
+        <table id="stats" class="sortable">
+            <thead>
+                <tr><th>Rk</th><th>Name</th></tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+    </body>
+    </html>
+    """
+
+
+# =============================================================================
+# CareerStatCategory Tests
+# =============================================================================
+
+
+class TestCareerStatCategory:
+    """Tests for CareerStatCategory enum."""
+
+    def test_all_categories_have_url_mapping(self) -> None:
+        """Test that all categories have URL mappings."""
+        for category in CareerStatCategory:
+            assert category in CATEGORY_URL_MAP
+
+    def test_category_values(self) -> None:
+        """Test category value strings."""
+        assert CareerStatCategory.POINTS.value == "points"
+        assert CareerStatCategory.GOALS.value == "goals"
+        assert CareerStatCategory.ASSISTS.value == "assists"
+        assert CareerStatCategory.GAMES_PLAYED.value == "games-played"
+        assert CareerStatCategory.PENALTY_MINUTES.value == "penalty-minutes"
+        assert CareerStatCategory.PLUS_MINUS.value == "plus-minus"
+        assert CareerStatCategory.POWER_PLAY_GOALS.value == "power-play-goals"
+        assert CareerStatCategory.GAME_WINNING_GOALS.value == "game-winning-goals"
+        assert CareerStatCategory.SHOTS_ON_GOAL.value == "shots-on-goal"
+
+    def test_url_mapping_format(self) -> None:
+        """Test that URL mappings have expected format."""
+        for _category, url_segment in CATEGORY_URL_MAP.items():
+            assert "nhl-players-all-time" in url_segment
+            assert "-leaders" in url_segment
+
+
+# =============================================================================
+# Downloader Initialization Tests
+# =============================================================================
+
+
+class TestDownloaderInit:
+    """Tests for downloader initialization."""
+
+    def test_source_name(self, downloader: QuantHockeyCareerStatsDownloader) -> None:
+        """Test source name property."""
+        assert downloader.source_name == "quanthockey_career_stats"
+
+    def test_default_config(self) -> None:
+        """Test initialization with default config."""
+        downloader = QuantHockeyCareerStatsDownloader()
+
+        assert downloader.config.base_url == "https://www.quanthockey.com"
+
+    def test_custom_config(self) -> None:
+        """Test initialization with custom config."""
+        config = QuantHockeyConfig(requests_per_second=0.25)
+        downloader = QuantHockeyCareerStatsDownloader(config)
+
+        assert downloader.config.requests_per_second == 0.25
+
+
+# =============================================================================
+# URL Building Tests
+# =============================================================================
+
+
+class TestUrlBuilding:
+    """Tests for URL construction."""
+
+    def test_build_category_url_points_page_1(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test URL building for points leaders, first page."""
+        url = downloader._build_category_url(CareerStatCategory.POINTS, page=1)
+
+        assert (
+            url
+            == "https://www.quanthockey.com/nhl/records/nhl-players-all-time-points-leaders.html"
+        )
+
+    def test_build_category_url_goals_page_1(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test URL building for goals leaders, first page."""
+        url = downloader._build_category_url(CareerStatCategory.GOALS, page=1)
+
+        assert (
+            url
+            == "https://www.quanthockey.com/nhl/records/nhl-players-all-time-goals-leaders.html"
+        )
+
+    def test_build_category_url_page_2(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test URL building for subsequent pages."""
+        url = downloader._build_category_url(CareerStatCategory.POINTS, page=2)
+
+        assert (
+            url
+            == "https://www.quanthockey.com/nhl/records/nhl-players-all-time-points-leaders.html?page=2"
+        )
+
+    def test_build_category_url_all_categories(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test URL building for all categories."""
+        for category in CareerStatCategory:
+            url = downloader._build_category_url(category, page=1)
+            assert url.startswith("https://www.quanthockey.com/nhl/records/")
+            assert url.endswith(".html")
+            assert CATEGORY_URL_MAP[category] in url
+
+
+# =============================================================================
+# HTML Parsing Tests
+# =============================================================================
+
+
+class TestHtmlParsing:
+    """Tests for HTML parsing functionality."""
+
+    def test_parse_career_table_with_players(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test parsing a table with player data."""
+        players = downloader._parse_career_table(
+            sample_career_html_page, CareerStatCategory.POINTS
+        )
+
+        assert len(players) == 1
+        player = players[0]
+        assert player.name == "Wayne Gretzky"
+        assert player.position == "C"
+        assert player.games_played == 1487
+        assert player.goals == 894
+        assert player.assists == 1963
+        assert player.points == 2857
+        assert player.pim == 577
+        assert player.plus_minus == 520
+
+    def test_parse_career_table_empty(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page_no_next: str,
+    ) -> None:
+        """Test parsing an empty table."""
+        players = downloader._parse_career_table(
+            sample_career_html_page_no_next, CareerStatCategory.POINTS
+        )
+
+        assert len(players) == 0
+
+    def test_parse_career_table_no_table(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test parsing HTML with no stats table."""
+        html = "<html><body><p>No stats here</p></body></html>"
+        players = downloader._parse_career_table(html, CareerStatCategory.POINTS)
+
+        assert len(players) == 0
+
+    def test_parse_career_table_with_additional_stats(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test that additional stat fields are correctly parsed."""
+        players = downloader._parse_career_table(
+            sample_career_html_page, CareerStatCategory.POINTS
+        )
+        player = players[0]
+
+        # Verify additional stats
+        assert player.pp_goals == 204
+        assert player.gw_goals == 91
+        assert player.shots_on_goal == 5088
+        assert player.shooting_pct == 17.6
+
+
+# =============================================================================
+# Pagination Detection Tests
+# =============================================================================
+
+
+class TestPaginationDetection:
+    """Tests for pagination detection."""
+
+    def test_has_next_page_with_links(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test detecting next page from pagination links."""
+        assert downloader._has_next_page(sample_career_html_page, 1) is True
+        assert downloader._has_next_page(sample_career_html_page, 2) is True
+
+    def test_has_next_page_no_pagination(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page_no_next: str,
+    ) -> None:
+        """Test detecting no next page."""
+        assert downloader._has_next_page(sample_career_html_page_no_next, 1) is False
+
+    def test_has_next_page_with_next_link(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test detecting next page from 'Next' text link."""
+        html = """
+        <html><body>
+            <div class="pagination">
+                <a href="?page=2">Next ►</a>
+            </div>
+        </body></html>
+        """
+        assert downloader._has_next_page(html, 1) is True
+
+
+# =============================================================================
+# Extract Player Row Tests
+# =============================================================================
+
+
+class TestExtractPlayerRow:
+    """Tests for extracting player data from table rows."""
+
+    def test_extract_player_row_valid(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_row: str,
+    ) -> None:
+        """Test extracting player from valid row."""
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(sample_career_html_row, "lxml")
+        row = soup.find("tr")
+        assert row is not None
+
+        player = downloader._extract_player_row(row, CareerStatCategory.POINTS)
+
+        assert player is not None
+        assert player.name == "Wayne Gretzky"
+        assert player.position == "C"
+        assert player.games_played == 1487
+
+    def test_extract_player_row_insufficient_cells(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test extracting player from row with too few cells."""
+        from bs4 import BeautifulSoup
+
+        html = "<tr><td>1</td><td>Name</td></tr>"
+        soup = BeautifulSoup(html, "lxml")
+        row = soup.find("tr")
+        assert row is not None
+
+        player = downloader._extract_player_row(row, CareerStatCategory.POINTS)
+
+        assert player is None
+
+    def test_extract_player_row_calculates_seasons(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_row: str,
+    ) -> None:
+        """Test that seasons played is calculated from GP."""
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(sample_career_html_row, "lxml")
+        row = soup.find("tr")
+        assert row is not None
+
+        player = downloader._extract_player_row(row, CareerStatCategory.POINTS)
+
+        assert player is not None
+        # 1487 GP / 60 ≈ 24 seasons (rounded)
+        assert player.seasons_played >= 20
+
+
+# =============================================================================
+# Download Leaders Tests
+# =============================================================================
+
+
+class TestDownloadLeaders:
+    """Tests for download_leaders method."""
+
+    @pytest.mark.asyncio
+    async def test_download_leaders_single_page(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test downloading a single page of career stats."""
+        # Create page without next link for single page test
+        sample_html_no_next = sample_career_html_page.replace(
+            '<a href="?page=2">2</a>', ""
+        ).replace('<a href="?page=3">3</a>', "")
+
+        # Create mock response
+        mock_response = MagicMock()
+        mock_response.text = MagicMock(return_value=sample_html_no_next)
+        mock_response.content = sample_html_no_next.encode()
+        mock_response.is_success = True
+        mock_response.status = 200
+
+        with patch.object(
+            downloader, "_get_with_headers", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with downloader:
+                players = await downloader.download_leaders(
+                    CareerStatCategory.POINTS, max_pages=1
+                )
+
+        assert len(players) == 1
+        assert players[0].name == "Wayne Gretzky"
+
+    @pytest.mark.asyncio
+    async def test_download_leaders_top_n_limit(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test that top_n limit is respected."""
+        mock_response = MagicMock()
+        mock_response.text = MagicMock(return_value=sample_career_html_page)
+        mock_response.content = sample_career_html_page.encode()
+        mock_response.is_success = True
+        mock_response.status = 200
+
+        with patch.object(
+            downloader, "_get_with_headers", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with downloader:
+                players = await downloader.download_leaders(
+                    CareerStatCategory.POINTS, top_n=1, max_pages=10
+                )
+
+        # Should stop after reaching top_n
+        assert len(players) <= 1
+
+    @pytest.mark.asyncio
+    async def test_download_leaders_max_pages_limit(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test that max_pages limit is respected."""
+        mock_response = MagicMock()
+        mock_response.text = MagicMock(return_value=sample_career_html_page)
+        mock_response.content = sample_career_html_page.encode()
+        mock_response.is_success = True
+        mock_response.status = 200
+
+        with patch.object(
+            downloader, "_get_with_headers", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with downloader:
+                await downloader.download_leaders(
+                    CareerStatCategory.POINTS, max_pages=2
+                )
+
+        # Should have made at most 2 requests
+        assert mock_get.call_count <= 2
+
+    @pytest.mark.asyncio
+    async def test_download_leaders_different_categories(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test downloading different stat categories."""
+        sample_html_no_next = sample_career_html_page.replace(
+            '<a href="?page=2">2</a>', ""
+        ).replace('<a href="?page=3">3</a>', "")
+
+        mock_response = MagicMock()
+        mock_response.text = MagicMock(return_value=sample_html_no_next)
+        mock_response.content = sample_html_no_next.encode()
+        mock_response.is_success = True
+        mock_response.status = 200
+
+        with patch.object(
+            downloader, "_get_with_headers", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with downloader:
+                # Test goals category
+                await downloader.download_leaders(CareerStatCategory.GOALS, max_pages=1)
+
+                # Test assists category
+                await downloader.download_leaders(
+                    CareerStatCategory.ASSISTS, max_pages=1
+                )
+
+        # Should have made calls for both categories
+        assert mock_get.call_count == 2
+
+
+# =============================================================================
+# Download All Categories Tests
+# =============================================================================
+
+
+class TestDownloadAllCategories:
+    """Tests for download_all_categories method."""
+
+    @pytest.mark.asyncio
+    async def test_download_all_categories_returns_dict(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test that download_all_categories returns dict of all categories."""
+        sample_html_no_next = sample_career_html_page.replace(
+            '<a href="?page=2">2</a>', ""
+        ).replace('<a href="?page=3">3</a>', "")
+
+        mock_response = MagicMock()
+        mock_response.text = MagicMock(return_value=sample_html_no_next)
+        mock_response.content = sample_html_no_next.encode()
+        mock_response.is_success = True
+        mock_response.status = 200
+
+        with patch.object(
+            downloader, "_get_with_headers", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with downloader:
+                results = await downloader.download_all_categories(top_n=1)
+
+        assert isinstance(results, dict)
+        # Should have entry for each category
+        for category in CareerStatCategory:
+            assert category in results
+            assert isinstance(results[category], list)
+
+
+# =============================================================================
+# Parse Response Tests
+# =============================================================================
+
+
+class TestParseResponse:
+    """Tests for _parse_response method."""
+
+    @pytest.mark.asyncio
+    async def test_parse_response_returns_dict(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test that _parse_response returns expected structure."""
+        mock_response = MagicMock()
+        mock_response.text = MagicMock(return_value=sample_career_html_page)
+
+        context: dict[str, Any] = {"category": CareerStatCategory.POINTS, "page": 1}
+        result = await downloader._parse_response(mock_response, context)
+
+        assert isinstance(result, dict)
+        assert "players" in result
+        assert "player_count" in result
+        assert "has_next_page" in result
+        assert result["player_count"] == 1
+        assert result["has_next_page"] is True
+
+
+# =============================================================================
+# Constants Tests
+# =============================================================================
+
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_players_per_page(self) -> None:
+        """Test players per page constant."""
+        assert PLAYERS_PER_PAGE == 20
+
+    def test_max_pages(self) -> None:
+        """Test max pages constant."""
+        assert MAX_PAGES == 20
+
+    def test_category_url_map_not_empty(self) -> None:
+        """Test category URL map is populated."""
+        assert len(CATEGORY_URL_MAP) == len(CareerStatCategory)
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_parse_malformed_html(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test parsing malformed HTML doesn't crash."""
+        malformed_html = "<html><table<tr><td>broken"
+        players = downloader._parse_career_table(
+            malformed_html, CareerStatCategory.POINTS
+        )
+
+        # Should return empty list, not raise
+        assert isinstance(players, list)
+
+    def test_parse_unicode_characters(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test parsing player names with unicode characters."""
+        html = """
+        <html><body>
+            <table id="stats">
+                <tbody>
+                    <tr>
+                        <td>1</td>
+                        <td>Jaromír Jágr</td>
+                        <td>PIT, WSH, NYR, ...</td>
+                        <td>1972</td>
+                        <td>RW</td>
+                        <td>1733</td>
+                        <td>766</td>
+                        <td>1155</td>
+                        <td>1921</td>
+                        <td>1167</td>
+                        <td>322</td>
+                        <td>217</td>
+                        <td>135</td>
+                        <td>5637</td>
+                        <td>13.6</td>
+                    </tr>
+                </tbody>
+            </table>
+        </body></html>
+        """
+        players = downloader._parse_career_table(html, CareerStatCategory.POINTS)
+
+        assert len(players) == 1
+        assert "Jágr" in players[0].name
+
+    def test_parse_row_missing_optional_fields(
+        self, downloader: QuantHockeyCareerStatsDownloader
+    ) -> None:
+        """Test parsing row with missing optional fields."""
+        html = """
+        <html><body>
+            <table id="stats">
+                <tbody>
+                    <tr>
+                        <td>1</td>
+                        <td>Test Player</td>
+                        <td>TOR</td>
+                        <td>1990</td>
+                        <td>C</td>
+                        <td>500</td>
+                        <td>200</td>
+                        <td>300</td>
+                        <td>500</td>
+                        <td>100</td>
+                        <td>50</td>
+                    </tr>
+                </tbody>
+            </table>
+        </body></html>
+        """
+        players = downloader._parse_career_table(html, CareerStatCategory.POINTS)
+
+        assert len(players) == 1
+        player = players[0]
+        assert player.name == "Test Player"
+        assert player.goals == 200
+        # Optional fields should default to 0
+        assert player.pp_goals == 0
+        assert player.gw_goals == 0
+
+    def test_computed_properties(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test computed properties on career stats."""
+        players = downloader._parse_career_table(
+            sample_career_html_page, CareerStatCategory.POINTS
+        )
+        player = players[0]
+
+        # Test per-game rates
+        assert player.goals_per_game == pytest.approx(
+            player.goals / player.games_played, rel=0.01
+        )
+        assert player.assists_per_game == pytest.approx(
+            player.assists / player.games_played, rel=0.01
+        )
+        assert player.points_per_game == pytest.approx(
+            player.points / player.games_played, rel=0.01
+        )
+
+    def test_career_span_property(
+        self,
+        downloader: QuantHockeyCareerStatsDownloader,
+        sample_career_html_page: str,
+    ) -> None:
+        """Test career_span computed property."""
+        players = downloader._parse_career_table(
+            sample_career_html_page, CareerStatCategory.POINTS
+        )
+        player = players[0]
+
+        # Career span should be formatted as "YYYY-YYYY"
+        if player.first_season and player.last_season:
+            assert "-" in player.career_span


### PR DESCRIPTION
## Summary

- Implements Wave 5a.5 - Career statistics downloader for QuantHockey
- Add `QuantHockeyCareerStatsDownloader` for fetching all-time career leaders
- Support 9 leaderboard categories (points, goals, assists, games played, penalty minutes, plus/minus, power play goals, game-winning goals, shots on goal)
- HTML parsing with BeautifulSoup and pagination support
- 34 unit tests with 87% coverage

## Features

- `CareerStatCategory` enum for selecting leader types
- `download_leaders(category, top_n)` - download single category
- `download_all_categories()` - download all leaderboards
- Conservative rate limiting (0.5 req/sec)
- Graceful handling of missing optional fields

## Test plan

- [x] All 34 unit tests pass
- [x] 87% test coverage for career_stats.py
- [x] Mypy passes in strict mode
- [x] Pre-commit hooks pass (ruff, format)

## Files Changed

- `src/nhl_api/downloaders/sources/external/quanthockey/career_stats.py` (new)
- `src/nhl_api/downloaders/sources/external/quanthockey/__init__.py` (updated exports)
- `tests/unit/downloaders/sources/external/quanthockey/test_career_stats.py` (new)

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)