### PR TITLE
feat(downloaders): Add database persistence for HTML report data (#231)

### DIFF
--- a/migrations/023_html_reports.sql
+++ b/migrations/023_html_reports.sql
@@ -1,0 +1,99 @@
+-- Migration 023: HTML Report persistence tables
+-- Store parsed HTML report data for cross-source validation
+
+-- Game Summary (GS reports) - scoring and penalty summaries
+CREATE TABLE IF NOT EXISTS html_game_summary (
+    game_id INTEGER NOT NULL,
+    season_id INTEGER NOT NULL,
+    away_team_abbrev VARCHAR(3),
+    home_team_abbrev VARCHAR(3),
+    away_goals INTEGER,
+    home_goals INTEGER,
+    venue TEXT,
+    attendance INTEGER,
+    game_date TEXT,
+    start_time TEXT,
+    end_time TEXT,
+    goals JSONB DEFAULT '[]'::jsonb,      -- Array of goal details
+    penalties JSONB DEFAULT '[]'::jsonb,   -- Array of penalty details
+    referees JSONB DEFAULT '[]'::jsonb,    -- Array of referee names
+    linesmen JSONB DEFAULT '[]'::jsonb,    -- Array of linesman names
+    parsed_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (game_id, season_id)
+);
+
+-- Event Summary (ES reports) - player stats per game
+CREATE TABLE IF NOT EXISTS html_event_summary (
+    game_id INTEGER NOT NULL,
+    season_id INTEGER NOT NULL,
+    away_team_abbrev VARCHAR(3),
+    home_team_abbrev VARCHAR(3),
+    away_skaters JSONB DEFAULT '[]'::jsonb,   -- Player stats array
+    home_skaters JSONB DEFAULT '[]'::jsonb,
+    away_goalies JSONB DEFAULT '[]'::jsonb,
+    home_goalies JSONB DEFAULT '[]'::jsonb,
+    away_totals JSONB,                         -- Team totals
+    home_totals JSONB,
+    parsed_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (game_id, season_id)
+);
+
+-- Time on Ice (TH/TV reports) - shift-by-shift player TOI
+CREATE TABLE IF NOT EXISTS html_time_on_ice (
+    game_id INTEGER NOT NULL,
+    season_id INTEGER NOT NULL,
+    side VARCHAR(4) NOT NULL,  -- 'home' or 'away'
+    team_abbrev VARCHAR(3),
+    players JSONB DEFAULT '[]'::jsonb,  -- Player TOI details
+    parsed_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (game_id, season_id, side)
+);
+
+-- Faceoff Summary (FS reports) - faceoff stats by zone/strength
+CREATE TABLE IF NOT EXISTS html_faceoff_summary (
+    game_id INTEGER NOT NULL,
+    season_id INTEGER NOT NULL,
+    away_team_abbrev VARCHAR(3),
+    home_team_abbrev VARCHAR(3),
+    away_team JSONB,  -- Team faceoff data (by_period, by_strength, players)
+    home_team JSONB,
+    parsed_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (game_id, season_id)
+);
+
+-- Shot Summary (SS reports) - shot stats by period/situation
+CREATE TABLE IF NOT EXISTS html_shot_summary (
+    game_id INTEGER NOT NULL,
+    season_id INTEGER NOT NULL,
+    away_team_abbrev VARCHAR(3),
+    home_team_abbrev VARCHAR(3),
+    away_periods JSONB DEFAULT '[]'::jsonb,  -- Period shot breakdowns
+    home_periods JSONB DEFAULT '[]'::jsonb,
+    away_players JSONB DEFAULT '[]'::jsonb,  -- Player shot details
+    home_players JSONB DEFAULT '[]'::jsonb,
+    parsed_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (game_id, season_id)
+);
+
+-- Add HTML report sources to data_sources if not exists
+INSERT INTO data_sources (source_id, name, source_type, base_url, description)
+VALUES
+    (8, 'html_game_summary', 'html_report', 'https://www.nhl.com/scores/htmlreports', 'NHL HTML Game Summary (GS) reports'),
+    (9, 'html_event_summary', 'html_report', 'https://www.nhl.com/scores/htmlreports', 'NHL HTML Event Summary (ES) reports'),
+    (10, 'html_time_on_ice', 'html_report', 'https://www.nhl.com/scores/htmlreports', 'NHL HTML Time on Ice (TH/TV) reports'),
+    (11, 'html_faceoff_summary', 'html_report', 'https://www.nhl.com/scores/htmlreports', 'NHL HTML Faceoff Summary (FS) reports'),
+    (12, 'html_shot_summary', 'html_report', 'https://www.nhl.com/scores/htmlreports', 'NHL HTML Shot Summary (SS) reports')
+ON CONFLICT (source_id) DO NOTHING;
+
+-- Create indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_html_game_summary_season ON html_game_summary (season_id);
+CREATE INDEX IF NOT EXISTS idx_html_event_summary_season ON html_event_summary (season_id);
+CREATE INDEX IF NOT EXISTS idx_html_time_on_ice_season ON html_time_on_ice (season_id);
+CREATE INDEX IF NOT EXISTS idx_html_faceoff_summary_season ON html_faceoff_summary (season_id);
+CREATE INDEX IF NOT EXISTS idx_html_shot_summary_season ON html_shot_summary (season_id);
+
+COMMENT ON TABLE html_game_summary IS 'Parsed NHL HTML Game Summary (GS) reports with scoring and penalty data';
+COMMENT ON TABLE html_event_summary IS 'Parsed NHL HTML Event Summary (ES) reports with per-game player statistics';
+COMMENT ON TABLE html_time_on_ice IS 'Parsed NHL HTML Time on Ice (TH/TV) reports with shift data';
+COMMENT ON TABLE html_faceoff_summary IS 'Parsed NHL HTML Faceoff Summary (FS) reports with zone/strength breakdowns';
+COMMENT ON TABLE html_shot_summary IS 'Parsed NHL HTML Shot Summary (SS) reports with period/situation breakdowns';

--- a/src/nhl_api/downloaders/sources/html/shot_summary.py
+++ b/src/nhl_api/downloaders/sources/html/shot_summary.py
@@ -14,16 +14,20 @@ Example usage:
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from bs4 import BeautifulSoup, Tag
 
 from nhl_api.downloaders.sources.html.base_html_downloader import (
     BaseHTMLDownloader,
 )
+
+if TYPE_CHECKING:
+    from nhl_api.services.db import DatabaseService
 
 logger = logging.getLogger(__name__)
 
@@ -534,3 +538,65 @@ class ShotSummaryDownloader(BaseHTMLDownloader):
             "total_goals": player.total_goals,
             "periods": [self._period_to_dict(p) for p in player.periods],
         }
+
+    async def persist(
+        self,
+        db: DatabaseService,
+        summaries: list[dict[str, Any]],
+    ) -> int:
+        """Persist shot summary data to the database.
+
+        Stores parsed HTML shot summary data including period and situation
+        breakdowns for cross-source validation.
+
+        Args:
+            db: Database service instance
+            summaries: List of parsed shot summary dictionaries
+
+        Returns:
+            Number of shot summaries persisted
+        """
+        if not summaries:
+            return 0
+
+        count = 0
+        for summary in summaries:
+            game_id = summary.get("game_id")
+            season_id = summary.get("season_id")
+
+            if not game_id or not season_id:
+                logger.warning("Skipping shot summary without game_id or season_id")
+                continue
+
+            away_team = summary.get("away_team", {})
+            home_team = summary.get("home_team", {})
+
+            await db.execute(
+                """
+                INSERT INTO html_shot_summary (
+                    game_id, season_id, away_team_abbrev, home_team_abbrev,
+                    away_periods, home_periods, away_players, home_players,
+                    parsed_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CURRENT_TIMESTAMP)
+                ON CONFLICT (game_id, season_id) DO UPDATE SET
+                    away_team_abbrev = EXCLUDED.away_team_abbrev,
+                    home_team_abbrev = EXCLUDED.home_team_abbrev,
+                    away_periods = EXCLUDED.away_periods,
+                    home_periods = EXCLUDED.home_periods,
+                    away_players = EXCLUDED.away_players,
+                    home_players = EXCLUDED.home_players,
+                    parsed_at = CURRENT_TIMESTAMP
+                """,
+                game_id,
+                season_id,
+                away_team.get("abbrev"),
+                home_team.get("abbrev"),
+                json.dumps(away_team.get("periods", [])),
+                json.dumps(home_team.get("periods", [])),
+                json.dumps(away_team.get("players", [])),
+                json.dumps(home_team.get("players", [])),
+            )
+            count += 1
+
+        logger.info("Persisted %d HTML shot summaries", count)
+        return count

--- a/tests/unit/downloaders/sources/html/test_html_persist.py
+++ b/tests/unit/downloaders/sources/html/test_html_persist.py
@@ -1,0 +1,353 @@
+"""Unit tests for HTML downloader persist() methods.
+
+Tests the database persistence logic for all HTML report downloaders.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nhl_api.downloaders.sources.html import (
+    EventSummaryDownloader,
+    FaceoffSummaryDownloader,
+    GameSummaryDownloader,
+    HTMLDownloaderConfig,
+    ShotSummaryDownloader,
+    TimeOnIceDownloader,
+)
+
+
+@pytest.fixture
+def mock_db() -> AsyncMock:
+    """Create a mock database service."""
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    return db
+
+
+@pytest.fixture
+def html_config() -> HTMLDownloaderConfig:
+    """Create a test HTML downloader config."""
+    return HTMLDownloaderConfig()
+
+
+class TestGameSummaryPersist:
+    """Tests for GameSummaryDownloader.persist()."""
+
+    @pytest.mark.asyncio
+    async def test_persist_empty_list(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist with empty list returns 0."""
+        downloader = GameSummaryDownloader(html_config)
+        result = await downloader.persist(mock_db, [])
+        assert result == 0
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persist_single_summary(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist a single game summary."""
+        downloader = GameSummaryDownloader(html_config)
+        summaries = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "away_team": {"abbrev": "NYI", "goals": 2},
+                "home_team": {"abbrev": "CAR", "goals": 4},
+                "venue": "PNC Arena",
+                "attendance": 18680,
+                "date": "2024-01-15",
+                "start_time": "7:00 PM",
+                "end_time": "9:30 PM",
+                "goals": [{"goal_number": 1, "period": 1}],
+                "penalties": [],
+                "referees": ["Chris Rooney"],
+                "linesmen": ["Trent Knorr"],
+            }
+        ]
+        result = await downloader.persist(mock_db, summaries)
+        assert result == 1
+        mock_db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persist_skips_missing_ids(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist skips entries without game_id or season_id."""
+        downloader = GameSummaryDownloader(html_config)
+        summaries: list[dict[str, Any]] = [
+            {"game_id": None, "season_id": 20242025},
+            {"game_id": 2024020500, "season_id": None},
+            {"away_team": {"abbrev": "NYI"}},  # Missing both
+        ]
+        result = await downloader.persist(mock_db, summaries)
+        assert result == 0
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persist_multiple_summaries(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist multiple game summaries."""
+        downloader = GameSummaryDownloader(html_config)
+        summaries = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "away_team": {"abbrev": "NYI"},
+                "home_team": {"abbrev": "CAR"},
+            },
+            {
+                "game_id": 2024020501,
+                "season_id": 20242025,
+                "away_team": {"abbrev": "BOS"},
+                "home_team": {"abbrev": "TOR"},
+            },
+        ]
+        result = await downloader.persist(mock_db, summaries)
+        assert result == 2
+        assert mock_db.execute.call_count == 2
+
+
+class TestEventSummaryPersist:
+    """Tests for EventSummaryDownloader.persist()."""
+
+    @pytest.mark.asyncio
+    async def test_persist_empty_list(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist with empty list returns 0."""
+        downloader = EventSummaryDownloader(html_config)
+        result = await downloader.persist(mock_db, [])
+        assert result == 0
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persist_single_summary(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist a single event summary."""
+        downloader = EventSummaryDownloader(html_config)
+        summaries = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "away_team": {
+                    "abbrev": "NYI",
+                    "players": [{"number": 20, "name": "S.AHO", "goals": 2}],
+                    "goalies": [],
+                    "totals": {"g": 2, "a": 3},
+                },
+                "home_team": {
+                    "abbrev": "CAR",
+                    "players": [],
+                    "goalies": [],
+                    "totals": {},
+                },
+            }
+        ]
+        result = await downloader.persist(mock_db, summaries)
+        assert result == 1
+        mock_db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persist_serializes_json(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist correctly serializes players to JSON."""
+        downloader = EventSummaryDownloader(html_config)
+        summaries = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "away_team": {
+                    "abbrev": "NYI",
+                    "players": [{"number": 20, "name": "S.AHO"}],
+                    "goalies": [{"number": 30, "name": "F.ANDERSEN"}],
+                    "totals": {"g": 2},
+                },
+                "home_team": {
+                    "abbrev": "CAR",
+                    "players": [],
+                    "goalies": [],
+                    "totals": {},
+                },
+            }
+        ]
+        result = await downloader.persist(mock_db, summaries)
+        assert result == 1
+        # Check that JSON strings were passed (not dicts)
+        call_args = mock_db.execute.call_args
+        assert call_args is not None
+        # Positional args after the SQL query:
+        # args[0]=SQL, [1]=game_id, [2]=season_id, [3]=away_abbrev, [4]=home_abbrev,
+        # [5]=away_skaters, [6]=home_skaters, [7]=away_goalies, [8]=home_goalies,
+        # [9]=away_totals, [10]=home_totals
+        args = call_args[0]
+        assert isinstance(args[5], str)  # away_skaters JSON string
+        assert '"number": 20' in args[5]
+
+
+class TestTimeOnIcePersist:
+    """Tests for TimeOnIceDownloader.persist()."""
+
+    @pytest.mark.asyncio
+    async def test_persist_empty_list(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist with empty list returns 0."""
+        downloader = TimeOnIceDownloader(html_config, side="home")
+        result = await downloader.persist(mock_db, [])
+        assert result == 0
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persist_single_toi(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist a single TOI record."""
+        downloader = TimeOnIceDownloader(html_config, side="home")
+        toi_data = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "side": "home",
+                "team_abbrev": "CAR",
+                "players": [
+                    {"number": 20, "name": "S.AHO", "toi_total": "22:30"},
+                ],
+            }
+        ]
+        result = await downloader.persist(mock_db, toi_data)
+        assert result == 1
+        mock_db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persist_requires_side(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist skips entries without side."""
+        downloader = TimeOnIceDownloader(html_config, side="home")
+        toi_data = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                # Missing side
+                "team_abbrev": "CAR",
+                "players": [],
+            }
+        ]
+        result = await downloader.persist(mock_db, toi_data)
+        assert result == 0
+        mock_db.execute.assert_not_called()
+
+
+class TestFaceoffSummaryPersist:
+    """Tests for FaceoffSummaryDownloader.persist()."""
+
+    @pytest.mark.asyncio
+    async def test_persist_empty_list(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist with empty list returns 0."""
+        downloader = FaceoffSummaryDownloader(html_config)
+        result = await downloader.persist(mock_db, [])
+        assert result == 0
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persist_single_summary(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist a single faceoff summary."""
+        downloader = FaceoffSummaryDownloader(html_config)
+        summaries = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "away_team": {
+                    "abbrev": "NYI",
+                    "by_period": [],
+                    "by_strength": [],
+                    "players": [],
+                },
+                "home_team": {
+                    "abbrev": "CAR",
+                    "by_period": [],
+                    "by_strength": [],
+                    "players": [],
+                },
+            }
+        ]
+        result = await downloader.persist(mock_db, summaries)
+        assert result == 1
+        mock_db.execute.assert_called_once()
+
+
+class TestShotSummaryPersist:
+    """Tests for ShotSummaryDownloader.persist()."""
+
+    @pytest.mark.asyncio
+    async def test_persist_empty_list(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist with empty list returns 0."""
+        downloader = ShotSummaryDownloader(html_config)
+        result = await downloader.persist(mock_db, [])
+        assert result == 0
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persist_single_summary(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist a single shot summary."""
+        downloader = ShotSummaryDownloader(html_config)
+        summaries = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "away_team": {
+                    "abbrev": "NYI",
+                    "periods": [{"period": "1", "total": {"goals": 0, "shots": 12}}],
+                    "players": [{"number": 13, "name": "M.BARZAL", "total_shots": 5}],
+                },
+                "home_team": {
+                    "abbrev": "CAR",
+                    "periods": [],
+                    "players": [],
+                },
+            }
+        ]
+        result = await downloader.persist(mock_db, summaries)
+        assert result == 1
+        mock_db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persist_multiple_summaries(
+        self, mock_db: AsyncMock, html_config: HTMLDownloaderConfig
+    ) -> None:
+        """Persist multiple shot summaries."""
+        downloader = ShotSummaryDownloader(html_config)
+        summaries = [
+            {
+                "game_id": 2024020500,
+                "season_id": 20242025,
+                "away_team": {"abbrev": "NYI", "periods": [], "players": []},
+                "home_team": {"abbrev": "CAR", "periods": [], "players": []},
+            },
+            {
+                "game_id": 2024020501,
+                "season_id": 20242025,
+                "away_team": {"abbrev": "BOS", "periods": [], "players": []},
+                "home_team": {"abbrev": "TOR", "periods": [], "players": []},
+            },
+        ]
+        result = await downloader.persist(mock_db, summaries)
+        assert result == 2
+        assert mock_db.execute.call_count == 2


### PR DESCRIPTION
## Summary

- Add database persistence for all 5 HTML report downloaders (GS, ES, TH/TV, FS, SS)
- Create migration 023 with tables for storing parsed HTML data as JSONB
- Integrate HTML downloads into viewer DownloadService
- Add 15 unit tests for persist() methods

## Changes

### Database (migration 023)
- `html_game_summary`: Goals, penalties, referees from Game Summary (GS) reports
- `html_event_summary`: Player stats from Event Summary (ES) reports  
- `html_time_on_ice`: Shift data from Time on Ice (TH/TV) reports
- `html_faceoff_summary`: Faceoff stats from Faceoff Summary (FS) reports
- `html_shot_summary`: Shot data from Shot Summary (SS) reports

### Downloaders
- Add `persist()` method to all 5 HTML downloaders
- Each method serializes nested structures to JSONB
- Uses INSERT...ON CONFLICT for upsert semantics

### DownloadService
- Add source IDs 8-12 for HTML sources
- Implement `_run_html_report_download()` for game-based HTML downloads
- Special handling for TimeOnIce (downloads both home and away reports)

## Test plan

- [x] Unit tests for all persist() methods (15 tests)
- [x] Test empty list handling
- [x] Test JSON serialization
- [x] Test missing ID validation
- [ ] Integration test with viewer download UI

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)