### PR TITLE
feat(viewer): Add game type filter to Downloads page

### DIFF
--- a/src/nhl_api/viewer/routers/downloads.py
+++ b/src/nhl_api/viewer/routers/downloads.py
@@ -179,6 +179,7 @@ async def start_download(
                     db=db,
                     source_name=source_name,
                     season_id=season_id,
+                    game_types=request.game_types,
                     force=request.force,
                 )
                 batches.append(

--- a/src/nhl_api/viewer/schemas/downloads.py
+++ b/src/nhl_api/viewer/schemas/downloads.py
@@ -57,6 +57,7 @@ class DownloadStartRequest(BaseModel):
 
     season_ids: list[int]
     source_names: list[str]  # e.g., ["nhl_schedule", "nhl_boxscore"]
+    game_types: list[int] = [2]  # 1=pre, 2=regular (default), 3=playoffs
     force: bool = False  # Re-download even if already completed
 
 

--- a/viewer-frontend/src/hooks/useDownloads.ts
+++ b/viewer-frontend/src/hooks/useDownloads.ts
@@ -53,6 +53,7 @@ interface ActiveDownloadsResponse {
 interface StartDownloadRequest {
   season_ids: number[]
   source_names: string[]
+  game_types?: number[]  // 1=pre, 2=regular, 3=playoffs
   force?: boolean
 }
 


### PR DESCRIPTION
## Summary
Add checkboxes to the Downloads page to filter schedule downloads by game type:
- Pre-season (game_type=1)
- Regular Season (game_type=2) - **default checked**
- Playoffs (game_type=3)

## Changes

### Backend
- `DownloadStartRequest` schema accepts `game_types` parameter (default `[2]`)
- `DownloadService.start_download()` passes game_types through to downloaders
- `_download_schedule()` filters games by game type before persisting
- `_download_game_based()` filters completed games by game type (for boxscore, play-by-play)
- `_run_shift_chart_download()` also respects game type filter

### Frontend
- New Game Types card with checkboxes above Seasons/Sources grid
- Regular Season checked by default
- Validation: at least one game type required to start download
- Status line shows selected game types
- Clear visual feedback with descriptions for each game type

## Why This Change
Pre-season and All-Star games often have non-standard team IDs that can cause issues in downstream processing. This filter allows users to:
1. Download only regular season games (most common use case)
2. Selectively include pre-season or playoffs when needed
3. Avoid 404 errors and data issues from special game types

## Test Plan
- [x] Backend unit tests pass (125 viewer tests)
- [x] Frontend builds successfully (TypeScript + Vite)
- [x] Pre-commit hooks pass (ruff, mypy, pytest)
- [ ] Manual test: Start download with Regular Season only
- [ ] Manual test: Start download with all game types selected
- [ ] Manual test: Verify empty selection shows validation error

## Screenshots
(Frontend changes visible on Downloads page at http://localhost:5173/downloads)

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)