### PR TITLE
fix(viewer): Fix duplicate headings for accessibility/testing

### DIFF
--- a/viewer-frontend/src/pages/Games.tsx
+++ b/viewer-frontend/src/pages/Games.tsx
@@ -208,7 +208,7 @@ export function Games() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
-            <CardTitle>Games</CardTitle>
+            <CardTitle>Game Schedule</CardTitle>
             <CardDescription>
               {pagination
                 ? `Showing ${(pagination.page - 1) * pagination.per_page + 1}-${Math.min(

--- a/viewer-frontend/tests/dashboard.spec.ts
+++ b/viewer-frontend/tests/dashboard.spec.ts
@@ -99,34 +99,36 @@ test.describe('Navigation', () => {
     await page.goto('http://localhost:5173/');
     await page.click('text=Downloads');
     await expect(page).toHaveURL(/\/downloads/);
-    await expect(page.getByRole('heading', { name: 'Downloads' })).toBeVisible();
+    // Use exact: true to match only h1, not "Active Downloads" h3
+    await expect(page.getByRole('heading', { name: 'Downloads', exact: true })).toBeVisible();
   });
 
   test('should navigate to Players page', async ({ page }) => {
     await page.goto('http://localhost:5173/');
     await page.click('text=Players');
     await expect(page).toHaveURL(/\/players/);
-    await expect(page.getByRole('heading', { name: 'Players' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Players', exact: true })).toBeVisible();
   });
 
   test('should navigate to Games page', async ({ page }) => {
     await page.goto('http://localhost:5173/');
     await page.click('text=Games');
     await expect(page).toHaveURL(/\/games/);
-    await expect(page.getByRole('heading', { name: 'Games' })).toBeVisible();
+    // Page title is "Games", card title changed to "Game Schedule"
+    await expect(page.getByRole('heading', { name: 'Games', exact: true })).toBeVisible();
   });
 
   test('should navigate to Teams page', async ({ page }) => {
     await page.goto('http://localhost:5173/');
     await page.click('text=Teams');
     await expect(page).toHaveURL(/\/teams/);
-    await expect(page.getByRole('heading', { name: 'Teams' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Teams', exact: true })).toBeVisible();
   });
 
   test('should navigate to Validation page', async ({ page }) => {
     await page.goto('http://localhost:5173/');
     await page.click('text=Validation');
     await expect(page).toHaveURL(/\/validation/);
-    await expect(page.getByRole('heading', { name: 'Validation' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Data Validation', exact: true })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Fixes duplicate heading text that caused Playwright strict mode violations and accessibility concerns.

## Changes

### Games Page (`src/pages/Games.tsx`)
- Changed card title from "Games" to "Game Schedule"
- This differentiates it from the `<h1>Games</h1>` page title

### Playwright Tests (`tests/dashboard.spec.ts`)
- Added `exact: true` to all navigation heading selectors
- This prevents substring matching (e.g., "Downloads" matching "Active Downloads")
- Fixed Validation test to match actual heading "Data Validation"

## Before/After

| Page | Before | After |
|------|--------|-------|
| Games | Two headings: "Games" (h1) + "Games" (h3) | "Games" (h1) + "Game Schedule" (h3) |
| Downloads | Test matched both "Downloads" and "Active Downloads" | Test uses `exact: true` |

## Test Results

All 14 Playwright tests pass:
- 9 Dashboard Page tests
- 5 Navigation tests

## Impact

- Low severity enhancement
- Improves accessibility (screen readers can distinguish headings)
- Fixes automated testing reliability

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)