### PR TITLE
feat(viewer): Add Validation API endpoints (#45)

### DIFF
--- a/src/nhl_api/viewer/routers/validation.py
+++ b/src/nhl_api/viewer/routers/validation.py
@@ -1,19 +1,272 @@
 """Data validation endpoints.
 
-Future implementation will provide:
-- Data quality checks
-- Validation rule status
-- Anomaly detection results
+Provides endpoints for:
+- Validation rules listing
+- Validation run history and results
+- Data quality scores by entity
+- Discrepancy management and tracking
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from nhl_api.services.db import DatabaseService
+from nhl_api.viewer.dependencies import get_db
+from nhl_api.viewer.schemas.validation import (
+    DiscrepanciesResponse,
+    DiscrepancyDetail,
+    QualityScore,
+    QualityScoresResponse,
+    ValidationRulesResponse,
+    ValidationRunDetail,
+    ValidationRunsResponse,
+)
+from nhl_api.viewer.services.validation_service import ValidationService
+
+# Type alias for dependency injection
+DbDep = Annotated[DatabaseService, Depends(get_db)]
 
 router = APIRouter(prefix="/validation", tags=["validation"])
 
+# Singleton service instance
+_service = ValidationService()
 
-@router.get("/status")
-async def get_validation_status() -> dict[str, str]:
-    """Get data validation status (not yet implemented)."""
-    return {"message": "Validation endpoints coming soon"}
+
+# =============================================================================
+# Validation Rules
+# =============================================================================
+
+
+@router.get(
+    "/rules",
+    response_model=ValidationRulesResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List Validation Rules",
+    description="Get all validation rules with optional filters",
+)
+async def get_validation_rules(
+    db: DbDep,
+    category: str | None = Query(
+        None,
+        description="Filter by category: cross_file, internal, completeness, accuracy",
+        pattern="^(cross_file|internal|completeness|accuracy)$",
+    ),
+    is_active: bool | None = Query(
+        None,
+        description="Filter by active status",
+    ),
+) -> ValidationRulesResponse:
+    """Get all validation rules.
+
+    Returns a list of all configured validation rules.
+    Optionally filter by category or active status.
+    """
+    return await _service.get_validation_rules(
+        db,
+        category=category,
+        is_active=is_active,
+    )
+
+
+# =============================================================================
+# Validation Runs
+# =============================================================================
+
+
+@router.get(
+    "/runs",
+    response_model=ValidationRunsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List Validation Runs",
+    description="Get paginated list of validation runs with status",
+)
+async def get_validation_runs(
+    db: DbDep,
+    season_id: int | None = Query(
+        None,
+        description="Filter by season ID (e.g., 20242025)",
+        ge=20102011,
+        le=20302031,
+    ),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page"),
+) -> ValidationRunsResponse:
+    """Get paginated list of validation runs.
+
+    Returns runs sorted by start time (most recent first).
+    Each run includes summary counts of passed/failed checks.
+    """
+    return await _service.get_validation_runs(
+        db,
+        season_id=season_id,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get(
+    "/runs/{run_id}",
+    response_model=ValidationRunDetail,
+    status_code=status.HTTP_200_OK,
+    summary="Validation Run Detail",
+    description="Get detailed validation run with rule results",
+)
+async def get_validation_run(
+    db: DbDep,
+    run_id: int,
+) -> ValidationRunDetail:
+    """Get detailed validation run with results.
+
+    Returns the run summary plus all individual validation results.
+    Results are sorted with failures first.
+    """
+    try:
+        return await _service.get_validation_run(db, run_id)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from None
+
+
+# =============================================================================
+# Quality Scores
+# =============================================================================
+
+
+@router.get(
+    "/scores",
+    response_model=QualityScoresResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List Quality Scores",
+    description="Get quality scores by entity type",
+)
+async def get_quality_scores(
+    db: DbDep,
+    season_id: int | None = Query(
+        None,
+        description="Filter by season ID (e.g., 20242025)",
+        ge=20102011,
+        le=20302031,
+    ),
+    entity_type: Literal["season", "game"] | None = Query(
+        None,
+        description="Filter by entity type: season or game",
+    ),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page"),
+) -> QualityScoresResponse:
+    """Get paginated list of quality scores.
+
+    Returns scores sorted by overall score (lowest first).
+    Includes completeness, accuracy, consistency, and timeliness dimensions.
+    """
+    return await _service.get_quality_scores(
+        db,
+        season_id=season_id,
+        entity_type=entity_type,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get(
+    "/scores/{entity_type}/{entity_id}",
+    response_model=QualityScore,
+    status_code=status.HTTP_200_OK,
+    summary="Entity Quality Score",
+    description="Get quality score for a specific entity",
+)
+async def get_entity_score(
+    db: DbDep,
+    entity_type: Literal["season", "game"],
+    entity_id: str,
+) -> QualityScore:
+    """Get quality score for a specific entity.
+
+    Entity type can be 'season' or 'game'.
+    For seasons, entity_id is the season ID (e.g., 20242025).
+    For games, entity_id is the game ID.
+    """
+    try:
+        return await _service.get_entity_score(db, entity_type, entity_id)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from None
+
+
+# =============================================================================
+# Discrepancies
+# =============================================================================
+
+
+@router.get(
+    "/discrepancies",
+    response_model=DiscrepanciesResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List Discrepancies",
+    description="Get cross-source data mismatches",
+)
+async def get_discrepancies(
+    db: DbDep,
+    season_id: int | None = Query(
+        None,
+        description="Filter by season ID (e.g., 20242025)",
+        ge=20102011,
+        le=20302031,
+    ),
+    status_filter: Literal["open", "resolved", "ignored"] | None = Query(
+        None,
+        alias="status",
+        description="Filter by resolution status",
+    ),
+    entity_type: str | None = Query(
+        None,
+        description="Filter by entity type (goal, assist, player, shift, etc.)",
+    ),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page"),
+) -> DiscrepanciesResponse:
+    """Get paginated list of discrepancies.
+
+    Returns discrepancies sorted by creation time (most recent first).
+    Filter by season, resolution status, or entity type.
+    """
+    return await _service.get_discrepancies(
+        db,
+        season_id=season_id,
+        status=status_filter,
+        entity_type=entity_type,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get(
+    "/discrepancies/{discrepancy_id}",
+    response_model=DiscrepancyDetail,
+    status_code=status.HTTP_200_OK,
+    summary="Discrepancy Detail",
+    description="Get discrepancy detail with source values",
+)
+async def get_discrepancy(
+    db: DbDep,
+    discrepancy_id: int,
+) -> DiscrepancyDetail:
+    """Get detailed discrepancy with source values.
+
+    Includes the actual values from each source that caused the discrepancy,
+    plus any resolution notes.
+    """
+    try:
+        return await _service.get_discrepancy(db, discrepancy_id)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from None

--- a/src/nhl_api/viewer/schemas/__init__.py
+++ b/src/nhl_api/viewer/schemas/__init__.py
@@ -36,6 +36,19 @@ from nhl_api.viewer.schemas.reconciliation import (
     ReconciliationGamesResponse,
     ReconciliationSummary,
 )
+from nhl_api.viewer.schemas.validation import (
+    DiscrepanciesResponse,
+    DiscrepancyDetail,
+    DiscrepancySummary,
+    QualityScore,
+    QualityScoresResponse,
+    ValidationResult,
+    ValidationRule,
+    ValidationRulesResponse,
+    ValidationRunDetail,
+    ValidationRunsResponse,
+    ValidationRunSummary,
+)
 
 __all__ = [
     # Downloads
@@ -71,4 +84,16 @@ __all__ = [
     "ReconciliationDashboardResponse",
     "ReconciliationGamesResponse",
     "ReconciliationSummary",
+    # Validation
+    "DiscrepanciesResponse",
+    "DiscrepancyDetail",
+    "DiscrepancySummary",
+    "QualityScore",
+    "QualityScoresResponse",
+    "ValidationResult",
+    "ValidationRule",
+    "ValidationRulesResponse",
+    "ValidationRunDetail",
+    "ValidationRunsResponse",
+    "ValidationRunSummary",
 ]

--- a/src/nhl_api/viewer/schemas/validation.py
+++ b/src/nhl_api/viewer/schemas/validation.py
@@ -1,0 +1,218 @@
+"""Validation API Pydantic schemas.
+
+Provides schemas for:
+- Validation rules configuration
+- Validation run history and results
+- Data quality scores
+- Discrepancy tracking and resolution
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+# =============================================================================
+# Validation Rules
+# =============================================================================
+
+
+class ValidationRule(BaseModel):
+    """Validation rule definition."""
+
+    rule_id: int = Field(description="Rule ID")
+    name: str = Field(description="Rule name (e.g., 'goal_reconciliation')")
+    description: str | None = Field(default=None, description="Rule description")
+    category: str = Field(
+        description="Rule category: cross_file, internal, completeness, accuracy"
+    )
+    severity: str = Field(
+        default="warning", description="Rule severity: error, warning, info"
+    )
+    is_active: bool = Field(default=True, description="Whether the rule is active")
+    config: dict[str, Any] | None = Field(
+        default=None, description="Rule-specific configuration"
+    )
+
+
+class ValidationRulesResponse(BaseModel):
+    """List of validation rules."""
+
+    rules: list[ValidationRule] = Field(description="List of validation rules")
+    total: int = Field(ge=0, description="Total number of rules")
+
+
+# =============================================================================
+# Validation Results
+# =============================================================================
+
+
+class ValidationResult(BaseModel):
+    """Individual validation check result."""
+
+    result_id: int = Field(description="Result ID")
+    rule_id: int = Field(description="Associated rule ID")
+    rule_name: str = Field(description="Rule name for display")
+    game_id: int | None = Field(default=None, description="Game ID if game-specific")
+    passed: bool = Field(description="Whether the check passed")
+    severity: str | None = Field(default=None, description="Result severity")
+    message: str | None = Field(default=None, description="Validation message")
+    details: dict[str, Any] | None = Field(
+        default=None, description="Structured discrepancy data"
+    )
+    source_values: dict[str, Any] | None = Field(
+        default=None, description="Source comparison values"
+    )
+    created_at: datetime = Field(description="When the result was created")
+
+
+# =============================================================================
+# Validation Runs
+# =============================================================================
+
+
+class ValidationRunSummary(BaseModel):
+    """Summary of a validation run."""
+
+    run_id: int = Field(description="Run ID")
+    season_id: int | None = Field(
+        default=None, description="Season ID if season-scoped"
+    )
+    started_at: datetime = Field(description="When the run started")
+    completed_at: datetime | None = Field(
+        default=None, description="When the run completed"
+    )
+    status: Literal["running", "completed", "failed"] = Field(description="Run status")
+    rules_checked: int = Field(ge=0, default=0, description="Number of rules checked")
+    total_passed: int = Field(ge=0, default=0, description="Number of passed checks")
+    total_failed: int = Field(ge=0, default=0, description="Number of failed checks")
+    total_warnings: int = Field(ge=0, default=0, description="Number of warnings")
+
+
+class ValidationRunDetail(ValidationRunSummary):
+    """Detailed validation run with results."""
+
+    results: list[ValidationResult] = Field(
+        default_factory=list, description="Validation results for this run"
+    )
+    metadata: dict[str, Any] | None = Field(default=None, description="Run metadata")
+
+
+class ValidationRunsResponse(BaseModel):
+    """Paginated list of validation runs."""
+
+    runs: list[ValidationRunSummary] = Field(description="List of validation runs")
+    total: int = Field(ge=0, description="Total runs matching filters")
+    page: int = Field(ge=1, description="Current page number")
+    page_size: int = Field(ge=1, description="Items per page")
+    pages: int = Field(ge=0, description="Total number of pages")
+
+
+# =============================================================================
+# Quality Scores
+# =============================================================================
+
+
+class QualityScore(BaseModel):
+    """Data quality score for an entity."""
+
+    score_id: int = Field(description="Score record ID")
+    season_id: int = Field(description="Season ID")
+    game_id: int | None = Field(default=None, description="Game ID if game-specific")
+    entity_type: Literal["season", "game"] = Field(
+        description="Type of entity being scored"
+    )
+    entity_id: str = Field(description="Entity identifier")
+
+    # Quality dimensions (0-100 scale)
+    completeness_score: float | None = Field(
+        default=None, ge=0.0, le=100.0, description="Data completeness (0-100)"
+    )
+    accuracy_score: float | None = Field(
+        default=None, ge=0.0, le=100.0, description="Data accuracy (0-100)"
+    )
+    consistency_score: float | None = Field(
+        default=None, ge=0.0, le=100.0, description="Cross-source consistency (0-100)"
+    )
+    timeliness_score: float | None = Field(
+        default=None, ge=0.0, le=100.0, description="Data freshness (0-100)"
+    )
+    overall_score: float | None = Field(
+        default=None, ge=0.0, le=100.0, description="Overall quality (0-100)"
+    )
+
+    # Check counts
+    total_checks: int = Field(ge=0, default=0, description="Total checks performed")
+    passed_checks: int = Field(ge=0, default=0, description="Number of passed checks")
+    failed_checks: int = Field(ge=0, default=0, description="Number of failed checks")
+    warning_checks: int = Field(ge=0, default=0, description="Number of warnings")
+
+    calculated_at: datetime = Field(description="When the score was calculated")
+
+
+class QualityScoresResponse(BaseModel):
+    """Paginated list of quality scores."""
+
+    scores: list[QualityScore] = Field(description="List of quality scores")
+    total: int = Field(ge=0, description="Total scores matching filters")
+    page: int = Field(ge=1, description="Current page number")
+    page_size: int = Field(ge=1, description="Items per page")
+    pages: int = Field(ge=0, description="Total number of pages")
+
+
+# =============================================================================
+# Discrepancies
+# =============================================================================
+
+
+class DiscrepancySummary(BaseModel):
+    """Summary of a data discrepancy."""
+
+    discrepancy_id: int = Field(description="Discrepancy ID")
+    rule_id: int = Field(description="Associated rule ID")
+    rule_name: str = Field(description="Rule name for display")
+    game_id: int | None = Field(default=None, description="Game ID if game-specific")
+    season_id: int | None = Field(default=None, description="Season ID")
+    entity_type: str | None = Field(
+        default=None, description="Entity type: goal, assist, player, shift, etc."
+    )
+    entity_id: str | None = Field(default=None, description="Entity identifier")
+    field_name: str | None = Field(default=None, description="Field with discrepancy")
+    source_a: str | None = Field(default=None, description="First source name")
+    source_b: str | None = Field(default=None, description="Second source name")
+    resolution_status: Literal["open", "resolved", "ignored"] = Field(
+        default="open", description="Resolution status"
+    )
+    created_at: datetime = Field(description="When the discrepancy was found")
+
+
+class DiscrepancyDetail(DiscrepancySummary):
+    """Detailed discrepancy with source values."""
+
+    source_a_value: str | None = Field(
+        default=None, description="Value from first source"
+    )
+    source_b_value: str | None = Field(
+        default=None, description="Value from second source"
+    )
+    resolution_notes: str | None = Field(
+        default=None, description="Notes on resolution"
+    )
+    resolved_at: datetime | None = Field(
+        default=None, description="When the discrepancy was resolved"
+    )
+    result_id: int | None = Field(
+        default=None, description="Associated validation result ID"
+    )
+
+
+class DiscrepanciesResponse(BaseModel):
+    """Paginated list of discrepancies."""
+
+    discrepancies: list[DiscrepancySummary] = Field(description="List of discrepancies")
+    total: int = Field(ge=0, description="Total discrepancies matching filters")
+    page: int = Field(ge=1, description="Current page number")
+    page_size: int = Field(ge=1, description="Items per page")
+    pages: int = Field(ge=0, description="Total number of pages")

--- a/src/nhl_api/viewer/services/__init__.py
+++ b/src/nhl_api/viewer/services/__init__.py
@@ -2,5 +2,6 @@
 
 from nhl_api.viewer.services.download_service import DownloadService
 from nhl_api.viewer.services.reconciliation_service import ReconciliationService
+from nhl_api.viewer.services.validation_service import ValidationService
 
-__all__ = ["DownloadService", "ReconciliationService"]
+__all__ = ["DownloadService", "ReconciliationService", "ValidationService"]

--- a/src/nhl_api/viewer/services/validation_service.py
+++ b/src/nhl_api/viewer/services/validation_service.py
@@ -1,0 +1,513 @@
+"""Validation service for data quality and discrepancy management.
+
+Provides business logic for:
+- Listing and managing validation rules
+- Tracking validation run history
+- Computing and retrieving quality scores
+- Managing discrepancies
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from nhl_api.services.db import DatabaseService
+from nhl_api.viewer.schemas.validation import (
+    DiscrepanciesResponse,
+    DiscrepancyDetail,
+    DiscrepancySummary,
+    QualityScore,
+    QualityScoresResponse,
+    ValidationResult,
+    ValidationRule,
+    ValidationRulesResponse,
+    ValidationRunDetail,
+    ValidationRunsResponse,
+    ValidationRunSummary,
+)
+
+
+@dataclass
+class ValidationService:
+    """Service for validation data access and business logic."""
+
+    # =========================================================================
+    # Validation Rules
+    # =========================================================================
+
+    async def get_validation_rules(
+        self,
+        db: DatabaseService,
+        category: str | None = None,
+        is_active: bool | None = None,
+    ) -> ValidationRulesResponse:
+        """Get all validation rules with optional filters."""
+        conditions: list[str] = []
+        params: list[Any] = []
+        param_idx = 1
+
+        if category is not None:
+            conditions.append(f"category = ${param_idx}")
+            params.append(category)
+            param_idx += 1
+
+        if is_active is not None:
+            conditions.append(f"is_active = ${param_idx}")
+            params.append(is_active)
+            param_idx += 1
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        query = f"""
+            SELECT
+                rule_id, name, description, category, severity,
+                is_active, config
+            FROM validation_rules
+            WHERE {where_clause}
+            ORDER BY category, name
+        """
+
+        rows = await db.fetch(query, *params)
+
+        rules = [
+            ValidationRule(
+                rule_id=row["rule_id"],
+                name=row["name"],
+                description=row["description"],
+                category=row["category"],
+                severity=row["severity"],
+                is_active=row["is_active"],
+                config=row["config"],
+            )
+            for row in rows
+        ]
+
+        return ValidationRulesResponse(rules=rules, total=len(rules))
+
+    # =========================================================================
+    # Validation Runs
+    # =========================================================================
+
+    async def get_validation_runs(
+        self,
+        db: DatabaseService,
+        season_id: int | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> ValidationRunsResponse:
+        """Get paginated list of validation runs."""
+        conditions: list[str] = []
+        params: list[Any] = []
+        param_idx = 1
+
+        if season_id is not None:
+            conditions.append(f"season_id = ${param_idx}")
+            params.append(season_id)
+            param_idx += 1
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        # Count total
+        count_query = f"SELECT COUNT(*) FROM validation_runs WHERE {where_clause}"
+        total = await db.fetchval(count_query, *params) or 0
+
+        # Calculate pagination
+        offset = (page - 1) * page_size
+        pages = math.ceil(total / page_size) if total > 0 else 1
+
+        # Fetch paginated data
+        query = f"""
+            SELECT
+                run_id, season_id, started_at, completed_at, status,
+                rules_checked, total_passed, total_failed, total_warnings
+            FROM validation_runs
+            WHERE {where_clause}
+            ORDER BY started_at DESC
+            LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """
+        params.extend([page_size, offset])
+
+        rows = await db.fetch(query, *params)
+
+        runs = [
+            ValidationRunSummary(
+                run_id=row["run_id"],
+                season_id=row["season_id"],
+                started_at=row["started_at"],
+                completed_at=row["completed_at"],
+                status=row["status"],
+                rules_checked=row["rules_checked"] or 0,
+                total_passed=row["total_passed"] or 0,
+                total_failed=row["total_failed"] or 0,
+                total_warnings=row["total_warnings"] or 0,
+            )
+            for row in rows
+        ]
+
+        return ValidationRunsResponse(
+            runs=runs,
+            total=total,
+            page=page,
+            page_size=page_size,
+            pages=pages,
+        )
+
+    async def get_validation_run(
+        self,
+        db: DatabaseService,
+        run_id: int,
+    ) -> ValidationRunDetail:
+        """Get detailed validation run with results."""
+        # Get run info
+        run_query = """
+            SELECT
+                run_id, season_id, started_at, completed_at, status,
+                rules_checked, total_passed, total_failed, total_warnings,
+                metadata
+            FROM validation_runs
+            WHERE run_id = $1
+        """
+        run_row = await db.fetchrow(run_query, run_id)
+
+        if not run_row:
+            raise ValueError(f"Validation run {run_id} not found")
+
+        # Get results for this run
+        results_query = """
+            SELECT
+                vr.result_id, vr.rule_id, r.name as rule_name, vr.game_id,
+                vr.passed, vr.severity, vr.message, vr.details, vr.source_values,
+                vr.created_at
+            FROM validation_results vr
+            JOIN validation_rules r ON r.rule_id = vr.rule_id
+            WHERE vr.run_id = $1
+            ORDER BY vr.passed ASC, vr.created_at DESC
+            LIMIT 1000
+        """
+        result_rows = await db.fetch(results_query, run_id)
+
+        results = [
+            ValidationResult(
+                result_id=row["result_id"],
+                rule_id=row["rule_id"],
+                rule_name=row["rule_name"],
+                game_id=row["game_id"],
+                passed=row["passed"],
+                severity=row["severity"],
+                message=row["message"],
+                details=row["details"],
+                source_values=row["source_values"],
+                created_at=row["created_at"],
+            )
+            for row in result_rows
+        ]
+
+        return ValidationRunDetail(
+            run_id=run_row["run_id"],
+            season_id=run_row["season_id"],
+            started_at=run_row["started_at"],
+            completed_at=run_row["completed_at"],
+            status=run_row["status"],
+            rules_checked=run_row["rules_checked"] or 0,
+            total_passed=run_row["total_passed"] or 0,
+            total_failed=run_row["total_failed"] or 0,
+            total_warnings=run_row["total_warnings"] or 0,
+            results=results,
+            metadata=run_row["metadata"],
+        )
+
+    # =========================================================================
+    # Quality Scores
+    # =========================================================================
+
+    async def get_quality_scores(
+        self,
+        db: DatabaseService,
+        season_id: int | None = None,
+        entity_type: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> QualityScoresResponse:
+        """Get paginated list of quality scores."""
+        conditions: list[str] = []
+        params: list[Any] = []
+        param_idx = 1
+
+        if season_id is not None:
+            conditions.append(f"season_id = ${param_idx}")
+            params.append(season_id)
+            param_idx += 1
+
+        if entity_type is not None:
+            if entity_type == "game":
+                conditions.append("game_id IS NOT NULL")
+            elif entity_type == "season":
+                conditions.append("game_id IS NULL")
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        # Count total
+        count_query = f"SELECT COUNT(*) FROM data_quality_scores WHERE {where_clause}"
+        total = await db.fetchval(count_query, *params) or 0
+
+        # Calculate pagination
+        offset = (page - 1) * page_size
+        pages = math.ceil(total / page_size) if total > 0 else 1
+
+        # Fetch paginated data
+        query = f"""
+            SELECT
+                score_id, season_id, game_id,
+                completeness_score, accuracy_score, consistency_score,
+                timeliness_score, overall_score,
+                total_checks, passed_checks, failed_checks, warning_checks,
+                calculated_at
+            FROM data_quality_scores
+            WHERE {where_clause}
+            ORDER BY overall_score ASC NULLS LAST, calculated_at DESC
+            LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """
+        params.extend([page_size, offset])
+
+        rows = await db.fetch(query, *params)
+
+        scores = [
+            QualityScore(
+                score_id=row["score_id"],
+                season_id=row["season_id"],
+                game_id=row["game_id"],
+                entity_type="game" if row["game_id"] else "season",
+                entity_id=str(row["game_id"])
+                if row["game_id"]
+                else str(row["season_id"]),
+                completeness_score=float(row["completeness_score"])
+                if row["completeness_score"]
+                else None,
+                accuracy_score=float(row["accuracy_score"])
+                if row["accuracy_score"]
+                else None,
+                consistency_score=float(row["consistency_score"])
+                if row["consistency_score"]
+                else None,
+                timeliness_score=float(row["timeliness_score"])
+                if row["timeliness_score"]
+                else None,
+                overall_score=float(row["overall_score"])
+                if row["overall_score"]
+                else None,
+                total_checks=row["total_checks"] or 0,
+                passed_checks=row["passed_checks"] or 0,
+                failed_checks=row["failed_checks"] or 0,
+                warning_checks=row["warning_checks"] or 0,
+                calculated_at=row["calculated_at"],
+            )
+            for row in rows
+        ]
+
+        return QualityScoresResponse(
+            scores=scores,
+            total=total,
+            page=page,
+            page_size=page_size,
+            pages=pages,
+        )
+
+    async def get_entity_score(
+        self,
+        db: DatabaseService,
+        entity_type: Literal["season", "game"],
+        entity_id: str,
+    ) -> QualityScore:
+        """Get quality score for a specific entity."""
+        if entity_type == "game":
+            query = """
+                SELECT
+                    score_id, season_id, game_id,
+                    completeness_score, accuracy_score, consistency_score,
+                    timeliness_score, overall_score,
+                    total_checks, passed_checks, failed_checks, warning_checks,
+                    calculated_at
+                FROM data_quality_scores
+                WHERE game_id = $1
+                ORDER BY calculated_at DESC
+                LIMIT 1
+            """
+            row = await db.fetchrow(query, int(entity_id))
+        elif entity_type == "season":
+            query = """
+                SELECT
+                    score_id, season_id, game_id,
+                    completeness_score, accuracy_score, consistency_score,
+                    timeliness_score, overall_score,
+                    total_checks, passed_checks, failed_checks, warning_checks,
+                    calculated_at
+                FROM data_quality_scores
+                WHERE season_id = $1 AND game_id IS NULL
+                ORDER BY calculated_at DESC
+                LIMIT 1
+            """
+            row = await db.fetchrow(query, int(entity_id))
+        else:
+            raise ValueError(f"Invalid entity type: {entity_type}")
+
+        if not row:
+            raise ValueError(f"No quality score found for {entity_type} {entity_id}")
+
+        return QualityScore(
+            score_id=row["score_id"],
+            season_id=row["season_id"],
+            game_id=row["game_id"],
+            entity_type=entity_type,
+            entity_id=entity_id,
+            completeness_score=float(row["completeness_score"])
+            if row["completeness_score"]
+            else None,
+            accuracy_score=float(row["accuracy_score"])
+            if row["accuracy_score"]
+            else None,
+            consistency_score=float(row["consistency_score"])
+            if row["consistency_score"]
+            else None,
+            timeliness_score=float(row["timeliness_score"])
+            if row["timeliness_score"]
+            else None,
+            overall_score=float(row["overall_score"]) if row["overall_score"] else None,
+            total_checks=row["total_checks"] or 0,
+            passed_checks=row["passed_checks"] or 0,
+            failed_checks=row["failed_checks"] or 0,
+            warning_checks=row["warning_checks"] or 0,
+            calculated_at=row["calculated_at"],
+        )
+
+    # =========================================================================
+    # Discrepancies
+    # =========================================================================
+
+    async def get_discrepancies(
+        self,
+        db: DatabaseService,
+        season_id: int | None = None,
+        status: str | None = None,
+        entity_type: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> DiscrepanciesResponse:
+        """Get paginated list of discrepancies."""
+        conditions: list[str] = []
+        params: list[Any] = []
+        param_idx = 1
+
+        if season_id is not None:
+            conditions.append(f"d.season_id = ${param_idx}")
+            params.append(season_id)
+            param_idx += 1
+
+        if status is not None:
+            conditions.append(f"d.resolution_status = ${param_idx}")
+            params.append(status)
+            param_idx += 1
+
+        if entity_type is not None:
+            conditions.append(f"d.entity_type = ${param_idx}")
+            params.append(entity_type)
+            param_idx += 1
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        # Count total
+        count_query = f"""
+            SELECT COUNT(*) FROM discrepancies d WHERE {where_clause}
+        """
+        total = await db.fetchval(count_query, *params) or 0
+
+        # Calculate pagination
+        offset = (page - 1) * page_size
+        pages = math.ceil(total / page_size) if total > 0 else 1
+
+        # Fetch paginated data
+        query = f"""
+            SELECT
+                d.discrepancy_id, d.rule_id, r.name as rule_name,
+                d.game_id, d.season_id, d.entity_type, d.entity_id,
+                d.field_name, d.source_a, d.source_b,
+                d.resolution_status, d.created_at
+            FROM discrepancies d
+            JOIN validation_rules r ON r.rule_id = d.rule_id
+            WHERE {where_clause}
+            ORDER BY d.created_at DESC
+            LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """
+        params.extend([page_size, offset])
+
+        rows = await db.fetch(query, *params)
+
+        discrepancies = [
+            DiscrepancySummary(
+                discrepancy_id=row["discrepancy_id"],
+                rule_id=row["rule_id"],
+                rule_name=row["rule_name"],
+                game_id=row["game_id"],
+                season_id=row["season_id"],
+                entity_type=row["entity_type"],
+                entity_id=row["entity_id"],
+                field_name=row["field_name"],
+                source_a=row["source_a"],
+                source_b=row["source_b"],
+                resolution_status=row["resolution_status"],
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
+        return DiscrepanciesResponse(
+            discrepancies=discrepancies,
+            total=total,
+            page=page,
+            page_size=page_size,
+            pages=pages,
+        )
+
+    async def get_discrepancy(
+        self,
+        db: DatabaseService,
+        discrepancy_id: int,
+    ) -> DiscrepancyDetail:
+        """Get detailed discrepancy with source values."""
+        query = """
+            SELECT
+                d.discrepancy_id, d.rule_id, r.name as rule_name,
+                d.game_id, d.season_id, d.entity_type, d.entity_id,
+                d.field_name, d.source_a, d.source_a_value,
+                d.source_b, d.source_b_value,
+                d.resolution_status, d.resolution_notes,
+                d.created_at, d.resolved_at, d.result_id
+            FROM discrepancies d
+            JOIN validation_rules r ON r.rule_id = d.rule_id
+            WHERE d.discrepancy_id = $1
+        """
+        row = await db.fetchrow(query, discrepancy_id)
+
+        if not row:
+            raise ValueError(f"Discrepancy {discrepancy_id} not found")
+
+        return DiscrepancyDetail(
+            discrepancy_id=row["discrepancy_id"],
+            rule_id=row["rule_id"],
+            rule_name=row["rule_name"],
+            game_id=row["game_id"],
+            season_id=row["season_id"],
+            entity_type=row["entity_type"],
+            entity_id=row["entity_id"],
+            field_name=row["field_name"],
+            source_a=row["source_a"],
+            source_a_value=row["source_a_value"],
+            source_b=row["source_b"],
+            source_b_value=row["source_b_value"],
+            resolution_status=row["resolution_status"],
+            resolution_notes=row["resolution_notes"],
+            created_at=row["created_at"],
+            resolved_at=row["resolved_at"],
+            result_id=row["result_id"],
+        )

--- a/tests/unit/viewer/conftest.py
+++ b/tests/unit/viewer/conftest.py
@@ -12,7 +12,13 @@ from fastapi.testclient import TestClient
 
 from nhl_api.viewer.config import get_settings
 from nhl_api.viewer.dependencies import set_db_service
-from nhl_api.viewer.routers import entities, health, monitoring, validation
+from nhl_api.viewer.routers import (
+    entities,
+    health,
+    monitoring,
+    reconciliation,
+    validation,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -55,6 +61,7 @@ def test_client(mock_db_service: MagicMock) -> Generator[TestClient, None, None]
     app.include_router(health.router)
     app.include_router(monitoring.router, prefix="/api/v1")
     app.include_router(entities.router, prefix="/api/v1")
+    app.include_router(reconciliation.router, prefix="/api/v1")
     app.include_router(validation.router, prefix="/api/v1")
 
     @app.get("/api/v1/info")

--- a/tests/unit/viewer/test_api_info.py
+++ b/tests/unit/viewer/test_api_info.py
@@ -26,16 +26,14 @@ class TestApiInfo:
         assert "title" in data
 
 
-class TestStubEndpoints:
-    """Tests for stub endpoints that are not yet implemented."""
+class TestValidationEndpoints:
+    """Tests for validation API endpoints."""
 
-    def test_validation_status_returns_coming_soon(
-        self, test_client: TestClient
-    ) -> None:
-        """Test validation status stub returns coming soon message."""
-        response = test_client.get("/api/v1/validation/status")
+    def test_validation_rules_returns_list(self, test_client: TestClient) -> None:
+        """Test validation rules endpoint returns list."""
+        response = test_client.get("/api/v1/validation/rules")
 
         assert response.status_code == 200
         data = response.json()
-        assert "message" in data
-        assert "coming soon" in data["message"].lower()
+        assert "rules" in data
+        assert "total" in data

--- a/tests/unit/viewer/test_validation_router.py
+++ b/tests/unit/viewer/test_validation_router.py
@@ -1,0 +1,573 @@
+"""Unit tests for validation router endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nhl_api.viewer.dependencies import set_db_service
+from nhl_api.viewer.routers import validation
+from nhl_api.viewer.schemas.validation import (
+    DiscrepanciesResponse,
+    DiscrepancyDetail,
+    DiscrepancySummary,
+    QualityScore,
+    QualityScoresResponse,
+    ValidationResult,
+    ValidationRule,
+    ValidationRulesResponse,
+    ValidationRunDetail,
+    ValidationRunsResponse,
+    ValidationRunSummary,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def mock_db_service() -> MagicMock:
+    """Create a mock DatabaseService."""
+    mock = MagicMock()
+    mock.is_connected = True
+    mock.fetchval = AsyncMock(return_value=1)
+    mock.fetch = AsyncMock(return_value=[])
+    mock.fetchrow = AsyncMock(return_value=None)
+    mock.execute = AsyncMock(return_value="OK")
+    return mock
+
+
+@pytest.fixture
+def test_app() -> FastAPI:
+    """Create a test FastAPI app with validation router."""
+    app = FastAPI()
+    app.include_router(validation.router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture
+def test_client(
+    test_app: FastAPI, mock_db_service: MagicMock
+) -> Generator[TestClient, None, None]:
+    """Create a test client with mocked database."""
+    set_db_service(mock_db_service)
+    client = TestClient(test_app)
+    yield client
+    set_db_service(None)
+
+
+# =============================================================================
+# Validation Rules Endpoint Tests
+# =============================================================================
+
+
+class TestValidationRulesEndpoint:
+    """Test GET /validation/rules endpoint."""
+
+    def test_get_rules_success(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Rules endpoint returns 200 with list of rules."""
+        mock_response = ValidationRulesResponse(
+            rules=[
+                ValidationRule(
+                    rule_id=1,
+                    name="goal_reconciliation",
+                    description="Goals match between sources",
+                    category="cross_file",
+                    severity="error",
+                    is_active=True,
+                    config=None,
+                ),
+                ValidationRule(
+                    rule_id=2,
+                    name="toi_validation",
+                    description="TOI matches between sources",
+                    category="cross_file",
+                    severity="warning",
+                    is_active=True,
+                    config=None,
+                ),
+            ],
+            total=2,
+        )
+
+        with patch.object(
+            validation._service, "get_validation_rules", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/rules")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 2
+            assert len(data["rules"]) == 2
+            assert data["rules"][0]["name"] == "goal_reconciliation"
+
+    def test_get_rules_with_category_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Rules endpoint accepts category filter."""
+        mock_response = ValidationRulesResponse(
+            rules=[
+                ValidationRule(
+                    rule_id=1,
+                    name="goal_reconciliation",
+                    description="Goals match",
+                    category="cross_file",
+                    severity="error",
+                    is_active=True,
+                    config=None,
+                ),
+            ],
+            total=1,
+        )
+
+        with patch.object(
+            validation._service, "get_validation_rules", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/rules?category=cross_file")
+
+            assert response.status_code == 200
+            mock_method.assert_called_once()
+
+    def test_get_rules_invalid_category(self, test_client: TestClient) -> None:
+        """Rules endpoint rejects invalid category."""
+        response = test_client.get("/api/v1/validation/rules?category=invalid_category")
+        assert response.status_code == 422
+
+    def test_get_rules_empty(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Rules endpoint returns empty list when no rules."""
+        mock_response = ValidationRulesResponse(rules=[], total=0)
+
+        with patch.object(
+            validation._service, "get_validation_rules", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/rules")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 0
+            assert data["rules"] == []
+
+
+# =============================================================================
+# Validation Runs Endpoint Tests
+# =============================================================================
+
+
+class TestValidationRunsEndpoint:
+    """Test GET /validation/runs endpoint."""
+
+    def test_get_runs_success(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Runs endpoint returns 200 with paginated list."""
+        now = datetime.now(UTC)
+        mock_response = ValidationRunsResponse(
+            runs=[
+                ValidationRunSummary(
+                    run_id=1,
+                    season_id=20242025,
+                    started_at=now,
+                    completed_at=now,
+                    status="completed",
+                    rules_checked=10,
+                    total_passed=8,
+                    total_failed=2,
+                    total_warnings=1,
+                ),
+            ],
+            total=1,
+            page=1,
+            page_size=20,
+            pages=1,
+        )
+
+        with patch.object(
+            validation._service, "get_validation_runs", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/runs")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 1
+            assert len(data["runs"]) == 1
+            assert data["runs"][0]["status"] == "completed"
+
+    def test_get_runs_with_season_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Runs endpoint accepts season_id filter."""
+        mock_response = ValidationRunsResponse(
+            runs=[], total=0, page=1, page_size=20, pages=1
+        )
+
+        with patch.object(
+            validation._service, "get_validation_runs", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/runs?season_id=20242025")
+
+            assert response.status_code == 200
+            mock_method.assert_called_once()
+
+    def test_get_runs_pagination(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Runs endpoint accepts pagination parameters."""
+        mock_response = ValidationRunsResponse(
+            runs=[], total=0, page=2, page_size=50, pages=0
+        )
+
+        with patch.object(
+            validation._service, "get_validation_runs", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/runs?page=2&page_size=50")
+
+            assert response.status_code == 200
+
+
+class TestValidationRunDetailEndpoint:
+    """Test GET /validation/runs/{run_id} endpoint."""
+
+    def test_get_run_detail_success(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Run detail endpoint returns 200 with results."""
+        now = datetime.now(UTC)
+        mock_response = ValidationRunDetail(
+            run_id=1,
+            season_id=20242025,
+            started_at=now,
+            completed_at=now,
+            status="completed",
+            rules_checked=10,
+            total_passed=9,
+            total_failed=1,
+            total_warnings=0,
+            results=[
+                ValidationResult(
+                    result_id=1,
+                    rule_id=1,
+                    rule_name="goal_reconciliation",
+                    game_id=2024020001,
+                    passed=False,
+                    severity="error",
+                    message="Goal count mismatch",
+                    details={"expected": 3, "actual": 2},
+                    source_values={"pbp": 3, "boxscore": 2},
+                    created_at=now,
+                ),
+            ],
+            metadata=None,
+        )
+
+        with patch.object(
+            validation._service, "get_validation_run", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/runs/1")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["run_id"] == 1
+            assert len(data["results"]) == 1
+
+    def test_get_run_detail_not_found(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Run detail endpoint returns 404 for nonexistent run."""
+        with patch.object(
+            validation._service, "get_validation_run", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.side_effect = ValueError("Validation run 999 not found")
+
+            response = test_client.get("/api/v1/validation/runs/999")
+
+            assert response.status_code == 404
+            assert "not found" in response.json()["detail"]
+
+
+# =============================================================================
+# Quality Scores Endpoint Tests
+# =============================================================================
+
+
+class TestQualityScoresEndpoint:
+    """Test GET /validation/scores endpoint."""
+
+    def test_get_scores_success(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Scores endpoint returns 200 with paginated list."""
+        now = datetime.now(UTC)
+        mock_response = QualityScoresResponse(
+            scores=[
+                QualityScore(
+                    score_id=1,
+                    season_id=20242025,
+                    game_id=None,
+                    entity_type="season",
+                    entity_id="20242025",
+                    completeness_score=95.0,
+                    accuracy_score=98.0,
+                    consistency_score=96.0,
+                    timeliness_score=100.0,
+                    overall_score=97.25,
+                    total_checks=100,
+                    passed_checks=97,
+                    failed_checks=3,
+                    warning_checks=2,
+                    calculated_at=now,
+                ),
+            ],
+            total=1,
+            page=1,
+            page_size=20,
+            pages=1,
+        )
+
+        with patch.object(
+            validation._service, "get_quality_scores", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/scores")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 1
+            assert data["scores"][0]["overall_score"] == 97.25
+
+    def test_get_scores_with_entity_type_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Scores endpoint accepts entity_type filter."""
+        mock_response = QualityScoresResponse(
+            scores=[], total=0, page=1, page_size=20, pages=1
+        )
+
+        with patch.object(
+            validation._service, "get_quality_scores", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/scores?entity_type=game")
+
+            assert response.status_code == 200
+
+
+class TestEntityScoreEndpoint:
+    """Test GET /validation/scores/{entity_type}/{entity_id} endpoint."""
+
+    def test_get_entity_score_success(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Entity score endpoint returns 200 with score."""
+        now = datetime.now(UTC)
+        mock_response = QualityScore(
+            score_id=1,
+            season_id=20242025,
+            game_id=2024020001,
+            entity_type="game",
+            entity_id="2024020001",
+            completeness_score=100.0,
+            accuracy_score=95.0,
+            consistency_score=100.0,
+            timeliness_score=100.0,
+            overall_score=98.75,
+            total_checks=20,
+            passed_checks=19,
+            failed_checks=1,
+            warning_checks=0,
+            calculated_at=now,
+        )
+
+        with patch.object(
+            validation._service, "get_entity_score", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/scores/game/2024020001")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["entity_type"] == "game"
+            assert data["entity_id"] == "2024020001"
+
+    def test_get_entity_score_not_found(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Entity score endpoint returns 404 when no score."""
+        with patch.object(
+            validation._service, "get_entity_score", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.side_effect = ValueError(
+                "No quality score found for game 999999"
+            )
+
+            response = test_client.get("/api/v1/validation/scores/game/999999")
+
+            assert response.status_code == 404
+
+
+# =============================================================================
+# Discrepancies Endpoint Tests
+# =============================================================================
+
+
+class TestDiscrepanciesEndpoint:
+    """Test GET /validation/discrepancies endpoint."""
+
+    def test_get_discrepancies_success(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Discrepancies endpoint returns 200 with paginated list."""
+        now = datetime.now(UTC)
+        mock_response = DiscrepanciesResponse(
+            discrepancies=[
+                DiscrepancySummary(
+                    discrepancy_id=1,
+                    rule_id=1,
+                    rule_name="goal_reconciliation",
+                    game_id=2024020001,
+                    season_id=20242025,
+                    entity_type="goal",
+                    entity_id="goal_1",
+                    field_name="count",
+                    source_a="pbp",
+                    source_b="boxscore",
+                    resolution_status="open",
+                    created_at=now,
+                ),
+            ],
+            total=1,
+            page=1,
+            page_size=20,
+            pages=1,
+        )
+
+        with patch.object(
+            validation._service, "get_discrepancies", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/discrepancies")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 1
+            assert data["discrepancies"][0]["resolution_status"] == "open"
+
+    def test_get_discrepancies_with_status_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Discrepancies endpoint accepts status filter."""
+        mock_response = DiscrepanciesResponse(
+            discrepancies=[], total=0, page=1, page_size=20, pages=1
+        )
+
+        with patch.object(
+            validation._service, "get_discrepancies", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get(
+                "/api/v1/validation/discrepancies?status=resolved"
+            )
+
+            assert response.status_code == 200
+
+    def test_get_discrepancies_with_entity_type_filter(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Discrepancies endpoint accepts entity_type filter."""
+        mock_response = DiscrepanciesResponse(
+            discrepancies=[], total=0, page=1, page_size=20, pages=1
+        )
+
+        with patch.object(
+            validation._service, "get_discrepancies", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get(
+                "/api/v1/validation/discrepancies?entity_type=goal"
+            )
+
+            assert response.status_code == 200
+
+
+class TestDiscrepancyDetailEndpoint:
+    """Test GET /validation/discrepancies/{discrepancy_id} endpoint."""
+
+    def test_get_discrepancy_detail_success(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Discrepancy detail endpoint returns 200 with full details."""
+        now = datetime.now(UTC)
+        mock_response = DiscrepancyDetail(
+            discrepancy_id=1,
+            rule_id=1,
+            rule_name="goal_reconciliation",
+            game_id=2024020001,
+            season_id=20242025,
+            entity_type="goal",
+            entity_id="goal_1",
+            field_name="count",
+            source_a="pbp",
+            source_a_value="3",
+            source_b="boxscore",
+            source_b_value="2",
+            resolution_status="open",
+            resolution_notes=None,
+            created_at=now,
+            resolved_at=None,
+            result_id=1,
+        )
+
+        with patch.object(
+            validation._service, "get_discrepancy", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.return_value = mock_response
+
+            response = test_client.get("/api/v1/validation/discrepancies/1")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["discrepancy_id"] == 1
+            assert data["source_a_value"] == "3"
+            assert data["source_b_value"] == "2"
+
+    def test_get_discrepancy_detail_not_found(
+        self, test_client: TestClient, mock_db_service: MagicMock
+    ) -> None:
+        """Discrepancy detail endpoint returns 404 for nonexistent."""
+        with patch.object(
+            validation._service, "get_discrepancy", new_callable=AsyncMock
+        ) as mock_method:
+            mock_method.side_effect = ValueError("Discrepancy 999 not found")
+
+            response = test_client.get("/api/v1/validation/discrepancies/999")
+
+            assert response.status_code == 404
+            assert "not found" in response.json()["detail"]


### PR DESCRIPTION
## Summary

Implement the Viewer Backend - Validation API (Issue #45), providing endpoints for validation runs, quality scores, and discrepancy management.

### Endpoints Added

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/v1/validation/rules` | GET | List validation rules (filterable by category) |
| `/api/v1/validation/runs` | GET | List validation runs (paginated) |
| `/api/v1/validation/runs/{run_id}` | GET | Run detail with results |
| `/api/v1/validation/scores` | GET | Quality scores (filterable by entity type) |
| `/api/v1/validation/scores/{entity_type}/{entity_id}` | GET | Entity score |
| `/api/v1/validation/discrepancies` | GET | List discrepancies (filterable) |
| `/api/v1/validation/discrepancies/{id}` | GET | Discrepancy detail |

### Files Changed

- `src/nhl_api/viewer/schemas/validation.py` - Pydantic models for all responses
- `src/nhl_api/viewer/services/validation_service.py` - Database queries and business logic
- `src/nhl_api/viewer/routers/validation.py` - API endpoints (replaced stub)
- `tests/unit/viewer/test_validation_router.py` - 18 unit tests

### Database Tables Used

Uses existing tables from migration `009_validation.sql`:
- `validation_rules` - Rule definitions
- `validation_runs` - Run history
- `validation_results` - Check outcomes
- `data_quality_scores` - Quality metrics
- `discrepancies` - Mismatch details

## Test Plan

- [x] All 18 new unit tests pass
- [x] All 108 viewer tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [ ] Manual testing with Swagger UI

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)