### PR TITLE
feat(viewer): Add Delete Season Data feature

### DIFF
--- a/src/nhl_api/viewer/schemas/monitoring.py
+++ b/src/nhl_api/viewer/schemas/monitoring.py
@@ -170,6 +170,17 @@ class CleanupResponse(BaseModel):
     message: str
 
 
+class DeleteSeasonResponse(BaseModel):
+    """Response after deleting season data."""
+
+    season_id: int
+    dry_run: bool
+    deleted_counts: dict[str, int]
+    total_records_deleted: int
+    execution_time_ms: float
+    message: str
+
+
 # =============================================================================
 # Sources
 # =============================================================================

--- a/viewer-frontend/package-lock.json
+++ b/viewer-frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "viewer-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-progress": "^1.1.8",
@@ -1135,6 +1136,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/viewer-frontend/package.json
+++ b/viewer-frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",

--- a/viewer-frontend/src/components/ui/alert-dialog.tsx
+++ b/viewer-frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}


### PR DESCRIPTION
## Summary

Implements a complete UI and backend feature for permanently deleting all data for a specific season.

## Backend Implementation

**New DELETE endpoint:** `/api/v1/monitoring/seasons/{season_id}/data`

### Features:
- **Dry-run mode** (default): Preview deletion counts without executing
- **Transaction-based deletion**: All-or-nothing cascade deletion
- **Proper deletion order** (respecting foreign keys):
  1. game_events
  2. game_skater_stats
  3. game_goalie_stats
  4. game_shifts
  5. game_team_stats
  6. player_game_logs
  7. games
  8. download_progress
  9. import_batches
- **Auto-refresh materialized views** after deletion
- **Detailed response**: Shows counts per table and execution time

**Files:**
- `src/nhl_api/viewer/routers/monitoring.py` - DELETE endpoint
- `src/nhl_api/viewer/schemas/monitoring.py` - DeleteSeasonResponse schema

## Frontend Implementation

### New Components:
- **AlertDialog component** (`viewer-frontend/src/components/ui/alert-dialog.tsx`)
  - Based on shadcn/ui pattern with Radix UI primitives
  - Supports controlled open state and portal rendering

### Delete Season UI:
- Added **Delete Season Data** section to Downloads page
- Red bordered card with destructive styling
- Lists all available seasons with delete buttons

### Two-Step Confirmation Flow:
1. User clicks "Delete" → triggers dry-run API call
2. Dialog shows preview with detailed counts per table
3. User reviews and either:
   - Confirms → executes permanent deletion
   - Cancels → closes dialog without action

### Data Management:
- `useDeleteSeason` hook with TanStack Query mutation
- Invalidates all cached queries after successful deletion
- Loading and error states handled throughout

**Files:**
- `viewer-frontend/src/components/ui/alert-dialog.tsx` - Dialog component
- `viewer-frontend/src/hooks/useDownloads.ts` - useDeleteSeason hook
- `viewer-frontend/src/pages/Downloads.tsx` - Delete UI section
- `viewer-frontend/package.json` - Added @radix-ui/react-alert-dialog

## Safety Features

✅ **Dry-run by default** - Must explicitly confirm to execute  
✅ **Confirmation dialog** - Shows exactly what will be deleted  
✅ **Transaction-based** - All-or-nothing guarantee  
✅ **Destructive styling** - Red colors and clear warnings  
✅ **Detailed preview** - Table-by-table breakdown

## Test Results

**Dry-run test for season 20242025:**
```json
{
  "season_id": 20242025,
  "dry_run": true,
  "deleted_counts": {
    "game_events": 49579,
    "game_skater_stats": 6300,
    "game_goalie_stats": 700,
    "game_shifts": 49701,
    "game_team_stats": 350,
    "player_game_logs": 1813,
    "games": 175,
    "download_progress": 0,
    "import_batches": 37
  },
  "total_records_deleted": 108655,
  "execution_time_ms": 42.14
}
```

## Screenshots

_Available at http://localhost:5173/downloads (scroll to bottom)_

## Testing Checklist

- [x] Backend endpoint works with dry-run
- [x] Backend endpoint returns correct counts
- [x] Frontend dialog opens and shows preview
- [x] Frontend displays deletion counts correctly
- [x] TypeScript compiles without errors
- [x] Pre-commit hooks pass (ruff, mypy, pytest)
- [ ] Manual E2E test (requires user confirmation)

## Related

Closes #222

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)