### PR TITLE
fix(frontend): Rename duplicate 'Games' heading for accessibility (#185)

### DIFF
--- a/viewer-frontend/src/pages/Games.tsx
+++ b/viewer-frontend/src/pages/Games.tsx
@@ -208,7 +208,7 @@ export function Games() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
-            <CardTitle>Games</CardTitle>
+            <CardTitle>Game Results</CardTitle>
             <CardDescription>
               {pagination
                 ? `Showing ${(pagination.page - 1) * pagination.per_page + 1}-${Math.min(


### PR DESCRIPTION
## Summary

- Renamed CardTitle from "Games" to "Game Results" on the Games page to eliminate duplicate heading text

## Problem

The Games page had two headings with identical text:
- `<h1>Games</h1>` (page title)
- `<CardTitle>Games</CardTitle>` (card title, renders as h3)

This caused:
1. Playwright strict mode violations when testing with `getByRole('heading', { name: 'Games' })`
2. Accessibility concerns for screen reader users

## Solution

Changed the card title to "Game Results" - more descriptive and unique.

## Test plan

- [x] TypeScript compiles without errors
- [x] Pre-commit hooks pass
- [ ] Playwright tests can now use `getByRole('heading', { name: 'Games' })` without strict mode errors

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)