### PR TITLE
fix(roster): Handle ARI→UTA team relocation

### DIFF
--- a/src/nhl_api/downloaders/sources/nhl_json/__init__.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/__init__.py
@@ -36,11 +36,16 @@ from nhl_api.downloaders.sources.nhl_json.player_landing import (
     SkaterSeasonStats,
 )
 from nhl_api.downloaders.sources.nhl_json.roster import (
+    ALL_TEAM_ABBREVS,
+    CURRENT_TEAM_ABBREVS,
     NHL_TEAM_ABBREVS,
+    TEAM_RELOCATIONS,
     ParsedRoster,
     PlayerInfo,
     RosterDownloader,
     create_roster_downloader,
+    get_teams_for_season,
+    resolve_team_abbrev,
 )
 from nhl_api.downloaders.sources.nhl_json.schedule import ScheduleDownloader
 from nhl_api.downloaders.sources.nhl_json.standings import (
@@ -53,7 +58,9 @@ from nhl_api.downloaders.sources.nhl_json.standings import (
 )
 
 __all__ = [
+    "ALL_TEAM_ABBREVS",
     "BoxscoreDownloader",
+    "CURRENT_TEAM_ABBREVS",
     "DraftDetails",
     "EventPlayer",
     "GameEvent",
@@ -85,9 +92,12 @@ __all__ = [
     "SkaterSeasonStats",
     "StandingsDownloader",
     "StreakInfo",
+    "TEAM_RELOCATIONS",
     "TeamStandings",
     "create_play_by_play_downloader",
     "create_player_game_log_downloader",
     "create_roster_downloader",
     "create_standings_downloader",
+    "get_teams_for_season",
+    "resolve_team_abbrev",
 ]

--- a/src/nhl_api/viewer/services/download_service.py
+++ b/src/nhl_api/viewer/services/download_service.py
@@ -781,10 +781,11 @@ class DownloadService:
         active_download: ActiveDownloadTask | None,
     ) -> None:
         """Download rosters for all teams and persist to database."""
-        from nhl_api.downloaders.sources.nhl_json import NHL_TEAM_ABBREVS
+        from nhl_api.downloaders.sources.nhl_json import get_teams_for_season
         from nhl_api.downloaders.sources.nhl_json.roster import ParsedRoster
 
-        teams = NHL_TEAM_ABBREVS
+        # Use season-appropriate team list (handles ARI→UTA relocation)
+        teams = get_teams_for_season(season_id)
 
         if active_download:
             active_download.items_total = len(teams)
@@ -881,16 +882,18 @@ class DownloadService:
         """Download player landing pages and persist to database."""
         # Get player IDs from rosters
         from nhl_api.downloaders.sources.nhl_json import (
-            NHL_TEAM_ABBREVS,
             RosterDownloader,
+            get_teams_for_season,
         )
 
         roster_config = DownloaderConfig(base_url=NHL_API_BASE_URL)
         player_ids: set[int] = set()
 
+        # Use season-appropriate team list (handles ARI→UTA relocation)
+        teams = get_teams_for_season(season_id)
         roster_dl = RosterDownloader(roster_config)
         async with roster_dl:
-            for team_abbrev in NHL_TEAM_ABBREVS:
+            for team_abbrev in teams:
                 try:
                     roster = await roster_dl.get_roster_for_season(
                         team_abbrev, season_id
@@ -955,17 +958,19 @@ class DownloadService:
         """Download player game logs and persist to database."""
         # Get player IDs from rosters
         from nhl_api.downloaders.sources.nhl_json import (
-            NHL_TEAM_ABBREVS,
             RosterDownloader,
+            get_teams_for_season,
         )
         from nhl_api.downloaders.sources.nhl_json.player_game_log import REGULAR_SEASON
 
         roster_config = DownloaderConfig(base_url=NHL_API_BASE_URL)
         player_ids: set[int] = set()
 
+        # Use season-appropriate team list (handles ARI→UTA relocation)
+        teams = get_teams_for_season(season_id)
         roster_dl = RosterDownloader(roster_config)
         async with roster_dl:
-            for team_abbrev in NHL_TEAM_ABBREVS:
+            for team_abbrev in teams:
                 try:
                     roster = await roster_dl.get_roster_for_season(
                         team_abbrev, season_id


### PR DESCRIPTION
## Summary

- Fixes 404 errors when downloading rosters for Arizona Coyotes (ARI), which relocated to Utah Hockey Club (UTA) in 2024-25 season
- Adds team relocation infrastructure that can handle future team moves
- Updates download service to use season-appropriate team lists

## Changes

### Core Implementation
- `TEAM_RELOCATIONS` mapping: `{"ARI": ("UTA", 20242025)}`
- `resolve_team_abbrev(abbrev, season_id)` - resolves abbreviations based on season
- `get_teams_for_season(season_id)` - returns correct 32-team list for any season
- `CURRENT_TEAM_ABBREVS` - 32 active teams (UTA, not ARI)
- `ALL_TEAM_ABBREVS` - 33 teams including historical ARI
- `NHL_TEAM_ABBREVS` - legacy alias (now equals CURRENT_TEAM_ABBREVS)

### Download Service Updates
- `_download_rosters()` - uses `get_teams_for_season(season_id)`
- `_download_player_landing()` - uses `get_teams_for_season(season_id)`
- `_download_player_game_logs()` - uses `get_teams_for_season(season_id)`

## Test plan

- [x] 17 new tests for relocation logic
- [x] All 58 roster unit tests pass
- [x] All 237 unit tests pass
- [x] Type checking passes (mypy)
- [x] Pre-commit hooks pass (ruff, format, tests)

## Impact

- **Current season (2024-25+):** Downloads UTA roster, skips ARI
- **Historical seasons (pre-2024):** Downloads ARI roster correctly
- **Success rate:** Should improve from 96.97% to 100% for roster downloads

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)