### PR TITLE
feat(testing): Add comprehensive data flow test infrastructure (#200)

### DIFF
--- a/tests/integration/data_flow/__init__.py
+++ b/tests/integration/data_flow/__init__.py
@@ -1,0 +1,5 @@
+"""Data flow integration tests.
+
+This module provides end-to-end testing of the NHL API data pipeline,
+from download through storage and validation.
+"""

--- a/tests/integration/data_flow/conftest.py
+++ b/tests/integration/data_flow/conftest.py
@@ -1,0 +1,202 @@
+"""Pytest fixtures for data flow integration tests.
+
+This module provides fixtures for testing the complete data pipeline
+from download through storage and validation.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.integration.data_flow.reports.generator import ReportGenerator
+from tests.integration.data_flow.reports.models import DataFlowReport
+from tests.integration.data_flow.sources.registry import (
+    SourceDefinition,
+    SourceRegistry,
+)
+from tests.integration.data_flow.stages.download import DownloadStage
+from tests.integration.data_flow.stages.storage import MockDatabaseService, StorageStage
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from nhl_api.services.db import DatabaseService
+
+# =============================================================================
+# Fixture Game Constants
+# =============================================================================
+
+# Primary fixture game: Season opener BUF @ NJ, Oct 4, 2024
+FIXTURE_GAME_ID = 2024020001
+FIXTURE_SEASON_ID = 20242025
+
+# Alternative fixture for testing (already used in HTML tests)
+ALT_FIXTURE_GAME_ID = 2024020500
+ALT_FIXTURE_SEASON_ID = 20242025
+
+
+# =============================================================================
+# Game Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def fixture_game_id() -> int:
+    """Primary game ID for data flow testing.
+
+    Returns game 2024020001 (BUF @ NJ, Oct 4, 2024 - season opener).
+    """
+    return FIXTURE_GAME_ID
+
+
+@pytest.fixture
+def fixture_season_id() -> int:
+    """Season ID for the fixture game."""
+    return FIXTURE_SEASON_ID
+
+
+@pytest.fixture
+def alt_fixture_game_id() -> int:
+    """Alternative game ID for additional testing."""
+    return ALT_FIXTURE_GAME_ID
+
+
+# =============================================================================
+# Registry Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def source_registry() -> type[SourceRegistry]:
+    """Get the source registry class."""
+    return SourceRegistry
+
+
+@pytest.fixture
+def persist_sources() -> list[SourceDefinition]:
+    """Get all sources with persist methods."""
+    return SourceRegistry.get_persist_sources()
+
+
+@pytest.fixture
+def game_level_sources() -> list[SourceDefinition]:
+    """Get all game-level sources."""
+    return SourceRegistry.get_game_level_sources()
+
+
+# =============================================================================
+# Database Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_db() -> MockDatabaseService:
+    """Create a mock database service for testing.
+
+    Returns a MockDatabaseService that tracks persist calls
+    without requiring a real database.
+    """
+    return MockDatabaseService()
+
+
+@pytest.fixture
+async def test_db() -> AsyncGenerator[DatabaseService | MockDatabaseService, None]:
+    """Get test database service.
+
+    If USE_REAL_DB=true, returns a real DatabaseService.
+    Otherwise, returns a MockDatabaseService.
+    """
+    use_real_db = os.getenv("USE_REAL_DB", "false").lower() == "true"
+
+    if use_real_db:
+        from nhl_api.services.db import DatabaseService
+
+        db = DatabaseService()
+        await db.connect()
+        try:
+            yield db
+        finally:
+            await db.disconnect()
+    else:
+        yield MockDatabaseService()
+
+
+# =============================================================================
+# Stage Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def download_stage() -> DownloadStage:
+    """Create download stage for testing.
+
+    Uses a high rate limit for faster testing.
+    """
+    return DownloadStage(rate_limit_override=100.0)
+
+
+@pytest.fixture
+def storage_stage(mock_db: MockDatabaseService) -> StorageStage:
+    """Create storage stage with mock database."""
+    return StorageStage(mock_db)
+
+
+@pytest.fixture
+async def storage_stage_real(
+    test_db: DatabaseService | MockDatabaseService,
+) -> StorageStage:
+    """Create storage stage with test database (real or mock)."""
+    return StorageStage(test_db)
+
+
+# =============================================================================
+# Report Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def report_generator() -> ReportGenerator:
+    """Create report generator."""
+    return ReportGenerator()
+
+
+@pytest.fixture
+def empty_report() -> DataFlowReport:
+    """Create an empty report for testing."""
+    return DataFlowReport()
+
+
+@pytest.fixture
+def report_with_game(fixture_game_id: int, fixture_season_id: int) -> DataFlowReport:
+    """Create a report initialized with fixture game."""
+    return DataFlowReport(game_id=fixture_game_id, season_id=fixture_season_id)
+
+
+# =============================================================================
+# Source Name Fixtures (for parametrization)
+# =============================================================================
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Generate parameterized tests for source names.
+
+    This hook enables @pytest.mark.parametrize("source_name", ...)
+    to use all registered source names.
+    """
+    if "source_name" in metafunc.fixturenames:
+        # Check if test has a specific marker for source selection
+        markers = list(metafunc.definition.iter_markers("source_type"))
+        if markers:
+            source_type = markers[0].args[0]
+            if source_type == "persist":
+                names = SourceRegistry.PERSIST_SOURCE_NAMES
+            elif source_type == "game_level":
+                names = SourceRegistry.GAME_LEVEL_SOURCE_NAMES
+            else:
+                names = tuple(SourceRegistry.get_source_names())
+        else:
+            names = tuple(SourceRegistry.get_source_names())
+        metafunc.parametrize("source_name", names)

--- a/tests/integration/data_flow/reports/__init__.py
+++ b/tests/integration/data_flow/reports/__init__.py
@@ -1,0 +1,12 @@
+"""Data flow test reporting.
+
+Provides report generation for data flow test results.
+"""
+
+from .generator import ReportGenerator
+from .models import DataFlowReport
+
+__all__ = [
+    "DataFlowReport",
+    "ReportGenerator",
+]

--- a/tests/integration/data_flow/reports/generator.py
+++ b/tests/integration/data_flow/reports/generator.py
@@ -1,0 +1,201 @@
+"""Report generator for data flow tests.
+
+This module generates human-readable reports from data flow test results.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tests.integration.data_flow.reports.models import DataFlowReport
+
+
+class ReportGenerator:
+    """Generator for data flow test reports.
+
+    Produces markdown-formatted reports from test results.
+    """
+
+    def generate(self, report: DataFlowReport) -> str:
+        """Generate a complete markdown report.
+
+        Args:
+            report: DataFlowReport with test results
+
+        Returns:
+            Markdown-formatted report string
+        """
+        lines = [
+            self._header(report),
+            self._summary(report),
+            self._download_section(report),
+            self._storage_section(report),
+            self._source_details(report),
+        ]
+        return "\n".join(lines)
+
+    def _header(self, report: DataFlowReport) -> str:
+        """Generate report header."""
+        lines = [
+            "# Data Flow Test Report",
+            "",
+            f"**Test ID:** {report.test_id}",
+        ]
+        if report.game_id:
+            lines.append(f"**Game ID:** {report.game_id}")
+        if report.season_id:
+            lines.append(f"**Season ID:** {report.season_id}")
+        lines.append(f"**Duration:** {report.duration_seconds:.2f}s")
+        lines.append("")
+        return "\n".join(lines)
+
+    def _summary(self, report: DataFlowReport) -> str:
+        """Generate summary section."""
+        lines = [
+            "## Summary",
+            "",
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Total Sources | {report.total_sources} |",
+            f"| Passed | {report.passed_sources} |",
+            f"| Failed | {report.failed_sources} |",
+            f"| Success Rate | {report.success_rate:.1f}% |",
+            "",
+        ]
+        return "\n".join(lines)
+
+    def _download_section(self, report: DataFlowReport) -> str:
+        """Generate download stage section."""
+        stats = report.download_stats
+        lines = [
+            "## Download Stage",
+            "",
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Total | {stats.total} |",
+            f"| Passed | {stats.passed} |",
+            f"| Failed | {stats.failed} |",
+            f"| Success Rate | {stats.success_rate:.1f}% |",
+            f"| Total Time | {stats.total_time_ms:.1f}ms |",
+            "",
+        ]
+
+        # Add failed sources if any
+        failed = [r for r in report.download_results.values() if not r.success]
+        if failed:
+            lines.append("### Failed Downloads")
+            lines.append("")
+            lines.append("| Source | Error |")
+            lines.append("|--------|-------|")
+            for r in failed:
+                error = r.error or "Unknown error"
+                # Truncate long errors
+                if len(error) > 50:
+                    error = error[:47] + "..."
+                lines.append(f"| {r.source_name} | {error} |")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _storage_section(self, report: DataFlowReport) -> str:
+        """Generate storage stage section."""
+        stats = report.storage_stats
+        lines = [
+            "## Storage Stage",
+            "",
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Total | {stats.total} |",
+            f"| Passed | {stats.passed} |",
+            f"| Failed | {stats.failed} |",
+            f"| Skipped | {stats.skipped} |",
+            f"| Success Rate | {stats.success_rate:.1f}% |",
+            f"| Total Time | {stats.total_time_ms:.1f}ms |",
+            "",
+        ]
+
+        # Add table population summary
+        all_tables: dict[str, int] = {}
+        for r in report.storage_results.values():
+            for table, count in r.tables_populated.items():
+                all_tables[table] = all_tables.get(table, 0) + count
+
+        if all_tables:
+            lines.append("### Tables Populated")
+            lines.append("")
+            lines.append("| Table | Rows Added |")
+            lines.append("|-------|------------|")
+            for table, count in sorted(all_tables.items()):
+                lines.append(f"| {table} | {count} |")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _source_details(self, report: DataFlowReport) -> str:
+        """Generate detailed source results section."""
+        lines = [
+            "## Source Details",
+            "",
+            "| Source | Download | Storage | Rows | Time (ms) |",
+            "|--------|----------|---------|------|-----------|",
+        ]
+
+        for source in sorted(
+            report.source_results.values(), key=lambda x: x.source_name
+        ):
+            dl_status = "✅" if source.download_success else "❌"
+            if source.storage_success is None:
+                st_status = "N/A"
+            elif source.storage_success:
+                st_status = "✅"
+            else:
+                st_status = "❌"
+
+            lines.append(
+                f"| {source.display_name} | {dl_status} | {st_status} | "
+                f"{source.rows_affected} | {source.total_time_ms:.1f} |"
+            )
+
+        lines.append("")
+
+        # Add error details for failed sources
+        failed = report.get_failed_sources()
+        if failed:
+            lines.append("### Errors")
+            lines.append("")
+            for source in failed:
+                lines.append(f"**{source.display_name}:** {source.error}")
+                lines.append("")
+
+        return "\n".join(lines)
+
+    def generate_console_summary(self, report: DataFlowReport) -> str:
+        """Generate a concise console-friendly summary.
+
+        Args:
+            report: DataFlowReport with test results
+
+        Returns:
+            Concise summary string for console output
+        """
+        status = "PASSED" if report.success_rate >= 80 else "FAILED"
+        lines = [
+            f"Data Flow Test {status}",
+            f"  Sources: {report.passed_sources}/{report.total_sources} passed "
+            f"({report.success_rate:.1f}%)",
+            f"  Duration: {report.duration_seconds:.2f}s",
+        ]
+
+        failed = report.get_failed_sources()
+        if failed:
+            lines.append("  Failed:")
+            for source in failed[:5]:  # Limit to first 5
+                error = source.error or "Unknown"
+                if len(error) > 40:
+                    error = error[:37] + "..."
+                lines.append(f"    - {source.display_name}: {error}")
+            if len(failed) > 5:
+                lines.append(f"    ... and {len(failed) - 5} more")
+
+        return "\n".join(lines)

--- a/tests/integration/data_flow/reports/models.py
+++ b/tests/integration/data_flow/reports/models.py
@@ -1,0 +1,233 @@
+"""Data models for data flow test reports.
+
+This module defines the data structures used to capture and
+represent test results across all stages of data flow testing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from tests.integration.data_flow.stages.download import DownloadStageResult
+    from tests.integration.data_flow.stages.storage import StorageStageResult
+
+
+@dataclass
+class StageStats:
+    """Statistics for a single test stage.
+
+    Attributes:
+        total: Total number of sources tested
+        passed: Number of successful tests
+        failed: Number of failed tests
+        skipped: Number of skipped tests
+        total_time_ms: Total time for stage in milliseconds
+    """
+
+    total: int
+    passed: int
+    failed: int
+    skipped: int = 0
+    total_time_ms: float = 0
+
+    @property
+    def success_rate(self) -> float:
+        """Calculate success rate as percentage."""
+        if self.total == 0:
+            return 0.0
+        return (self.passed / self.total) * 100
+
+
+@dataclass
+class SourceResult:
+    """Combined result for a single source across all stages.
+
+    Attributes:
+        source_name: Identifier of the data source
+        display_name: Human-readable name
+        download_success: Whether download succeeded
+        download_time_ms: Download duration
+        storage_success: Whether storage succeeded (None if N/A)
+        storage_time_ms: Storage duration
+        rows_affected: Number of rows persisted
+        tables_populated: Mapping of tables to row counts
+        error: Combined error message if any stage failed
+    """
+
+    source_name: str
+    display_name: str
+    download_success: bool
+    download_time_ms: float
+    storage_success: bool | None = None
+    storage_time_ms: float = 0
+    rows_affected: int = 0
+    tables_populated: dict[str, int] = field(default_factory=dict)
+    error: str | None = None
+
+    @property
+    def overall_success(self) -> bool:
+        """Check if all stages succeeded."""
+        if not self.download_success:
+            return False
+        if self.storage_success is not None and not self.storage_success:
+            return False
+        return True
+
+    @property
+    def total_time_ms(self) -> float:
+        """Total time across all stages."""
+        return self.download_time_ms + self.storage_time_ms
+
+
+@dataclass
+class DataFlowReport:
+    """Complete data flow test report.
+
+    This is the main report object that aggregates all test results
+    and provides summary statistics and report generation.
+
+    Attributes:
+        test_id: Unique identifier for this test run
+        game_id: Game ID tested (if applicable)
+        season_id: Season ID tested
+        started_at: Timestamp when test started
+        completed_at: Timestamp when test completed (None if in progress)
+        source_results: Individual results per source
+        download_results: Raw download stage results
+        storage_results: Raw storage stage results
+    """
+
+    test_id: str = field(default_factory=lambda: str(uuid4())[:8])
+    game_id: int | None = None
+    season_id: int | None = None
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    completed_at: datetime | None = None
+    source_results: dict[str, SourceResult] = field(default_factory=dict)
+    download_results: dict[str, DownloadStageResult] = field(default_factory=dict)
+    storage_results: dict[str, StorageStageResult] = field(default_factory=dict)
+
+    @property
+    def total_sources(self) -> int:
+        """Total number of sources tested."""
+        return len(self.source_results)
+
+    @property
+    def passed_sources(self) -> int:
+        """Number of sources that passed all stages."""
+        return sum(1 for r in self.source_results.values() if r.overall_success)
+
+    @property
+    def failed_sources(self) -> int:
+        """Number of sources that failed any stage."""
+        return self.total_sources - self.passed_sources
+
+    @property
+    def success_rate(self) -> float:
+        """Overall success rate as percentage."""
+        if self.total_sources == 0:
+            return 0.0
+        return (self.passed_sources / self.total_sources) * 100
+
+    @property
+    def duration_seconds(self) -> float:
+        """Test duration in seconds."""
+        if self.completed_at is None:
+            end = datetime.now(UTC)
+        else:
+            end = self.completed_at
+        return (end - self.started_at).total_seconds()
+
+    @property
+    def download_stats(self) -> StageStats:
+        """Get statistics for download stage."""
+        results = self.download_results.values()
+        passed = sum(1 for r in results if r.success)
+        failed = len(results) - passed
+        total_time = sum(r.download_time_ms for r in results)
+        return StageStats(
+            total=len(results),
+            passed=passed,
+            failed=failed,
+            total_time_ms=total_time,
+        )
+
+    @property
+    def storage_stats(self) -> StageStats:
+        """Get statistics for storage stage."""
+        results = self.storage_results.values()
+        passed = sum(1 for r in results if r.success)
+        failed = sum(
+            1 for r in results if not r.success and r.error != "No persist method"
+        )
+        skipped = sum(1 for r in results if r.error == "No persist method")
+        total_time = sum(r.persist_time_ms for r in results)
+        return StageStats(
+            total=len(results),
+            passed=passed,
+            failed=failed,
+            skipped=skipped,
+            total_time_ms=total_time,
+        )
+
+    def get_failed_sources(self) -> list[SourceResult]:
+        """Get list of sources that failed any stage."""
+        return [r for r in self.source_results.values() if not r.overall_success]
+
+    def get_passed_sources(self) -> list[SourceResult]:
+        """Get list of sources that passed all stages."""
+        return [r for r in self.source_results.values() if r.overall_success]
+
+    def mark_completed(self) -> None:
+        """Mark the test as completed with current timestamp."""
+        self.completed_at = datetime.now(UTC)
+
+    def add_source_result(
+        self,
+        source_name: str,
+        display_name: str,
+        download_result: DownloadStageResult,
+        storage_result: StorageStageResult | None = None,
+    ) -> None:
+        """Add a combined result for a source.
+
+        Args:
+            source_name: Source identifier
+            display_name: Human-readable name
+            download_result: Result from download stage
+            storage_result: Result from storage stage (optional)
+        """
+        self.download_results[source_name] = download_result
+
+        storage_success = None
+        storage_time = 0.0
+        rows_affected = 0
+        tables_populated: dict[str, int] = {}
+        error = download_result.error
+
+        if storage_result is not None:
+            self.storage_results[source_name] = storage_result
+            storage_success = storage_result.success
+            storage_time = storage_result.persist_time_ms
+            rows_affected = storage_result.rows_affected
+            tables_populated = storage_result.tables_populated
+            if not storage_result.success and storage_result.error:
+                if error:
+                    error = f"{error}; {storage_result.error}"
+                else:
+                    error = storage_result.error
+
+        self.source_results[source_name] = SourceResult(
+            source_name=source_name,
+            display_name=display_name,
+            download_success=download_result.success,
+            download_time_ms=download_result.download_time_ms,
+            storage_success=storage_success,
+            storage_time_ms=storage_time,
+            rows_affected=rows_affected,
+            tables_populated=tables_populated,
+            error=error,
+        )

--- a/tests/integration/data_flow/sources/__init__.py
+++ b/tests/integration/data_flow/sources/__init__.py
@@ -1,0 +1,11 @@
+"""Data source definitions for testing.
+
+Provides registry of all testable data sources with metadata.
+"""
+
+from .registry import SourceDefinition, SourceRegistry
+
+__all__ = [
+    "SourceDefinition",
+    "SourceRegistry",
+]

--- a/tests/integration/data_flow/sources/registry.py
+++ b/tests/integration/data_flow/sources/registry.py
@@ -1,0 +1,263 @@
+"""Source registry for data flow testing.
+
+Provides centralized definitions of all testable data sources
+with their metadata, downloader classes, and target tables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+# Base URLs for different API sources
+NHL_API_BASE_URL = "https://api-web.nhle.com"
+NHL_API_BASE_URL_V1 = "https://api-web.nhle.com/v1"
+NHL_STATS_API_BASE_URL = "https://api.nhle.com/stats/rest/en"
+
+
+class SourceType(Enum):
+    """Type of data source based on how it's accessed."""
+
+    GAME = "game"  # Requires game_id
+    SEASON = "season"  # Season-level data
+    TEAM = "team"  # Team-based data
+    PLAYER = "player"  # Player-based data
+    DATE = "date"  # Date-based data
+
+
+@dataclass(frozen=True, slots=True)
+class SourceDefinition:
+    """Definition of a testable data source.
+
+    Attributes:
+        name: Unique identifier for the source (e.g., "nhl_json_boxscore")
+        display_name: Human-readable name for reports
+        downloader_class: Fully qualified class name for lazy loading
+        config_class: Fully qualified config class name
+        source_type: Type of source (game, season, team, etc.)
+        has_persist: Whether the downloader has a persist() method
+        target_tables: Database tables populated by this source
+        requires_game_id: Whether download_game() requires a game ID
+        default_base_url: Default base URL for this source
+    """
+
+    name: str
+    display_name: str
+    downloader_class: str
+    config_class: str
+    source_type: SourceType
+    has_persist: bool
+    target_tables: tuple[str, ...] = field(default_factory=tuple)
+    requires_game_id: bool = True
+    default_base_url: str | None = None
+
+    def get_downloader_class(self) -> type[Any]:
+        """Lazily load and return the downloader class."""
+        module_path, class_name = self.downloader_class.rsplit(".", 1)
+        import importlib
+
+        module = importlib.import_module(module_path)
+        return getattr(module, class_name)  # type: ignore[no-any-return]
+
+    def get_config_class(self) -> type[Any]:
+        """Lazily load and return the config class."""
+        module_path, class_name = self.config_class.rsplit(".", 1)
+        import importlib
+
+        module = importlib.import_module(module_path)
+        return getattr(module, class_name)  # type: ignore[no-any-return]
+
+    def create_downloader(self, **config_overrides: Any) -> Any:
+        """Create a downloader instance with optional config overrides.
+
+        Args:
+            **config_overrides: Override default config values
+
+        Returns:
+            Configured downloader instance
+        """
+        config_cls = self.get_config_class()
+        downloader_cls = self.get_downloader_class()
+
+        # For base DownloaderConfig, we need to provide base_url
+        # Config classes that inherit with defaults don't need this
+        if self.default_base_url and "base_url" not in config_overrides:
+            # Check if config class requires base_url (base class does)
+            import inspect
+
+            sig = inspect.signature(config_cls)
+            if "base_url" in sig.parameters:
+                param = sig.parameters["base_url"]
+                if param.default is inspect.Parameter.empty:
+                    config_overrides["base_url"] = self.default_base_url
+
+        # Create config with any overrides
+        config = config_cls(**config_overrides) if config_overrides else config_cls()
+
+        return downloader_cls(config)
+
+
+class SourceRegistry:
+    """Registry of all data sources available for testing.
+
+    Sources are organized by category:
+    - GAME_SOURCES: Sources that download per-game data (with persist)
+    - SEASON_SOURCES: Sources that download season-level data (with persist)
+    - HTML_SOURCES: HTML report sources (parse-only, no persist)
+    - EXTERNAL_SOURCES: Third-party sources (DailyFaceoff, QuantHockey)
+    """
+
+    # NHL JSON API sources with persist methods
+    GAME_SOURCES: dict[str, SourceDefinition] = {
+        "nhl_json_schedule": SourceDefinition(
+            name="nhl_json_schedule",
+            display_name="Schedule",
+            downloader_class="nhl_api.downloaders.sources.nhl_json.schedule.ScheduleDownloader",
+            config_class="nhl_api.downloaders.base.base_downloader.DownloaderConfig",
+            source_type=SourceType.SEASON,
+            has_persist=True,
+            target_tables=("games",),
+            requires_game_id=False,
+            default_base_url=NHL_API_BASE_URL_V1,
+        ),
+        "nhl_json_boxscore": SourceDefinition(
+            name="nhl_json_boxscore",
+            display_name="Boxscore",
+            downloader_class="nhl_api.downloaders.sources.nhl_json.boxscore.BoxscoreDownloader",
+            # BoxscoreDownloaderConfig has default base_url
+            config_class="nhl_api.downloaders.sources.nhl_json.boxscore.BoxscoreDownloaderConfig",
+            source_type=SourceType.GAME,
+            has_persist=True,
+            target_tables=("game_skater_stats", "game_goalie_stats"),
+            requires_game_id=True,
+        ),
+        "nhl_json_play_by_play": SourceDefinition(
+            name="nhl_json_play_by_play",
+            display_name="Play-by-Play",
+            downloader_class="nhl_api.downloaders.sources.nhl_json.play_by_play.PlayByPlayDownloader",
+            config_class="nhl_api.downloaders.sources.nhl_json.play_by_play.PlayByPlayDownloaderConfig",
+            source_type=SourceType.GAME,
+            has_persist=True,
+            target_tables=("game_events",),
+            requires_game_id=True,
+        ),
+        "nhl_json_player_landing": SourceDefinition(
+            name="nhl_json_player_landing",
+            display_name="Player Landing",
+            downloader_class="nhl_api.downloaders.sources.nhl_json.player_landing.PlayerLandingDownloader",
+            config_class="nhl_api.downloaders.sources.nhl_json.player_landing.PlayerLandingDownloaderConfig",
+            source_type=SourceType.PLAYER,
+            has_persist=True,
+            target_tables=("players",),
+            requires_game_id=False,
+        ),
+        "nhl_json_player_game_log": SourceDefinition(
+            name="nhl_json_player_game_log",
+            display_name="Player Game Log",
+            downloader_class="nhl_api.downloaders.sources.nhl_json.player_game_log.PlayerGameLogDownloader",
+            config_class="nhl_api.downloaders.sources.nhl_json.player_game_log.PlayerGameLogDownloaderConfig",
+            source_type=SourceType.PLAYER,
+            has_persist=True,
+            target_tables=("player_game_logs",),
+            requires_game_id=False,
+        ),
+        "nhl_json_roster": SourceDefinition(
+            name="nhl_json_roster",
+            display_name="Roster",
+            downloader_class="nhl_api.downloaders.sources.nhl_json.roster.RosterDownloader",
+            config_class="nhl_api.downloaders.base.base_downloader.DownloaderConfig",
+            source_type=SourceType.TEAM,
+            has_persist=True,
+            target_tables=("team_rosters",),
+            requires_game_id=False,
+            default_base_url=NHL_API_BASE_URL,
+        ),
+        "nhl_json_standings": SourceDefinition(
+            name="nhl_json_standings",
+            display_name="Standings",
+            downloader_class="nhl_api.downloaders.sources.nhl_json.standings.StandingsDownloader",
+            config_class="nhl_api.downloaders.base.base_downloader.DownloaderConfig",
+            source_type=SourceType.DATE,
+            has_persist=True,
+            target_tables=("standings_snapshots",),
+            requires_game_id=False,
+            default_base_url=NHL_API_BASE_URL,
+        ),
+        "nhl_stats_shift_charts": SourceDefinition(
+            name="nhl_stats_shift_charts",
+            display_name="Shift Charts",
+            downloader_class="nhl_api.downloaders.sources.nhl_stats.shift_charts.ShiftChartsDownloader",
+            config_class="nhl_api.downloaders.sources.nhl_stats.shift_charts.ShiftChartsDownloaderConfig",
+            source_type=SourceType.GAME,
+            has_persist=True,
+            target_tables=("game_shifts",),
+            requires_game_id=True,
+        ),
+    }
+
+    # All source names that have persist methods
+    PERSIST_SOURCE_NAMES: tuple[str, ...] = tuple(GAME_SOURCES.keys())
+
+    # Game-level sources (require game_id for download_game)
+    GAME_LEVEL_SOURCE_NAMES: tuple[str, ...] = (
+        "nhl_json_boxscore",
+        "nhl_json_play_by_play",
+        "nhl_stats_shift_charts",
+    )
+
+    @classmethod
+    def get_source(cls, name: str) -> SourceDefinition:
+        """Get a source definition by name.
+
+        Args:
+            name: Source name (e.g., "nhl_json_boxscore")
+
+        Returns:
+            SourceDefinition for the source
+
+        Raises:
+            KeyError: If source not found
+        """
+        if name in cls.GAME_SOURCES:
+            return cls.GAME_SOURCES[name]
+        raise KeyError(f"Unknown source: {name}")
+
+    @classmethod
+    def get_all_sources(cls) -> list[SourceDefinition]:
+        """Get all registered source definitions.
+
+        Returns:
+            List of all SourceDefinition objects
+        """
+        return list(cls.GAME_SOURCES.values())
+
+    @classmethod
+    def get_persist_sources(cls) -> list[SourceDefinition]:
+        """Get sources that have persist methods.
+
+        Returns:
+            List of SourceDefinition objects with has_persist=True
+        """
+        return [s for s in cls.GAME_SOURCES.values() if s.has_persist]
+
+    @classmethod
+    def get_game_level_sources(cls) -> list[SourceDefinition]:
+        """Get sources that download per-game data.
+
+        Returns:
+            List of SourceDefinition objects that require game_id
+        """
+        return [s for s in cls.GAME_SOURCES.values() if s.requires_game_id]
+
+    @classmethod
+    def get_source_names(cls) -> list[str]:
+        """Get all source names.
+
+        Returns:
+            List of source name strings
+        """
+        return list(cls.GAME_SOURCES.keys())

--- a/tests/integration/data_flow/stages/__init__.py
+++ b/tests/integration/data_flow/stages/__init__.py
@@ -1,0 +1,16 @@
+"""Data flow validation stages.
+
+Stages:
+- download: Validates data source downloads
+- storage: Validates database persistence
+"""
+
+from .download import DownloadStage, DownloadStageResult
+from .storage import StorageStage, StorageStageResult
+
+__all__ = [
+    "DownloadStage",
+    "DownloadStageResult",
+    "StorageStage",
+    "StorageStageResult",
+]

--- a/tests/integration/data_flow/stages/download.py
+++ b/tests/integration/data_flow/stages/download.py
@@ -1,0 +1,240 @@
+"""Download stage validation for data flow tests.
+
+This module handles downloading data from all configured sources
+and capturing results for validation.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tests.integration.data_flow.sources.registry import SourceDefinition
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DownloadStageResult:
+    """Result of a download operation for a single source.
+
+    Attributes:
+        source_name: Identifier of the data source
+        success: Whether the download completed successfully
+        download_time_ms: Time taken to download in milliseconds
+        data: Parsed data from the download (if successful)
+        raw_content: Raw bytes content (if preserved)
+        error: Error message if download failed
+        game_id: Game ID used for the download (if applicable)
+        downloaded_at: Timestamp when download completed
+    """
+
+    source_name: str
+    success: bool
+    download_time_ms: float
+    data: Any | None = None
+    raw_content: bytes | None = None
+    error: str | None = None
+    game_id: int | None = None
+    downloaded_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def has_data(self) -> bool:
+        """Check if the result has data."""
+        return self.data is not None
+
+    def __repr__(self) -> str:
+        status = "OK" if self.success else "FAILED"
+        return f"DownloadStageResult({self.source_name}={status}, {self.download_time_ms:.1f}ms)"
+
+
+class DownloadStage:
+    """Download stage for data flow testing.
+
+    Handles downloading data from configured sources and capturing
+    results for validation in subsequent stages.
+    """
+
+    def __init__(self, *, rate_limit_override: float | None = None) -> None:
+        """Initialize download stage.
+
+        Args:
+            rate_limit_override: Override rate limit for faster testing
+        """
+        self.rate_limit_override = rate_limit_override
+
+    async def download_source(
+        self,
+        source: SourceDefinition,
+        game_id: int | None = None,
+        season_id: int | None = None,
+        *,
+        config_overrides: dict[str, Any] | None = None,
+    ) -> DownloadStageResult:
+        """Download data from a single source.
+
+        Args:
+            source: Source definition to download from
+            game_id: Game ID for game-level sources
+            season_id: Season ID for season-level sources
+            config_overrides: Optional config overrides
+
+        Returns:
+            DownloadStageResult with outcome
+        """
+        start_time = time.perf_counter()
+        overrides = config_overrides or {}
+
+        # Apply rate limit override if set
+        if self.rate_limit_override is not None:
+            overrides["requests_per_second"] = self.rate_limit_override
+
+        try:
+            downloader = source.create_downloader(**overrides)
+
+            # Choose download method based on source type
+            if source.requires_game_id and game_id is not None:
+                result = await downloader.download_game(game_id)
+                data = result.data if hasattr(result, "data") else result
+            elif season_id is not None:
+                # For season-level sources, download first item
+                async for result in downloader.download_season(season_id):
+                    data = result.data if hasattr(result, "data") else result
+                    break
+                else:
+                    data = None
+            else:
+                # Fallback: use health check to verify connectivity
+                await downloader.health_check()
+                data = {"health_check": True}
+
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+
+            return DownloadStageResult(
+                source_name=source.name,
+                success=True,
+                download_time_ms=elapsed_ms,
+                data=data,
+                game_id=game_id,
+            )
+
+        except Exception as e:
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+            logger.exception(f"Download failed for {source.name}: {e}")
+
+            return DownloadStageResult(
+                source_name=source.name,
+                success=False,
+                download_time_ms=elapsed_ms,
+                error=str(e),
+                game_id=game_id,
+            )
+
+    async def download_game_sources(
+        self,
+        sources: list[SourceDefinition],
+        game_id: int,
+        *,
+        config_overrides: dict[str, Any] | None = None,
+    ) -> dict[str, DownloadStageResult]:
+        """Download data from all game-level sources.
+
+        Args:
+            sources: List of source definitions to download from
+            game_id: Game ID to download
+            config_overrides: Optional config overrides
+
+        Returns:
+            Dictionary mapping source names to results
+        """
+        results: dict[str, DownloadStageResult] = {}
+
+        for source in sources:
+            if not source.requires_game_id:
+                continue
+
+            result = await self.download_source(
+                source,
+                game_id=game_id,
+                config_overrides=config_overrides,
+            )
+            results[source.name] = result
+
+            logger.info(
+                f"Downloaded {source.name}: "
+                f"{'OK' if result.success else 'FAILED'} "
+                f"({result.download_time_ms:.1f}ms)"
+            )
+
+        return results
+
+    async def download_all_sources(
+        self,
+        sources: list[SourceDefinition],
+        game_id: int | None = None,
+        season_id: int | None = None,
+        *,
+        config_overrides: dict[str, Any] | None = None,
+    ) -> dict[str, DownloadStageResult]:
+        """Download data from all configured sources.
+
+        Args:
+            sources: List of source definitions to download from
+            game_id: Game ID for game-level sources
+            season_id: Season ID for season-level sources
+            config_overrides: Optional config overrides
+
+        Returns:
+            Dictionary mapping source names to results
+        """
+        results: dict[str, DownloadStageResult] = {}
+
+        for source in sources:
+            result = await self.download_source(
+                source,
+                game_id=game_id if source.requires_game_id else None,
+                season_id=season_id,
+                config_overrides=config_overrides,
+            )
+            results[source.name] = result
+
+            logger.info(
+                f"Downloaded {source.name}: "
+                f"{'OK' if result.success else 'FAILED'} "
+                f"({result.download_time_ms:.1f}ms)"
+            )
+
+        return results
+
+    @staticmethod
+    def summarize_results(
+        results: dict[str, DownloadStageResult],
+    ) -> dict[str, Any]:
+        """Generate summary statistics for download results.
+
+        Args:
+            results: Dictionary of download results
+
+        Returns:
+            Summary dictionary with counts and timing
+        """
+        total = len(results)
+        passed = sum(1 for r in results.values() if r.success)
+        failed = total - passed
+        total_time_ms = sum(r.download_time_ms for r in results.values())
+
+        return {
+            "total": total,
+            "passed": passed,
+            "failed": failed,
+            "success_rate": (passed / total * 100) if total > 0 else 0,
+            "total_time_ms": total_time_ms,
+            "avg_time_ms": (total_time_ms / total) if total > 0 else 0,
+            "failed_sources": [
+                r.source_name for r in results.values() if not r.success
+            ],
+        }

--- a/tests/integration/data_flow/stages/storage.py
+++ b/tests/integration/data_flow/stages/storage.py
@@ -1,0 +1,332 @@
+"""Storage stage validation for data flow tests.
+
+This module handles persisting downloaded data to the database
+and verifying that tables are properly populated.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nhl_api.services.db import DatabaseService
+    from tests.integration.data_flow.sources.registry import SourceDefinition
+    from tests.integration.data_flow.stages.download import DownloadStageResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StorageStageResult:
+    """Result of a storage operation for a single source.
+
+    Attributes:
+        source_name: Identifier of the data source
+        success: Whether the persist completed successfully
+        persist_time_ms: Time taken to persist in milliseconds
+        rows_affected: Number of rows inserted/updated
+        tables_populated: Mapping of table names to new row counts
+        error: Error message if persist failed
+        persisted_at: Timestamp when persist completed
+    """
+
+    source_name: str
+    success: bool
+    persist_time_ms: float
+    rows_affected: int = 0
+    tables_populated: dict[str, int] = field(default_factory=dict)
+    error: str | None = None
+    persisted_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def has_data(self) -> bool:
+        """Check if any data was persisted."""
+        return self.rows_affected > 0 or any(self.tables_populated.values())
+
+    def __repr__(self) -> str:
+        status = "OK" if self.success else "FAILED"
+        return (
+            f"StorageStageResult({self.source_name}={status}, "
+            f"rows={self.rows_affected}, {self.persist_time_ms:.1f}ms)"
+        )
+
+
+class MockDatabaseService:
+    """Mock database service for testing without real database.
+
+    This mock tracks persist calls and simulates table counts
+    for validation purposes.
+    """
+
+    def __init__(self) -> None:
+        """Initialize mock database service."""
+        self._connected = True
+        self._table_counts: dict[str, int] = {}
+        self._persist_calls: list[dict[str, Any]] = []
+        self._execute_count = 0
+
+    @property
+    def is_connected(self) -> bool:
+        """Return connection status."""
+        return self._connected
+
+    async def connect(self) -> None:
+        """Simulate database connection."""
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        """Simulate database disconnection."""
+        self._connected = False
+
+    async def execute(self, query: str, *args: object, **kwargs: object) -> str:
+        """Mock execute - tracks calls and returns success."""
+        self._execute_count += 1
+        self._persist_calls.append({"query": query[:100], "args_count": len(args)})
+        return "INSERT 0 1"
+
+    async def executemany(
+        self, query: str, args: list[tuple[Any, ...]], **kwargs: object
+    ) -> None:
+        """Mock executemany - tracks calls."""
+        self._execute_count += len(args)
+        self._persist_calls.append({"query": query[:100], "batch_size": len(args)})
+
+    async def fetch(
+        self, query: str, *args: object, **kwargs: object
+    ) -> list[dict[str, Any]]:
+        """Mock fetch - returns empty list."""
+        return []
+
+    async def fetchrow(
+        self, query: str, *args: object, **kwargs: object
+    ) -> dict[str, Any] | None:
+        """Mock fetchrow - returns None."""
+        return None
+
+    async def fetchval(
+        self, query: str, *args: object, column: int = 0, **kwargs: object
+    ) -> Any:
+        """Mock fetchval - returns simulated count for COUNT queries."""
+        # Simulate row count for COUNT queries
+        if "COUNT" in query.upper():
+            return self._execute_count
+        return 1
+
+    async def table_exists(self, table_name: str, schema: str = "public") -> bool:
+        """Mock table_exists - always returns True."""
+        return True
+
+    async def get_table_count(self, table_name: str) -> int:
+        """Mock get_table_count - returns tracked count."""
+        return self._table_counts.get(table_name, 0)
+
+    def set_table_count(self, table_name: str, count: int) -> None:
+        """Set simulated table count for testing."""
+        self._table_counts[table_name] = count
+
+    def get_persist_calls(self) -> list[dict[str, Any]]:
+        """Get list of persist calls made."""
+        return self._persist_calls
+
+    def reset(self) -> None:
+        """Reset mock state."""
+        self._persist_calls.clear()
+        self._table_counts.clear()
+        self._execute_count = 0
+
+
+class StorageStage:
+    """Storage stage for data flow testing.
+
+    Handles persisting downloaded data to the database and
+    verifying table population.
+    """
+
+    def __init__(self, db: DatabaseService | MockDatabaseService) -> None:
+        """Initialize storage stage.
+
+        Args:
+            db: Database service (real or mock)
+        """
+        self.db = db
+
+    async def _get_table_counts(self, tables: tuple[str, ...]) -> dict[str, int]:
+        """Get current row counts for specified tables.
+
+        Args:
+            tables: Tuple of table names
+
+        Returns:
+            Dictionary mapping table names to row counts
+        """
+        counts: dict[str, int] = {}
+        for table in tables:
+            try:
+                count = await self.db.get_table_count(table)
+                counts[table] = count
+            except Exception as e:
+                logger.warning(f"Failed to get count for {table}: {e}")
+                counts[table] = 0
+        return counts
+
+    async def persist_and_verify(
+        self,
+        source: SourceDefinition,
+        download_result: DownloadStageResult,
+    ) -> StorageStageResult:
+        """Persist downloaded data and verify storage.
+
+        Args:
+            source: Source definition with persist info
+            download_result: Result from download stage
+
+        Returns:
+            StorageStageResult with outcome
+        """
+        # Skip if source doesn't have persist
+        if not source.has_persist:
+            return StorageStageResult(
+                source_name=source.name,
+                success=True,
+                persist_time_ms=0,
+                rows_affected=0,
+                tables_populated={},
+                error=None,
+            )
+
+        # Skip if download failed
+        if not download_result.success or download_result.data is None:
+            return StorageStageResult(
+                source_name=source.name,
+                success=False,
+                persist_time_ms=0,
+                rows_affected=0,
+                tables_populated={},
+                error=f"Skipped: download failed - {download_result.error}",
+            )
+
+        start_time = time.perf_counter()
+
+        try:
+            # Get counts before persist
+            before_counts = await self._get_table_counts(source.target_tables)
+
+            # Create downloader and call persist
+            downloader = source.create_downloader()
+
+            # Call persist method (assumes it exists based on has_persist)
+            if hasattr(downloader, "persist"):
+                rows = await downloader.persist(self.db, [download_result.data])
+            else:
+                rows = 0
+
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+
+            # Get counts after persist
+            after_counts = await self._get_table_counts(source.target_tables)
+
+            # Calculate differences
+            tables_populated = {
+                table: after_counts[table] - before_counts[table]
+                for table in source.target_tables
+            }
+
+            return StorageStageResult(
+                source_name=source.name,
+                success=True,
+                persist_time_ms=elapsed_ms,
+                rows_affected=rows if isinstance(rows, int) else 0,
+                tables_populated=tables_populated,
+            )
+
+        except Exception as e:
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+            logger.exception(f"Persist failed for {source.name}: {e}")
+
+            return StorageStageResult(
+                source_name=source.name,
+                success=False,
+                persist_time_ms=elapsed_ms,
+                error=str(e),
+            )
+
+    async def persist_all(
+        self,
+        sources: list[SourceDefinition],
+        download_results: dict[str, DownloadStageResult],
+    ) -> dict[str, StorageStageResult]:
+        """Persist all downloaded data.
+
+        Args:
+            sources: List of source definitions
+            download_results: Results from download stage
+
+        Returns:
+            Dictionary mapping source names to storage results
+        """
+        results: dict[str, StorageStageResult] = {}
+
+        for source in sources:
+            if not source.has_persist:
+                results[source.name] = StorageStageResult(
+                    source_name=source.name,
+                    success=True,
+                    persist_time_ms=0,
+                    error="No persist method",
+                )
+                continue
+
+            download_result = download_results.get(source.name)
+            if download_result is None:
+                results[source.name] = StorageStageResult(
+                    source_name=source.name,
+                    success=False,
+                    persist_time_ms=0,
+                    error="No download result",
+                )
+                continue
+
+            result = await self.persist_and_verify(source, download_result)
+            results[source.name] = result
+
+            logger.info(
+                f"Persisted {source.name}: "
+                f"{'OK' if result.success else 'FAILED'} "
+                f"(rows={result.rows_affected}, {result.persist_time_ms:.1f}ms)"
+            )
+
+        return results
+
+    @staticmethod
+    def summarize_results(
+        results: dict[str, StorageStageResult],
+    ) -> dict[str, Any]:
+        """Generate summary statistics for storage results.
+
+        Args:
+            results: Dictionary of storage results
+
+        Returns:
+            Summary dictionary with counts and timing
+        """
+        total = len(results)
+        passed = sum(1 for r in results.values() if r.success)
+        failed = total - passed
+        total_rows = sum(r.rows_affected for r in results.values())
+        total_time_ms = sum(r.persist_time_ms for r in results.values())
+
+        return {
+            "total": total,
+            "passed": passed,
+            "failed": failed,
+            "success_rate": (passed / total * 100) if total > 0 else 0,
+            "total_rows": total_rows,
+            "total_time_ms": total_time_ms,
+            "failed_sources": [
+                r.source_name for r in results.values() if not r.success
+            ],
+        }

--- a/tests/integration/data_flow/test_data_flow.py
+++ b/tests/integration/data_flow/test_data_flow.py
@@ -1,0 +1,341 @@
+"""Data flow integration tests.
+
+This module contains end-to-end tests for the NHL API data pipeline,
+validating the complete flow from download through storage.
+
+Test Categories:
+- test_full_data_flow: Complete pipeline test for fixture game
+- test_individual_source_*: Per-source validation tests
+- test_report_generation: Verify report output
+
+Markers:
+- @pytest.mark.integration: Integration tests (default)
+- @pytest.mark.data_validation: Data validation tests
+- @pytest.mark.live: Tests that require network access
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.data_flow.reports.generator import ReportGenerator
+from tests.integration.data_flow.reports.models import DataFlowReport
+from tests.integration.data_flow.sources.registry import SourceRegistry
+from tests.integration.data_flow.stages.download import DownloadStage
+from tests.integration.data_flow.stages.storage import MockDatabaseService, StorageStage
+
+
+@pytest.mark.integration
+@pytest.mark.data_validation
+class TestDataFlowInfrastructure:
+    """Tests for data flow test infrastructure components."""
+
+    def test_source_registry_has_sources(self) -> None:
+        """Verify source registry has expected sources."""
+        sources = SourceRegistry.get_all_sources()
+        assert len(sources) >= 8, "Expected at least 8 sources"
+
+        # Verify expected source names exist
+        names = SourceRegistry.get_source_names()
+        assert "nhl_json_boxscore" in names
+        assert "nhl_json_play_by_play" in names
+        assert "nhl_stats_shift_charts" in names
+
+    def test_source_definitions_valid(self) -> None:
+        """Verify all source definitions are valid."""
+        for source in SourceRegistry.get_all_sources():
+            assert source.name, "Source name required"
+            assert source.display_name, "Display name required"
+            assert source.downloader_class, "Downloader class required"
+            assert source.config_class, "Config class required"
+
+            # Verify classes can be loaded
+            try:
+                source.get_downloader_class()
+                source.get_config_class()
+            except (ImportError, AttributeError) as e:
+                pytest.fail(f"Failed to load classes for {source.name}: {e}")
+
+    def test_persist_sources_have_target_tables(self) -> None:
+        """Verify persist sources define target tables."""
+        for source in SourceRegistry.get_persist_sources():
+            assert source.has_persist, f"{source.name} should have persist"
+            assert source.target_tables, f"{source.name} should have target tables"
+
+    def test_mock_database_service(self) -> None:
+        """Test MockDatabaseService functionality."""
+        db = MockDatabaseService()
+
+        assert db.is_connected
+        db.set_table_count("games", 100)
+        assert db._table_counts["games"] == 100
+
+        db.reset()
+        assert not db._persist_calls
+        assert not db._table_counts
+
+
+@pytest.mark.integration
+@pytest.mark.data_validation
+class TestDownloadStage:
+    """Tests for the download stage."""
+
+    def test_download_stage_creation(self) -> None:
+        """Test download stage can be created."""
+        stage = DownloadStage()
+        assert stage is not None
+
+    def test_download_stage_with_rate_limit(self) -> None:
+        """Test download stage respects rate limit override."""
+        stage = DownloadStage(rate_limit_override=10.0)
+        assert stage.rate_limit_override == 10.0
+
+    @pytest.mark.asyncio
+    async def test_download_source_creates_result(
+        self,
+        download_stage: DownloadStage,
+    ) -> None:
+        """Test download creates proper result object."""
+        source = SourceRegistry.get_source("nhl_json_boxscore")
+
+        # This will fail without network, but should return a proper result
+        result = await download_stage.download_source(source, game_id=2024020001)
+
+        assert result.source_name == "nhl_json_boxscore"
+        assert result.download_time_ms >= 0
+        # Result may succeed or fail depending on network
+        assert result.success or result.error is not None
+
+
+@pytest.mark.integration
+@pytest.mark.data_validation
+class TestStorageStage:
+    """Tests for the storage stage."""
+
+    def test_storage_stage_creation(self, mock_db: MockDatabaseService) -> None:
+        """Test storage stage can be created."""
+        stage = StorageStage(mock_db)
+        assert stage.db is mock_db
+
+    @pytest.mark.asyncio
+    async def test_storage_skip_no_persist(
+        self,
+        storage_stage: StorageStage,
+    ) -> None:
+        """Test storage skips sources without persist."""
+        # Create a source definition without persist
+        from tests.integration.data_flow.sources.registry import (
+            SourceDefinition,
+            SourceType,
+        )
+        from tests.integration.data_flow.stages.download import DownloadStageResult
+
+        source = SourceDefinition(
+            name="test_no_persist",
+            display_name="Test",
+            downloader_class="nhl_api.downloaders.sources.nhl_json.schedule.ScheduleDownloader",
+            config_class="nhl_api.downloaders.base.base_downloader.DownloaderConfig",
+            source_type=SourceType.GAME,
+            has_persist=False,
+        )
+
+        download_result = DownloadStageResult(
+            source_name="test_no_persist",
+            success=True,
+            download_time_ms=100,
+            data={"test": "data"},
+        )
+
+        result = await storage_stage.persist_and_verify(source, download_result)
+
+        assert result.success
+        assert result.rows_affected == 0
+        assert result.error is None
+
+
+@pytest.mark.integration
+@pytest.mark.data_validation
+class TestReportGeneration:
+    """Tests for report generation."""
+
+    def test_empty_report(self, report_generator: ReportGenerator) -> None:
+        """Test report generation with empty report."""
+        report = DataFlowReport()
+        output = report_generator.generate(report)
+
+        assert "Data Flow Test Report" in output
+        assert "Summary" in output
+        assert "Total Sources | 0" in output
+
+    def test_report_with_results(self, report_generator: ReportGenerator) -> None:
+        """Test report generation with mock results."""
+        from tests.integration.data_flow.stages.download import DownloadStageResult
+        from tests.integration.data_flow.stages.storage import StorageStageResult
+
+        report = DataFlowReport(game_id=2024020001, season_id=20242025)
+
+        # Add a successful result
+        download_result = DownloadStageResult(
+            source_name="nhl_json_boxscore",
+            success=True,
+            download_time_ms=150,
+            data={"test": "data"},
+        )
+        storage_result = StorageStageResult(
+            source_name="nhl_json_boxscore",
+            success=True,
+            persist_time_ms=50,
+            rows_affected=10,
+            tables_populated={"game_skater_stats": 5, "game_goalie_stats": 2},
+        )
+
+        report.add_source_result(
+            source_name="nhl_json_boxscore",
+            display_name="Boxscore",
+            download_result=download_result,
+            storage_result=storage_result,
+        )
+
+        output = report_generator.generate(report)
+
+        assert "Game ID:** 2024020001" in output
+        assert "Boxscore" in output
+        assert "game_skater_stats" in output
+
+    def test_console_summary(self, report_generator: ReportGenerator) -> None:
+        """Test console summary generation."""
+        from tests.integration.data_flow.stages.download import DownloadStageResult
+
+        report = DataFlowReport()
+        report.add_source_result(
+            source_name="test",
+            display_name="Test Source",
+            download_result=DownloadStageResult(
+                source_name="test",
+                success=True,
+                download_time_ms=100,
+            ),
+        )
+        report.mark_completed()
+
+        summary = report_generator.generate_console_summary(report)
+
+        assert "Data Flow Test" in summary
+        assert "1/1 passed" in summary
+
+
+@pytest.mark.integration
+@pytest.mark.data_validation
+@pytest.mark.live
+class TestLiveDataFlow:
+    """Live tests that require network access.
+
+    These tests are skipped by default. Run with:
+        pytest -m live tests/integration/data_flow/
+    """
+
+    @pytest.mark.asyncio
+    async def test_boxscore_download_live(
+        self,
+        fixture_game_id: int,
+        download_stage: DownloadStage,
+    ) -> None:
+        """Test live boxscore download."""
+        source = SourceRegistry.get_source("nhl_json_boxscore")
+
+        result = await download_stage.download_source(
+            source,
+            game_id=fixture_game_id,
+            config_overrides={"requests_per_second": 2.0},
+        )
+
+        assert result.success, f"Download failed: {result.error}"
+        assert result.has_data
+        assert result.download_time_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_play_by_play_download_live(
+        self,
+        fixture_game_id: int,
+        download_stage: DownloadStage,
+    ) -> None:
+        """Test live play-by-play download."""
+        source = SourceRegistry.get_source("nhl_json_play_by_play")
+
+        result = await download_stage.download_source(
+            source,
+            game_id=fixture_game_id,
+            config_overrides={"requests_per_second": 2.0},
+        )
+
+        assert result.success, f"Download failed: {result.error}"
+        assert result.has_data
+
+    @pytest.mark.asyncio
+    async def test_shift_charts_download_live(
+        self,
+        fixture_game_id: int,
+        download_stage: DownloadStage,
+    ) -> None:
+        """Test live shift charts download."""
+        source = SourceRegistry.get_source("nhl_stats_shift_charts")
+
+        result = await download_stage.download_source(
+            source,
+            game_id=fixture_game_id,
+            config_overrides={"requests_per_second": 2.0},
+        )
+
+        assert result.success, f"Download failed: {result.error}"
+        assert result.has_data
+
+    @pytest.mark.asyncio
+    async def test_full_game_data_flow_live(
+        self,
+        fixture_game_id: int,
+        fixture_season_id: int,
+        download_stage: DownloadStage,
+        mock_db: MockDatabaseService,
+        report_generator: ReportGenerator,
+    ) -> None:
+        """Test complete data flow for game-level sources.
+
+        Downloads from all game-level sources and generates report.
+        Uses mock database for storage validation.
+        """
+        storage_stage = StorageStage(mock_db)
+        game_sources = SourceRegistry.get_game_level_sources()
+        report = DataFlowReport(game_id=fixture_game_id, season_id=fixture_season_id)
+
+        # Download and persist each source
+        for source in game_sources:
+            download_result = await download_stage.download_source(
+                source,
+                game_id=fixture_game_id,
+                config_overrides={"requests_per_second": 2.0},
+            )
+
+            storage_result = None
+            if source.has_persist and download_result.success:
+                storage_result = await storage_stage.persist_and_verify(
+                    source, download_result
+                )
+
+            report.add_source_result(
+                source_name=source.name,
+                display_name=source.display_name,
+                download_result=download_result,
+                storage_result=storage_result,
+            )
+
+        report.mark_completed()
+
+        # Generate and print report
+        print("\n" + report_generator.generate(report))
+        print("\n" + report_generator.generate_console_summary(report))
+
+        # Assert success rate
+        assert report.success_rate >= 80, (
+            f"Success rate too low: {report.success_rate:.1f}%\n"
+            f"Failed sources: {[s.source_name for s in report.get_failed_sources()]}"
+        )


### PR DESCRIPTION
## Summary

- Implement foundation for end-to-end data flow testing
- Create source registry with 8 persist-capable sources
- Add download stage with async timing and error capture
- Add storage stage with MockDatabaseService for CI testing
- Add markdown report generator with console summary

## Key Components

| Component | Purpose |
|-----------|---------|
| `sources/registry.py` | 8 sources with metadata and lazy loading |
| `stages/download.py` | Async download with rate limiting |
| `stages/storage.py` | MockDatabaseService for CI, real DB support |
| `reports/generator.py` | Markdown and console report output |

## Test Coverage

- 12 infrastructure tests (all passing)
- 4 live tests (skipped by default, run with `-m live`)
- No regressions in existing 1748 unit tests

## Usage

```bash
# Run infrastructure tests (no network)
pytest tests/integration/data_flow/ -v --no-cov -k "not live"

# Run live tests (network required)
pytest -m live tests/integration/data_flow/ -v --no-cov

# Run with real database
USE_REAL_DB=true pytest tests/integration/data_flow/ -v
```

## Test plan

- [x] All infrastructure tests pass
- [x] Source registry loads all 8 sources correctly
- [x] Download stage creates proper result objects
- [x] Storage stage skips sources without persist
- [x] Report generator produces valid markdown
- [x] No regressions in existing test suite

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)