### PR TITLE
test(integration): Add QuantHockey live integration tests

### DIFF
--- a/tests/integration/downloaders/sources/__init__.py
+++ b/tests/integration/downloaders/sources/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for data source downloaders."""

--- a/tests/integration/downloaders/sources/external/__init__.py
+++ b/tests/integration/downloaders/sources/external/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for external data source downloaders."""

--- a/tests/integration/downloaders/sources/external/quanthockey/__init__.py
+++ b/tests/integration/downloaders/sources/external/quanthockey/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for QuantHockey downloaders."""

--- a/tests/integration/downloaders/sources/external/quanthockey/conftest.py
+++ b/tests/integration/downloaders/sources/external/quanthockey/conftest.py
@@ -1,0 +1,115 @@
+"""Shared fixtures for QuantHockey integration tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from nhl_api.downloaders.sources.external.quanthockey import (
+    QuantHockeyCareerStatsDownloader,
+    QuantHockeyPlayerStatsDownloader,
+)
+from nhl_api.downloaders.sources.external.quanthockey.career_stats import (
+    CareerStatCategory,
+)
+from nhl_api.downloaders.sources.external.quanthockey.player_stats import (
+    QuantHockeyConfig,
+)
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+# Current NHL season for testing
+CURRENT_SEASON_ID = 20242025
+
+# Previous season for testing
+PREVIOUS_SEASON_ID = 20232024
+
+# Known all-time points leader (Wayne Gretzky)
+KNOWN_POINTS_LEADER = "Wayne Gretzky"
+
+# Known all-time goals leader (Wayne Gretzky)
+KNOWN_GOALS_LEADER = "Wayne Gretzky"
+
+
+# =============================================================================
+# Configuration Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def quanthockey_config() -> QuantHockeyConfig:
+    """Configuration for integration tests.
+
+    Uses a conservative rate limit since we're hitting the real site.
+    """
+    return QuantHockeyConfig(
+        requests_per_second=0.5,  # 1 request every 2 seconds
+        max_retries=2,
+        http_timeout=30.0,
+    )
+
+
+@pytest.fixture
+def fast_config() -> QuantHockeyConfig:
+    """Fast configuration for unit-style tests with mocks."""
+    return QuantHockeyConfig(
+        requests_per_second=100.0,
+        max_retries=1,
+        http_timeout=10.0,
+    )
+
+
+# =============================================================================
+# Season Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def current_season_id() -> int:
+    """Current NHL season ID (2024-25)."""
+    return CURRENT_SEASON_ID
+
+
+@pytest.fixture
+def previous_season_id() -> int:
+    """Previous NHL season ID (2023-24)."""
+    return PREVIOUS_SEASON_ID
+
+
+# =============================================================================
+# Downloader Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def player_stats_downloader(
+    quanthockey_config: QuantHockeyConfig,
+) -> QuantHockeyPlayerStatsDownloader:
+    """Create a QuantHockeyPlayerStatsDownloader for testing."""
+    return QuantHockeyPlayerStatsDownloader(quanthockey_config)
+
+
+@pytest.fixture
+def career_stats_downloader(
+    quanthockey_config: QuantHockeyConfig,
+) -> QuantHockeyCareerStatsDownloader:
+    """Create a QuantHockeyCareerStatsDownloader for testing."""
+    return QuantHockeyCareerStatsDownloader(quanthockey_config)
+
+
+# =============================================================================
+# Category Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def points_category() -> CareerStatCategory:
+    """Points category for career stats."""
+    return CareerStatCategory.POINTS
+
+
+@pytest.fixture
+def goals_category() -> CareerStatCategory:
+    """Goals category for career stats."""
+    return CareerStatCategory.GOALS

--- a/tests/integration/downloaders/sources/external/quanthockey/test_career_stats_live.py
+++ b/tests/integration/downloaders/sources/external/quanthockey/test_career_stats_live.py
@@ -1,0 +1,415 @@
+"""Integration tests for QuantHockey career statistics downloader.
+
+These tests hit the live quanthockey.com website and verify that:
+1. Downloaders can fetch real career leaders data
+2. Parsed data structures match expected schemas
+3. Rate limiting is respected
+4. Known all-time leaders are correctly identified
+
+Run with: pytest tests/integration/downloaders/sources/external/quanthockey -v -m integration
+
+Skip in CI with: pytest -m "not integration"
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nhl_api.downloaders.sources.external.quanthockey import (
+    QuantHockeyCareerStatsDownloader,
+)
+from nhl_api.downloaders.sources.external.quanthockey.career_stats import (
+    CareerStatCategory,
+)
+from nhl_api.downloaders.sources.external.quanthockey.player_stats import (
+    QuantHockeyConfig,
+)
+from nhl_api.models.quanthockey import QuantHockeyPlayerCareerStats
+
+if TYPE_CHECKING:
+    pass
+
+
+# Skip all tests in this module if not running integration tests
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+]
+
+
+# =============================================================================
+# Basic Download Tests
+# =============================================================================
+
+
+class TestCareerStatsDownload:
+    """Integration tests for QuantHockeyCareerStatsDownloader."""
+
+    @pytest.mark.asyncio
+    async def test_download_points_leaders(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+        points_category: CareerStatCategory,
+    ) -> None:
+        """Test downloading all-time points leaders."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                points_category,
+                top_n=10,
+            )
+
+        # Should have fetched 10 players
+        assert len(leaders) == 10
+        assert all(isinstance(p, QuantHockeyPlayerCareerStats) for p in leaders)
+
+    @pytest.mark.asyncio
+    async def test_download_goals_leaders(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+        goals_category: CareerStatCategory,
+    ) -> None:
+        """Test downloading all-time goals leaders."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                goals_category,
+                top_n=10,
+            )
+
+        assert len(leaders) == 10
+        # Goals leaders should have significant goal counts
+        for player in leaders:
+            assert player.goals > 500  # Top 10 all-time should have 500+ goals
+
+    @pytest.mark.asyncio
+    async def test_download_assists_leaders(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Test downloading all-time assists leaders."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.ASSISTS,
+                top_n=10,
+            )
+
+        assert len(leaders) == 10
+        # Assists leaders should have significant assist counts
+        for player in leaders:
+            assert player.assists > 700  # Top 10 all-time should have 700+ assists
+
+
+# =============================================================================
+# Known Leaders Validation
+# =============================================================================
+
+
+class TestKnownLeaders:
+    """Tests verifying known all-time leaders are correctly identified."""
+
+    @pytest.mark.asyncio
+    async def test_gretzky_is_points_leader(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Verify Wayne Gretzky is the all-time points leader."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=1,
+            )
+
+        assert len(leaders) == 1
+        leader = leaders[0]
+        assert "Gretzky" in leader.name, f"Expected Gretzky, got {leader.name}"
+        assert leader.points >= 2857  # Gretzky's career points
+
+    @pytest.mark.asyncio
+    async def test_gretzky_is_goals_leader(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Verify Wayne Gretzky is the all-time goals leader."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.GOALS,
+                top_n=1,
+            )
+
+        assert len(leaders) == 1
+        leader = leaders[0]
+        assert "Gretzky" in leader.name, f"Expected Gretzky, got {leader.name}"
+        assert leader.goals >= 894  # Gretzky's career goals
+
+    @pytest.mark.asyncio
+    async def test_gretzky_is_assists_leader(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Verify Wayne Gretzky is the all-time assists leader."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.ASSISTS,
+                top_n=1,
+            )
+
+        assert len(leaders) == 1
+        leader = leaders[0]
+        assert "Gretzky" in leader.name, f"Expected Gretzky, got {leader.name}"
+        assert leader.assists >= 1963  # Gretzky's career assists
+
+
+# =============================================================================
+# Data Structure Tests
+# =============================================================================
+
+
+class TestCareerStatsStructure:
+    """Tests verifying career stats have expected structure."""
+
+    @pytest.mark.asyncio
+    async def test_core_fields_populated(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Verify core fields are populated for all players."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=10,
+            )
+
+        for player in leaders:
+            # Identity fields
+            assert player.name, "Player name should not be empty"
+
+            # Position should be valid
+            valid_positions = ["C", "LW", "RW", "D", "G", "F", "W", ""]
+            assert player.position in valid_positions, (
+                f"Invalid position: {player.position}"
+            )
+
+            # Games played should be significant for career leaders
+            assert player.games_played > 0
+
+    @pytest.mark.asyncio
+    async def test_career_totals_populated(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Verify career total stats are properly populated."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=10,
+            )
+
+        for player in leaders:
+            # Basic career stats should be non-negative
+            assert player.goals >= 0
+            assert player.assists >= 0
+            assert player.points >= 0
+            assert player.pim >= 0
+
+            # Points should equal goals + assists
+            assert player.points == player.goals + player.assists
+
+    @pytest.mark.asyncio
+    async def test_to_dict_serialization(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Verify players can be serialized to dict and back."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=3,
+            )
+
+        for player in leaders:
+            # Serialize to dict
+            player_dict = player.to_dict()
+            assert isinstance(player_dict, dict)
+
+            # Deserialize back
+            restored = QuantHockeyPlayerCareerStats.from_dict(player_dict)
+            assert restored.name == player.name
+            assert restored.points == player.points
+            assert restored.goals == player.goals
+
+
+# =============================================================================
+# Multiple Categories Tests
+# =============================================================================
+
+
+class TestMultipleCategories:
+    """Tests for downloading multiple categories."""
+
+    @pytest.mark.asyncio
+    async def test_different_categories_different_leaders(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Verify different categories return different top 10 lists."""
+        async with career_stats_downloader:
+            points_leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=10,
+            )
+            pim_leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.PENALTY_MINUTES,
+                top_n=10,
+            )
+
+        points_names = {p.name for p in points_leaders}
+        pim_names = {p.name for p in pim_leaders}
+
+        # The top 10 in each category should have minimal overlap
+        # (enforcers vs scorers)
+        overlap = points_names & pim_names
+        assert len(overlap) < 5, (
+            f"Too much overlap between points and PIM leaders: {overlap}"
+        )
+
+
+# =============================================================================
+# Rate Limiting Tests
+# =============================================================================
+
+
+class TestRateLimiting:
+    """Tests verifying rate limiting is respected."""
+
+    @pytest.mark.asyncio
+    async def test_rate_limiting_respected(
+        self,
+        quanthockey_config: QuantHockeyConfig,
+    ) -> None:
+        """Verify rate limiting is applied between requests.
+
+        With 0.5 req/sec, multiple categories should take appropriate time.
+        """
+        downloader = QuantHockeyCareerStatsDownloader(quanthockey_config)
+
+        start_time = time.monotonic()
+
+        async with downloader:
+            # Fetch two different categories
+            await downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=10,
+            )
+            await downloader.download_leaders(
+                CareerStatCategory.GOALS,
+                top_n=10,
+            )
+
+        elapsed = time.monotonic() - start_time
+
+        # At 0.5 req/sec, 2 requests should take at least 2 seconds
+        assert elapsed >= 1.5, f"Requests completed too quickly: {elapsed:.2f}s"
+
+
+# =============================================================================
+# Pagination Tests
+# =============================================================================
+
+
+class TestPagination:
+    """Tests for pagination handling."""
+
+    @pytest.mark.asyncio
+    async def test_pagination_fetches_multiple_pages(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Test fetching more than one page of results."""
+        async with career_stats_downloader:
+            # Request 25 players (more than 20 per page)
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=25,
+            )
+
+        assert len(leaders) == 25
+
+    @pytest.mark.asyncio
+    async def test_max_pages_limit(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Test that max_pages limit is respected."""
+        async with career_stats_downloader:
+            # Request 100 players but limit to 1 page
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=100,
+                max_pages=1,
+            )
+
+        # Should only get players from first page (20 max)
+        assert len(leaders) <= 20
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+class TestErrorHandling:
+    """Tests for error handling scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_zero_top_n(
+        self,
+        career_stats_downloader: QuantHockeyCareerStatsDownloader,
+    ) -> None:
+        """Test with top_n=0."""
+        async with career_stats_downloader:
+            leaders = await career_stats_downloader.download_leaders(
+                CareerStatCategory.POINTS,
+                top_n=0,
+            )
+
+        # Should return empty list
+        assert len(leaders) == 0
+
+
+# =============================================================================
+# All Categories Test
+# =============================================================================
+
+
+class TestAllCategories:
+    """Tests for all career stat categories."""
+
+    @pytest.mark.asyncio
+    async def test_all_categories_work(
+        self,
+        quanthockey_config: QuantHockeyConfig,
+    ) -> None:
+        """Verify all category types can be fetched.
+
+        Note: This test is slow due to rate limiting across many categories.
+        """
+        downloader = QuantHockeyCareerStatsDownloader(quanthockey_config)
+
+        # Test a subset of categories to keep test time reasonable
+        categories_to_test = [
+            CareerStatCategory.POINTS,
+            CareerStatCategory.GOALS,
+            CareerStatCategory.GAMES_PLAYED,
+        ]
+
+        async with downloader:
+            for category in categories_to_test:
+                leaders = await downloader.download_leaders(
+                    category,
+                    top_n=3,
+                )
+                assert len(leaders) == 3, (
+                    f"Failed to fetch 3 leaders for {category.value}"
+                )

--- a/tests/integration/downloaders/sources/external/quanthockey/test_player_stats_live.py
+++ b/tests/integration/downloaders/sources/external/quanthockey/test_player_stats_live.py
@@ -1,0 +1,455 @@
+"""Integration tests for QuantHockey player season statistics downloader.
+
+These tests hit the live quanthockey.com website and verify that:
+1. Downloaders can fetch real data
+2. Parsed data structures match expected schemas
+3. Rate limiting is respected
+4. All 51 fields are properly populated
+
+Run with: pytest tests/integration/downloaders/sources/external/quanthockey -v -m integration
+
+Skip in CI with: pytest -m "not integration"
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nhl_api.downloaders.sources.external.quanthockey import (
+    QuantHockeyPlayerStatsDownloader,
+)
+from nhl_api.downloaders.sources.external.quanthockey.player_stats import (
+    QuantHockeyConfig,
+)
+from nhl_api.models.quanthockey import QuantHockeyPlayerSeasonStats
+
+if TYPE_CHECKING:
+    pass
+
+
+# Skip all tests in this module if not running integration tests
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+]
+
+
+# =============================================================================
+# Basic Download Tests
+# =============================================================================
+
+
+class TestPlayerStatsDownload:
+    """Integration tests for QuantHockeyPlayerStatsDownloader."""
+
+    @pytest.mark.asyncio
+    async def test_download_top_10_players(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Test downloading top 10 players for current season."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=10,
+            )
+
+        # Should have fetched 10 players
+        assert len(players) == 10
+        assert all(isinstance(p, QuantHockeyPlayerSeasonStats) for p in players)
+
+    @pytest.mark.asyncio
+    async def test_download_previous_season(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        previous_season_id: int,
+    ) -> None:
+        """Test downloading from previous completed season."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                previous_season_id,
+                max_players=10,
+            )
+
+        assert len(players) == 10
+        # Previous season should have complete data
+        for player in players:
+            assert player.games_played > 0
+            assert player.name
+
+    @pytest.mark.asyncio
+    async def test_download_season_data(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Test the download_season_data convenience method."""
+        async with player_stats_downloader:
+            season_data = await player_stats_downloader.download_season_data(
+                current_season_id,
+                max_players=5,
+            )
+
+        assert season_data.season_id == current_season_id
+        assert season_data.season_name == "2024-25"
+        assert len(season_data.players) == 5
+        assert season_data.download_timestamp
+
+
+# =============================================================================
+# Data Structure Tests
+# =============================================================================
+
+
+class TestPlayerStatsStructure:
+    """Tests verifying player stats have expected structure."""
+
+    @pytest.mark.asyncio
+    async def test_core_fields_populated(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Verify core fields are populated for all players."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=10,
+            )
+
+        for player in players:
+            # Identity fields
+            assert player.name, "Player name should not be empty"
+            assert player.rank > 0, "Rank should be positive"
+
+            # Position should be valid
+            assert player.position in [
+                "C",
+                "LW",
+                "RW",
+                "D",
+                "G",
+                "F",
+                "W",
+            ], f"Invalid position: {player.position}"
+
+            # Games played should be positive
+            assert player.games_played > 0
+
+    @pytest.mark.asyncio
+    async def test_scoring_fields_populated(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Verify scoring fields are properly populated."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=10,
+            )
+
+        for player in players:
+            # Basic scoring stats should be non-negative
+            assert player.goals >= 0
+            assert player.assists >= 0
+            assert player.points >= 0
+            assert player.pim >= 0
+
+            # Points should equal goals + assists
+            assert player.points == player.goals + player.assists
+
+    @pytest.mark.asyncio
+    async def test_toi_fields_populated(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Verify TOI (time on ice) fields are populated."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=10,
+            )
+
+        for player in players:
+            # TOI should be non-negative
+            assert player.toi_avg >= 0
+            assert player.toi_es >= 0
+            assert player.toi_pp >= 0
+            assert player.toi_sh >= 0
+
+    @pytest.mark.asyncio
+    async def test_situational_goals_populated(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Verify situational goal breakdowns are populated."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=10,
+            )
+
+        for player in players:
+            # Situational goals should be non-negative
+            assert player.es_goals >= 0
+            assert player.pp_goals >= 0
+            assert player.sh_goals >= 0
+            assert player.gw_goals >= 0
+            assert player.ot_goals >= 0
+
+            # Sum of situational goals should not exceed total goals
+            situational_sum = player.es_goals + player.pp_goals + player.sh_goals
+            assert situational_sum <= player.goals + 1  # Allow small tolerance
+
+    @pytest.mark.asyncio
+    async def test_per_game_rates_computed(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Verify per-game rate stats are properly computed."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=10,
+            )
+
+        for player in players:
+            # Per-game rates should be non-negative
+            assert player.goals_per_game >= 0
+            assert player.assists_per_game >= 0
+            assert player.points_per_game >= 0
+
+
+# =============================================================================
+# All 51 Fields Test
+# =============================================================================
+
+
+class TestAll51Fields:
+    """Tests verifying all 51 fields are parsed correctly."""
+
+    @pytest.mark.asyncio
+    async def test_all_51_fields_present(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Verify all 51 fields are present in player stats."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=5,
+            )
+
+        # Get first player
+        player = players[0]
+
+        # Core identity fields (4)
+        assert hasattr(player, "rank")
+        assert hasattr(player, "name")
+        assert hasattr(player, "team")
+        assert hasattr(player, "age")
+
+        # Position and games (3)
+        assert hasattr(player, "position")
+        assert hasattr(player, "games_played")
+        assert hasattr(player, "nationality")
+
+        # Basic scoring (5)
+        assert hasattr(player, "goals")
+        assert hasattr(player, "assists")
+        assert hasattr(player, "points")
+        assert hasattr(player, "pim")
+        assert hasattr(player, "plus_minus")
+
+        # TOI (4)
+        assert hasattr(player, "toi_avg")
+        assert hasattr(player, "toi_es")
+        assert hasattr(player, "toi_pp")
+        assert hasattr(player, "toi_sh")
+
+        # Goals breakdown (5)
+        assert hasattr(player, "es_goals")
+        assert hasattr(player, "pp_goals")
+        assert hasattr(player, "sh_goals")
+        assert hasattr(player, "gw_goals")
+        assert hasattr(player, "ot_goals")
+
+        # Assists breakdown (5)
+        assert hasattr(player, "es_assists")
+        assert hasattr(player, "pp_assists")
+        assert hasattr(player, "sh_assists")
+        assert hasattr(player, "gw_assists")
+        assert hasattr(player, "ot_assists")
+
+        # Points breakdown (6)
+        assert hasattr(player, "es_points")
+        assert hasattr(player, "pp_points")
+        assert hasattr(player, "sh_points")
+        assert hasattr(player, "gw_points")
+        assert hasattr(player, "ot_points")
+        assert hasattr(player, "ppp_pct")
+
+        # Per-60 rates (9)
+        assert hasattr(player, "goals_per_60")
+        assert hasattr(player, "assists_per_60")
+        assert hasattr(player, "points_per_60")
+        assert hasattr(player, "es_goals_per_60")
+        assert hasattr(player, "es_assists_per_60")
+        assert hasattr(player, "es_points_per_60")
+        assert hasattr(player, "pp_goals_per_60")
+        assert hasattr(player, "pp_assists_per_60")
+        assert hasattr(player, "pp_points_per_60")
+
+        # Per-game rates (3)
+        assert hasattr(player, "goals_per_game")
+        assert hasattr(player, "assists_per_game")
+        assert hasattr(player, "points_per_game")
+
+        # Shooting (2)
+        assert hasattr(player, "shots_on_goal")
+        assert hasattr(player, "shooting_pct")
+
+        # Physical (2)
+        assert hasattr(player, "hits")
+        assert hasattr(player, "blocked_shots")
+
+        # Faceoffs (3)
+        assert hasattr(player, "faceoffs_won")
+        assert hasattr(player, "faceoffs_lost")
+        assert hasattr(player, "faceoff_pct")
+
+    @pytest.mark.asyncio
+    async def test_to_dict_serialization(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Verify players can be serialized to dict and back."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=3,
+            )
+
+        for player in players:
+            # Serialize to dict
+            player_dict = player.to_dict()
+            assert isinstance(player_dict, dict)
+
+            # Deserialize back
+            restored = QuantHockeyPlayerSeasonStats.from_dict(player_dict)
+            assert restored.name == player.name
+            assert restored.points == player.points
+            assert restored.goals == player.goals
+
+
+# =============================================================================
+# Rate Limiting Tests
+# =============================================================================
+
+
+class TestRateLimiting:
+    """Tests verifying rate limiting is respected."""
+
+    @pytest.mark.asyncio
+    async def test_rate_limiting_respected(
+        self,
+        quanthockey_config: QuantHockeyConfig,
+        current_season_id: int,
+    ) -> None:
+        """Verify rate limiting is applied between requests.
+
+        With 0.5 req/sec, multiple pages should take appropriate time.
+        """
+        downloader = QuantHockeyPlayerStatsDownloader(quanthockey_config)
+
+        start_time = time.monotonic()
+
+        async with downloader:
+            # Request enough players to trigger pagination (2 pages)
+            await downloader.download_player_stats(
+                current_season_id,
+                max_players=25,  # 20 per page + 5 more
+            )
+
+        elapsed = time.monotonic() - start_time
+
+        # At 0.5 req/sec, 2 pages should take at least 2 seconds
+        assert elapsed >= 1.5, f"Requests completed too quickly: {elapsed:.2f}s"
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+class TestErrorHandling:
+    """Tests for error handling scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_season_format(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+    ) -> None:
+        """Test handling of invalid season ID format."""
+        async with player_stats_downloader:
+            with pytest.raises(ValueError, match="Invalid season ID format"):
+                await player_stats_downloader.download_player_stats(
+                    2024,  # Wrong format, should be 20242025
+                )
+
+    @pytest.mark.asyncio
+    async def test_empty_max_players(
+        self,
+        player_stats_downloader: QuantHockeyPlayerStatsDownloader,
+        current_season_id: int,
+    ) -> None:
+        """Test with max_players=0."""
+        async with player_stats_downloader:
+            players = await player_stats_downloader.download_player_stats(
+                current_season_id,
+                max_players=0,
+            )
+
+        # Should return empty list when max_players=0
+        assert len(players) == 0
+
+
+# =============================================================================
+# Network Resilience Tests
+# =============================================================================
+
+
+class TestNetworkResilience:
+    """Tests for network resilience (skip if network unavailable)."""
+
+    @pytest.mark.asyncio
+    async def test_graceful_timeout_handling(
+        self,
+        current_season_id: int,
+    ) -> None:
+        """Test that timeouts are handled gracefully."""
+        # Create downloader with very short timeout
+        config = QuantHockeyConfig(
+            requests_per_second=10.0,
+            http_timeout=0.001,  # 1ms timeout
+            max_retries=1,
+        )
+        downloader = QuantHockeyPlayerStatsDownloader(config)
+
+        async with downloader:
+            # Should raise an exception due to timeout (httpx or asyncio timeout)
+            with pytest.raises((TimeoutError, OSError)):
+                await downloader.download_player_stats(
+                    current_season_id,
+                    max_players=10,
+                )


### PR DESCRIPTION
## Summary

Implements Wave 5a.7 - Integration tests for QuantHockey downloaders that hit the live quanthockey.com website.

### Player Season Stats Tests
- Download top 10/previous season players
- Verify all 51 fields populated correctly
- Core fields, scoring, TOI, situational goals validation
- Per-game rate computation verification
- Rate limiting (0.5 req/sec) enforcement
- Error handling (invalid season format, empty request)
- Network resilience (timeout handling)

### Career Stats Tests
- Points/goals/assists leaders download
- Known leaders validation (Wayne Gretzky is #1)
- Career totals and structure verification
- Multi-category comparison (points vs PIM leaders differ)
- Pagination (multi-page, max_pages limit)
- Rate limiting enforcement
- All category types verification

### Test Infrastructure
- Shared fixtures in `conftest.py`
- Conservative rate limits for live site (0.5 req/sec)
- pytest markers: `@integration`, `@slow`
- Skip in CI with: `pytest -m "not integration"`

## Test plan

- [x] Mypy passes
- [x] All 1699 unit tests pass
- [x] 29 integration tests collected
- [ ] Run integration tests manually: `pytest tests/integration/downloaders/sources/external/quanthockey -v -m integration`

## Notes

- Integration tests hit the live QuantHockey website
- Uses conservative rate limiting to be respectful
- Tests are skipped by default in CI (use `-m "not integration"`)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)