### PR TITLE
fix(viewer): Fix Dashboard health cards showing Offline/Disconnected

### DIFF
--- a/viewer-frontend/package-lock.json
+++ b/viewer-frontend/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.57.0",
         "@types/node": "^24.10.4",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -1105,6 +1106,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -4391,6 +4408,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/viewer-frontend/package.json
+++ b/viewer-frontend/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.57.0",
     "@types/node": "^24.10.4",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",

--- a/viewer-frontend/playwright.config.ts
+++ b/viewer-frontend/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/viewer-frontend/src/hooks/useApi.ts
+++ b/viewer-frontend/src/hooks/useApi.ts
@@ -1,11 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { api, type HealthResponse, type DashboardResponse, type BatchSummary, type SourceListResponse, type FailureListResponse, type RetryResponse } from '@/lib/api'
+import { api, fetchHealth, type DashboardResponse, type BatchSummary, type SourceListResponse, type FailureListResponse, type RetryResponse } from '@/lib/api'
 
-// Health check
+// Health check - uses /health endpoint directly (not under /api/v1)
 export function useHealth() {
   return useQuery({
     queryKey: ['health'],
-    queryFn: () => api.get<HealthResponse>('/health'),
+    queryFn: fetchHealth,
     refetchInterval: 30000, // 30 seconds
   })
 }

--- a/viewer-frontend/src/lib/api.ts
+++ b/viewer-frontend/src/lib/api.ts
@@ -47,10 +47,27 @@ export const api = {
 }
 
 // API response types
+export interface DatabaseHealth {
+  connected: boolean
+  latency_ms: number
+  error: string | null
+}
+
 export interface HealthResponse {
   status: string
-  database: string
+  version: string
+  uptime_seconds: number
   timestamp: string
+  database: DatabaseHealth
+}
+
+// Fetch health from /health endpoint (not under /api/v1)
+export async function fetchHealth(): Promise<HealthResponse> {
+  const response = await fetch('/health')
+  if (!response.ok) {
+    throw new ApiError(response.status, response.statusText)
+  }
+  return response.json()
 }
 
 export interface DashboardStats {

--- a/viewer-frontend/src/pages/Dashboard.tsx
+++ b/viewer-frontend/src/pages/Dashboard.tsx
@@ -51,15 +51,25 @@ export function Dashboard() {
               <Skeleton className="h-8 w-24" />
             ) : (
               <div className="flex items-center space-x-2">
-                {health?.database === 'connected' ? (
+                {health?.database?.connected ? (
                   <>
                     <CheckCircle className="h-5 w-5 text-green-500" />
                     <span className="text-lg font-bold">Connected</span>
+                    {health.database.latency_ms !== undefined && (
+                      <span className="text-xs text-muted-foreground">
+                        ({health.database.latency_ms.toFixed(1)}ms)
+                      </span>
+                    )}
                   </>
                 ) : (
                   <>
                     <XCircle className="h-5 w-5 text-destructive" />
                     <span className="text-lg font-bold text-destructive">Disconnected</span>
+                    {health?.database?.error && (
+                      <span className="text-xs text-destructive">
+                        {health.database.error}
+                      </span>
+                    )}
                   </>
                 )}
               </div>

--- a/viewer-frontend/tests/dashboard.spec.ts
+++ b/viewer-frontend/tests/dashboard.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:5173/');
+  });
+
+  test('should display Dashboard title', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  });
+
+  test('API Status card should show healthy status', async ({ page }) => {
+    // Wait for API data to load
+    await page.waitForSelector('text=API Status');
+
+    // Check the API Status card shows "healthy"
+    const apiStatusCard = page.locator('text=API Status').locator('..').locator('..');
+    await expect(apiStatusCard).toContainText(/healthy/i);
+  });
+
+  test('Database card should show connected status', async ({ page }) => {
+    await page.waitForSelector('text=Database');
+
+    const databaseCard = page.locator('text=Database').locator('..').locator('..');
+    await expect(databaseCard).toContainText(/Connected/i);
+  });
+
+  test('Last Update card should display timestamp', async ({ page }) => {
+    await page.waitForSelector('text=Last Update');
+
+    // Should show a time value (HH:MM:SS format)
+    const lastUpdateCard = page.locator('text=Last Update').locator('..').locator('..');
+    await expect(lastUpdateCard).toBeVisible();
+    // Check for time pattern like "6:01:09 AM" or similar
+    await expect(lastUpdateCard.locator('div.text-lg')).not.toHaveText('-');
+  });
+
+  test('Environment card should show Development badge', async ({ page }) => {
+    await page.waitForSelector('text=Environment');
+
+    const envCard = page.locator('text=Environment').locator('..').locator('..');
+    await expect(envCard).toContainText('Development');
+  });
+
+  test('Active Downloads section should be present', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Active Downloads' })).toBeVisible();
+    await expect(page.getByText('Coming soon (#167)')).toBeVisible();
+  });
+
+  test('Source Health grid should be visible', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Source Health' })).toBeVisible();
+
+    // Wait for source cards to load (should see at least one source)
+    await page.waitForSelector('[class*="grid"] [class*="border"]', { timeout: 10000 });
+  });
+
+  test('Source Health grid should display source cards', async ({ page }) => {
+    // Wait for data to load
+    await page.waitForTimeout(2000);
+
+    // Check for expected source names
+    const sourceNames = [
+      'schedule', 'boxscore', 'roster', 'shift_chart'
+    ];
+
+    // At least one should be visible
+    let foundAny = false;
+    for (const name of sourceNames) {
+      const element = page.getByText(name, { exact: false });
+      if (await element.count() > 0) {
+        foundAny = true;
+        break;
+      }
+    }
+
+    // If no specific sources found, check for "No sources" message or source type badges
+    if (!foundAny) {
+      const noSourcesMsg = page.getByText('No sources configured');
+      const badges = page.locator('[class*="Badge"]').filter({ hasText: /NHL JSON|HTML Report|DailyFaceoff/i });
+      expect(await noSourcesMsg.count() + await badges.count()).toBeGreaterThan(0);
+    }
+  });
+
+  test('Recent Failures section should be present', async ({ page }) => {
+    // Wait for heading to appear
+    await expect(page.getByRole('heading', { name: /Recent Failures/i })).toBeVisible();
+
+    // Should show either "No failures" or a table
+    const noFailures = page.getByText('No failures - all downloads successful!');
+    const failureTable = page.locator('table');
+
+    // One of these should be visible
+    await expect(noFailures.or(failureTable)).toBeVisible();
+  });
+});
+
+test.describe('Navigation', () => {
+  test('should navigate to Downloads page', async ({ page }) => {
+    await page.goto('http://localhost:5173/');
+    await page.click('text=Downloads');
+    await expect(page).toHaveURL(/\/downloads/);
+    await expect(page.getByRole('heading', { name: 'Downloads' })).toBeVisible();
+  });
+
+  test('should navigate to Players page', async ({ page }) => {
+    await page.goto('http://localhost:5173/');
+    await page.click('text=Players');
+    await expect(page).toHaveURL(/\/players/);
+    await expect(page.getByRole('heading', { name: 'Players' })).toBeVisible();
+  });
+
+  test('should navigate to Games page', async ({ page }) => {
+    await page.goto('http://localhost:5173/');
+    await page.click('text=Games');
+    await expect(page).toHaveURL(/\/games/);
+    await expect(page.getByRole('heading', { name: 'Games' })).toBeVisible();
+  });
+
+  test('should navigate to Teams page', async ({ page }) => {
+    await page.goto('http://localhost:5173/');
+    await page.click('text=Teams');
+    await expect(page).toHaveURL(/\/teams/);
+    await expect(page.getByRole('heading', { name: 'Teams' })).toBeVisible();
+  });
+
+  test('should navigate to Validation page', async ({ page }) => {
+    await page.goto('http://localhost:5173/');
+    await page.click('text=Validation');
+    await expect(page).toHaveURL(/\/validation/);
+    await expect(page.getByRole('heading', { name: 'Validation' })).toBeVisible();
+  });
+});

--- a/viewer-frontend/vite.config.ts
+++ b/viewer-frontend/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
         target: 'http://localhost:8000',
         changeOrigin: true,
       },
+      '/health': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary

Fixes the Dashboard page where:
- **API Status** showed "Offline" despite healthy backend
- **Database** showed "Disconnected" despite connected database  
- **Last Update** showed "-" instead of timestamp

## Root Causes Fixed

1. **Vite proxy missing `/health`** - Health endpoint is at root `/health`, but proxy only forwarded `/api/*`
2. **Type mismatch** - `HealthResponse.database` was typed as `string` but API returns an object
3. **Wrong comparison** - Dashboard compared `health?.database === 'connected'` (object vs string)

## Changes

| File | Change |
|------|--------|
| `vite.config.ts` | Added `/health` to proxy config |
| `src/lib/api.ts` | Added `DatabaseHealth` interface, updated `HealthResponse`, added `fetchHealth()` |
| `src/hooks/useApi.ts` | Updated `useHealth()` to use `fetchHealth()` |
| `src/pages/Dashboard.tsx` | Fixed database check, added latency display |

## Enhancements

- Database card now shows latency: "Connected (0.9ms)"
- Shows error message when database disconnected
- Added Playwright tests for Dashboard cards (9 tests)

## Screenshots

**Before:**
- API Status: Offline (red X)
- Database: Disconnected (red X)

**After:**
- API Status: healthy (green check)
- Database: Connected (0.9ms) (green check)

## Test Plan

- [x] All 9 Dashboard Playwright tests pass
- [x] TypeScript compiles without errors
- [x] Visual verification via screenshot

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)