### PR TITLE
feat(frontend): Add Coverage Dashboard with gas tank gauges (#178)

### DIFF
--- a/viewer-frontend/src/App.tsx
+++ b/viewer-frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { Layout } from '@/components/Layout'
 import { Dashboard } from '@/pages/Dashboard'
 import { Downloads } from '@/pages/Downloads'
+import { Coverage } from '@/pages/Coverage'
 import { Players } from '@/pages/Players'
 import { PlayerDetail } from '@/pages/PlayerDetail'
 import { Games } from '@/pages/Games'
@@ -18,6 +19,7 @@ function App() {
         <Route path="/" element={<Layout />}>
           <Route index element={<Dashboard />} />
           <Route path="downloads" element={<Downloads />} />
+          <Route path="coverage" element={<Coverage />} />
           <Route path="players" element={<Players />} />
           <Route path="players/:playerId" element={<PlayerDetail />} />
           <Route path="games" element={<Games />} />

--- a/viewer-frontend/src/components/GasTankGauge.tsx
+++ b/viewer-frontend/src/components/GasTankGauge.tsx
@@ -1,0 +1,98 @@
+import { Link } from 'react-router-dom'
+import { cn } from '@/lib/utils'
+
+interface GasTankGaugeProps {
+  label: string
+  actual: number
+  expected: number
+  percentage: number | null
+  linkPath: string
+  compact?: boolean
+}
+
+function getGaugeColor(percentage: number | null): string {
+  if (percentage === null) return 'bg-gray-400'
+  if (percentage >= 95) return 'bg-green-500'
+  if (percentage >= 75) return 'bg-emerald-400'
+  if (percentage >= 50) return 'bg-yellow-400'
+  if (percentage >= 25) return 'bg-orange-400'
+  return 'bg-red-400'
+}
+
+function getGaugeTextColor(percentage: number | null): string {
+  if (percentage === null) return 'text-gray-600'
+  if (percentage >= 95) return 'text-green-700'
+  if (percentage >= 75) return 'text-emerald-700'
+  if (percentage >= 50) return 'text-yellow-700'
+  if (percentage >= 25) return 'text-orange-700'
+  return 'text-red-700'
+}
+
+export function GasTankGauge({
+  label,
+  actual,
+  expected,
+  percentage,
+  linkPath,
+  compact = false,
+}: GasTankGaugeProps) {
+  const displayPercentage = percentage !== null ? percentage : 0
+  const gaugeColor = getGaugeColor(percentage)
+  const textColor = getGaugeTextColor(percentage)
+
+  return (
+    <Link
+      to={linkPath}
+      className={cn(
+        'block rounded-lg border bg-card p-3 transition-all hover:shadow-md hover:border-primary/50',
+        compact ? 'p-2' : 'p-3'
+      )}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <span className={cn('font-medium', compact ? 'text-xs' : 'text-sm')}>
+          {label}
+        </span>
+        <span className={cn('font-bold', textColor, compact ? 'text-xs' : 'text-sm')}>
+          {percentage !== null ? `${percentage.toFixed(1)}%` : 'N/A'}
+        </span>
+      </div>
+
+      {/* Progress bar container */}
+      <div className="relative h-3 w-full rounded-full bg-muted overflow-hidden">
+        {/* Fill */}
+        <div
+          className={cn('h-full rounded-full transition-all duration-500', gaugeColor)}
+          style={{ width: `${Math.min(displayPercentage, 100)}%` }}
+        />
+      </div>
+
+      {/* Count display */}
+      <div className={cn('mt-1 text-muted-foreground', compact ? 'text-xs' : 'text-xs')}>
+        {actual.toLocaleString()} / {expected.toLocaleString()}
+      </div>
+    </Link>
+  )
+}
+
+// Compact version for use in tables or smaller spaces
+export function GasTankGaugeInline({
+  percentage,
+}: Pick<GasTankGaugeProps, 'percentage'>) {
+  const displayPercentage = percentage !== null ? percentage : 0
+  const gaugeColor = getGaugeColor(percentage)
+  const textColor = getGaugeTextColor(percentage)
+
+  return (
+    <div className="flex items-center gap-2 min-w-[120px]">
+      <div className="relative h-2 flex-1 rounded-full bg-muted overflow-hidden">
+        <div
+          className={cn('h-full rounded-full', gaugeColor)}
+          style={{ width: `${Math.min(displayPercentage, 100)}%` }}
+        />
+      </div>
+      <span className={cn('text-xs font-medium tabular-nums', textColor)}>
+        {percentage !== null ? `${percentage.toFixed(0)}%` : '-'}
+      </span>
+    </div>
+  )
+}

--- a/viewer-frontend/src/components/Layout.tsx
+++ b/viewer-frontend/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/utils'
-import { Activity, Download, Users, Calendar, CheckCircle, Shield, Menu } from 'lucide-react'
+import { Activity, Download, Users, Calendar, CheckCircle, Shield, Menu, Fuel } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Sheet,
@@ -14,6 +14,7 @@ import {
 const navigation = [
   { name: 'Dashboard', href: '/', icon: Activity },
   { name: 'Downloads', href: '/downloads', icon: Download },
+  { name: 'Coverage', href: '/coverage', icon: Fuel },
   { name: 'Games', href: '/games', icon: Calendar },
   { name: 'Teams', href: '/teams', icon: Shield },
   { name: 'Players', href: '/players', icon: Users },

--- a/viewer-frontend/src/hooks/useCoverage.ts
+++ b/viewer-frontend/src/hooks/useCoverage.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query'
+import { api, type CoverageResponse } from '@/lib/api'
+
+interface UseCoverageOptions {
+  seasonIds?: number[]
+  includeAll?: boolean
+}
+
+export function useCoverage(options: UseCoverageOptions = {}) {
+  const { seasonIds, includeAll = false } = options
+
+  return useQuery({
+    queryKey: ['coverage', seasonIds, includeAll],
+    queryFn: async () => {
+      const params: Record<string, string> = {}
+
+      if (seasonIds && seasonIds.length > 0) {
+        // Pass season_ids as comma-separated for query string
+        params.season_ids = seasonIds.join(',')
+      }
+
+      if (includeAll) {
+        params.include_all = 'true'
+      }
+
+      return api.get<CoverageResponse>('/coverage/summary', params)
+    },
+    refetchInterval: 60000, // Refresh every 60 seconds
+  })
+}

--- a/viewer-frontend/src/lib/api.ts
+++ b/viewer-frontend/src/lib/api.ts
@@ -181,3 +181,28 @@ export interface RetryResponse {
   status: string
   message: string
 }
+
+// Coverage types
+export interface CategoryCoverage {
+  name: string
+  display_name: string
+  actual: number
+  expected: number
+  percentage: number | null
+  link_path: string
+}
+
+export interface SeasonCoverage {
+  season_id: number
+  season_label: string
+  is_current: boolean
+  categories: CategoryCoverage[]
+  game_logs_total: number
+  players_with_game_logs: number
+  refreshed_at: string | null
+}
+
+export interface CoverageResponse {
+  seasons: SeasonCoverage[]
+  refreshed_at: string | null
+}

--- a/viewer-frontend/src/pages/Coverage.tsx
+++ b/viewer-frontend/src/pages/Coverage.tsx
@@ -1,0 +1,293 @@
+import { useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { GasTankGauge, GasTankGaugeInline } from '@/components/GasTankGauge'
+import { useCoverage } from '@/hooks/useCoverage'
+import { Fuel, RefreshCw, AlertCircle } from 'lucide-react'
+import type { SeasonCoverage } from '@/lib/api'
+
+export function Coverage() {
+  const [includeAll, setIncludeAll] = useState(false)
+  const { data, isLoading, error, refetch, isFetching } = useCoverage({ includeAll })
+
+  // Calculate totals across all seasons for the table view
+  const calculateTotals = (seasons: SeasonCoverage[]): Record<string, { actual: number; expected: number }> => {
+    const totals: Record<string, { actual: number; expected: number }> = {}
+
+    for (const season of seasons) {
+      for (const cat of season.categories) {
+        if (!totals[cat.name]) {
+          totals[cat.name] = { actual: 0, expected: 0 }
+        }
+        totals[cat.name].actual += cat.actual
+        totals[cat.name].expected += cat.expected
+      }
+    }
+
+    return totals
+  }
+
+  const formatRefreshTime = (timestamp: string | null) => {
+    if (!timestamp) return 'Never'
+    const date = new Date(timestamp)
+    return date.toLocaleString()
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+            <Fuel className="h-8 w-8" />
+            Data Coverage
+          </h1>
+          <p className="text-muted-foreground">
+            Visual overview of data completeness per season
+          </p>
+        </div>
+
+        <Card className="border-destructive">
+          <CardContent className="flex items-center gap-4 py-6">
+            <AlertCircle className="h-8 w-8 text-destructive" />
+            <div>
+              <p className="font-medium text-destructive">Failed to load coverage data</p>
+              <p className="text-sm text-muted-foreground">{String(error)}</p>
+            </div>
+            <Button variant="outline" onClick={() => refetch()} className="ml-auto">
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+            <Fuel className="h-8 w-8" />
+            Data Coverage
+          </h1>
+          <p className="text-muted-foreground">
+            Visual overview of data completeness per season
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant={includeAll ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setIncludeAll(!includeAll)}
+          >
+            {includeAll ? 'Show Recent' : 'Show All Seasons'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+      </div>
+
+      {/* Tabs for Gauges / Raw Counts */}
+      <Tabs defaultValue="gauges" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="gauges">Gauges</TabsTrigger>
+          <TabsTrigger value="table">Raw Counts</TabsTrigger>
+        </TabsList>
+
+        {/* Gauges View */}
+        <TabsContent value="gauges" className="space-y-4">
+          {isLoading ? (
+            <div className="space-y-4">
+              {[1, 2, 3].map((i) => (
+                <Card key={i}>
+                  <CardHeader>
+                    <Skeleton className="h-6 w-32" />
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+                      {[1, 2, 3, 4, 5, 6].map((j) => (
+                        <Skeleton key={j} className="h-20" />
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : data?.seasons.length === 0 ? (
+            <Card>
+              <CardContent className="py-12 text-center text-muted-foreground">
+                No coverage data available. Run some downloads first.
+              </CardContent>
+            </Card>
+          ) : (
+            data?.seasons.map((season) => (
+              <SeasonCard key={season.season_id} season={season} />
+            ))
+          )}
+        </TabsContent>
+
+        {/* Table View */}
+        <TabsContent value="table">
+          <Card>
+            <CardHeader>
+              <CardTitle>Raw Coverage Counts</CardTitle>
+              <CardDescription>
+                Detailed breakdown of downloaded vs expected items
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {isLoading ? (
+                <div className="space-y-2">
+                  {[1, 2, 3, 4].map((i) => (
+                    <Skeleton key={i} className="h-12 w-full" />
+                  ))}
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Season</TableHead>
+                      <TableHead>Games</TableHead>
+                      <TableHead>Boxscore</TableHead>
+                      <TableHead>Play-by-Play</TableHead>
+                      <TableHead>Shifts</TableHead>
+                      <TableHead>Players</TableHead>
+                      <TableHead>HTML</TableHead>
+                      <TableHead>Game Logs</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {data?.seasons.map((season) => (
+                      <TableRow key={season.season_id}>
+                        <TableCell className="font-medium">
+                          <div className="flex items-center gap-2">
+                            {season.season_label}
+                            {season.is_current && (
+                              <Badge variant="secondary" className="text-xs">
+                                Current
+                              </Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        {season.categories.map((cat) => (
+                          <TableCell key={cat.name}>
+                            <div className="space-y-1">
+                              <GasTankGaugeInline percentage={cat.percentage} />
+                              <div className="text-xs text-muted-foreground">
+                                {cat.actual.toLocaleString()} / {cat.expected.toLocaleString()}
+                              </div>
+                            </div>
+                          </TableCell>
+                        ))}
+                        <TableCell>
+                          <div className="text-sm">
+                            {season.game_logs_total.toLocaleString()}
+                            <div className="text-xs text-muted-foreground">
+                              {season.players_with_game_logs.toLocaleString()} players
+                            </div>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+
+                    {/* Totals row */}
+                    {data && data.seasons.length > 1 && (
+                      <TableRow className="bg-muted/50 font-medium">
+                        <TableCell>Total</TableCell>
+                        {(() => {
+                          const totals = calculateTotals(data.seasons)
+                          const categoryOrder = ['games', 'boxscore', 'pbp', 'shifts', 'players', 'html']
+                          return categoryOrder.map((name) => {
+                            const t = totals[name] || { actual: 0, expected: 0 }
+                            const pct = t.expected > 0 ? (t.actual / t.expected) * 100 : null
+                            return (
+                              <TableCell key={name}>
+                                <div className="space-y-1">
+                                  <GasTankGaugeInline percentage={pct} />
+                                  <div className="text-xs text-muted-foreground">
+                                    {t.actual.toLocaleString()} / {t.expected.toLocaleString()}
+                                  </div>
+                                </div>
+                              </TableCell>
+                            )
+                          })
+                        })()}
+                        <TableCell>
+                          {data.seasons.reduce((sum, s) => sum + s.game_logs_total, 0).toLocaleString()}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Last refreshed footer */}
+      {data && (
+        <div className="text-center text-sm text-muted-foreground">
+          Last refreshed: {formatRefreshTime(data.refreshed_at)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Season card component with gauges
+function SeasonCard({ season }: { season: SeasonCoverage }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg flex items-center gap-2">
+            {season.season_label}
+            {season.is_current && (
+              <Badge variant="default" className="text-xs">
+                Current
+              </Badge>
+            )}
+          </CardTitle>
+          <div className="text-sm text-muted-foreground">
+            {season.game_logs_total.toLocaleString()} game logs &bull;{' '}
+            {season.players_with_game_logs.toLocaleString()} players
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+          {season.categories.map((cat) => (
+            <GasTankGauge
+              key={cat.name}
+              label={cat.display_name}
+              actual={cat.actual}
+              expected={cat.expected}
+              percentage={cat.percentage}
+              linkPath={cat.link_path}
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary

Implements the Coverage Dashboard frontend for visualizing data completeness per season with "gas tank" style gauges.

- **GasTankGauge component**: Color-coded progress bars (green ≥95%, yellow 50-75%, red <25%)
- **Coverage page**: Tabbed view with Gauges and Raw Counts table
- **useCoverage hook**: React Query hook with 60-second auto-refresh
- **Navigation**: Added Coverage link with Fuel icon

## Parent Issue
Part of #174 (Data Coverage Dashboard)

## Dependencies
- ✅ #176 (Database Migration) - Merged
- ✅ #177 (Backend API) - Merged

## Screenshots

The UI follows the spec from #178:
- Season cards with 6 category gauges
- Clickable gauges link to filtered explorer views
- "Show All Seasons" toggle
- Raw counts table with totals row

## Test plan
- [ ] Coverage page loads without errors
- [ ] Gauges display correct percentages and colors
- [ ] Clicking gauge navigates to filtered view
- [ ] "Show All Seasons" toggle fetches additional data
- [ ] Table view shows all seasons with totals
- [ ] Auto-refresh works (check network tab)
- [ ] Error state displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)