### PR TITLE
feat(viewer): Add QuantHockey viewer integration

### DIFF
--- a/migrations/023_quanthockey.sql
+++ b/migrations/023_quanthockey.sql
@@ -1,0 +1,240 @@
+-- Migration: 023_quanthockey.sql
+-- Description: Tables for QuantHockey player statistics
+-- Author: Claude Code
+-- Date: 2025-12-22
+-- Issue: #238
+
+-- This migration creates tables for storing:
+-- 1. QuantHockey player season statistics (51 fields)
+-- 2. Daily snapshots for tracking stat changes over time
+
+-- =============================================================================
+-- QuantHockey Player Season Statistics
+-- =============================================================================
+
+-- Player season stats: comprehensive 51-field statistics from QuantHockey
+CREATE TABLE IF NOT EXISTS qh_player_season_stats (
+    id SERIAL PRIMARY KEY,
+    season_id INTEGER NOT NULL REFERENCES seasons(season_id),
+    snapshot_date DATE NOT NULL,
+    fetched_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    -- Core Identity (11 fields)
+    rank INTEGER NOT NULL,
+    player_name VARCHAR(100) NOT NULL,
+    team_abbrev VARCHAR(10) NOT NULL,
+    age INTEGER,
+    position VARCHAR(5) NOT NULL,  -- C, LW, RW, D, G
+    games_played INTEGER NOT NULL DEFAULT 0,
+    goals INTEGER NOT NULL DEFAULT 0,
+    assists INTEGER NOT NULL DEFAULT 0,
+    points INTEGER NOT NULL DEFAULT 0,
+    pim INTEGER NOT NULL DEFAULT 0,  -- Penalty minutes
+    plus_minus INTEGER NOT NULL DEFAULT 0,
+
+    -- Player linking (optional - may not match NHL player)
+    player_id INTEGER REFERENCES players(player_id),
+
+    -- Time on Ice (4 fields) - in minutes per game
+    toi_avg DECIMAL(5, 2) DEFAULT 0,
+    toi_es DECIMAL(5, 2) DEFAULT 0,   -- Even-strength
+    toi_pp DECIMAL(5, 2) DEFAULT 0,   -- Power-play
+    toi_sh DECIMAL(5, 2) DEFAULT 0,   -- Short-handed
+
+    -- Goal Breakdowns (5 fields)
+    es_goals INTEGER DEFAULT 0,
+    pp_goals INTEGER DEFAULT 0,
+    sh_goals INTEGER DEFAULT 0,
+    gw_goals INTEGER DEFAULT 0,   -- Game-winning
+    ot_goals INTEGER DEFAULT 0,   -- Overtime
+
+    -- Assist Breakdowns (5 fields)
+    es_assists INTEGER DEFAULT 0,
+    pp_assists INTEGER DEFAULT 0,
+    sh_assists INTEGER DEFAULT 0,
+    gw_assists INTEGER DEFAULT 0,
+    ot_assists INTEGER DEFAULT 0,
+
+    -- Point Breakdowns (6 fields)
+    es_points INTEGER DEFAULT 0,
+    pp_points INTEGER DEFAULT 0,
+    sh_points INTEGER DEFAULT 0,
+    gw_points INTEGER DEFAULT 0,
+    ot_points INTEGER DEFAULT 0,
+    ppp_pct DECIMAL(5, 2) DEFAULT 0,  -- Power-play points percentage
+
+    -- Per-60 Rates - All Situations (3 fields)
+    goals_per_60 DECIMAL(5, 2) DEFAULT 0,
+    assists_per_60 DECIMAL(5, 2) DEFAULT 0,
+    points_per_60 DECIMAL(5, 2) DEFAULT 0,
+
+    -- Per-60 Rates - Even-Strength (3 fields)
+    es_goals_per_60 DECIMAL(5, 2) DEFAULT 0,
+    es_assists_per_60 DECIMAL(5, 2) DEFAULT 0,
+    es_points_per_60 DECIMAL(5, 2) DEFAULT 0,
+
+    -- Per-60 Rates - Power-Play (3 fields)
+    pp_goals_per_60 DECIMAL(5, 2) DEFAULT 0,
+    pp_assists_per_60 DECIMAL(5, 2) DEFAULT 0,
+    pp_points_per_60 DECIMAL(5, 2) DEFAULT 0,
+
+    -- Per-Game Rates (3 fields)
+    goals_per_game DECIMAL(5, 3) DEFAULT 0,
+    assists_per_game DECIMAL(5, 3) DEFAULT 0,
+    points_per_game DECIMAL(5, 3) DEFAULT 0,
+
+    -- Shooting Statistics (2 fields)
+    shots_on_goal INTEGER DEFAULT 0,
+    shooting_pct DECIMAL(5, 2) DEFAULT 0,
+
+    -- Physical Play (2 fields)
+    hits INTEGER DEFAULT 0,
+    blocked_shots INTEGER DEFAULT 0,
+
+    -- Faceoff Statistics (3 fields)
+    faceoffs_won INTEGER DEFAULT 0,
+    faceoffs_lost INTEGER DEFAULT 0,
+    faceoff_pct DECIMAL(5, 2) DEFAULT 0,
+
+    -- Additional Metadata (1 field)
+    nationality VARCHAR(10),
+
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+    -- Unique: one entry per player per season per snapshot date
+    UNIQUE(season_id, snapshot_date, player_name, team_abbrev)
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_qh_stats_season ON qh_player_season_stats(season_id);
+CREATE INDEX IF NOT EXISTS idx_qh_stats_date ON qh_player_season_stats(snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_qh_stats_player_name ON qh_player_season_stats(player_name);
+CREATE INDEX IF NOT EXISTS idx_qh_stats_team ON qh_player_season_stats(team_abbrev);
+CREATE INDEX IF NOT EXISTS idx_qh_stats_position ON qh_player_season_stats(position);
+CREATE INDEX IF NOT EXISTS idx_qh_stats_player ON qh_player_season_stats(player_id) WHERE player_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_qh_stats_season_date ON qh_player_season_stats(season_id, snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_qh_stats_points ON qh_player_season_stats(season_id, points DESC);
+CREATE INDEX IF NOT EXISTS idx_qh_stats_goals ON qh_player_season_stats(season_id, goals DESC);
+
+-- Scoring leaders index for quick leaderboard queries
+CREATE INDEX IF NOT EXISTS idx_qh_stats_leaders ON qh_player_season_stats(season_id, snapshot_date, points DESC, goals DESC);
+
+CREATE TRIGGER update_qh_player_season_stats_updated_at
+    BEFORE UPDATE ON qh_player_season_stats
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE qh_player_season_stats IS 'QuantHockey 51-field player season statistics with daily snapshots';
+COMMENT ON COLUMN qh_player_season_stats.rank IS 'Ranking in QuantHockey scoring leaders';
+COMMENT ON COLUMN qh_player_season_stats.snapshot_date IS 'Date this data was scraped (for tracking changes)';
+COMMENT ON COLUMN qh_player_season_stats.toi_avg IS 'Average TOI per game in minutes';
+COMMENT ON COLUMN qh_player_season_stats.ppp_pct IS 'Power-play points as percentage of total points';
+COMMENT ON COLUMN qh_player_season_stats.player_id IS 'NHL player_id if linked (nullable - QuantHockey names may differ)';
+
+
+-- =============================================================================
+-- Add Data Source for QuantHockey
+-- =============================================================================
+
+INSERT INTO data_sources (name, source_type, base_url, description, rate_limit_ms) VALUES
+    ('quanthockey_player_stats', 'quanthockey', 'https://www.quanthockey.com',
+     'QuantHockey player season statistics (51 fields)', 2000)
+ON CONFLICT (name) DO UPDATE SET
+    description = EXCLUDED.description,
+    rate_limit_ms = EXCLUDED.rate_limit_ms;
+
+
+-- =============================================================================
+-- View: Latest QuantHockey Stats per Player
+-- =============================================================================
+
+-- Get the most recent snapshot for each player in a season
+CREATE OR REPLACE VIEW v_qh_latest_stats AS
+SELECT DISTINCT ON (season_id, player_name, team_abbrev)
+    id,
+    season_id,
+    snapshot_date,
+    fetched_at,
+    rank,
+    player_name,
+    team_abbrev,
+    age,
+    position,
+    games_played,
+    goals,
+    assists,
+    points,
+    pim,
+    plus_minus,
+    player_id,
+    toi_avg,
+    toi_es,
+    toi_pp,
+    toi_sh,
+    es_goals,
+    pp_goals,
+    sh_goals,
+    gw_goals,
+    ot_goals,
+    es_assists,
+    pp_assists,
+    sh_assists,
+    gw_assists,
+    ot_assists,
+    es_points,
+    pp_points,
+    sh_points,
+    gw_points,
+    ot_points,
+    ppp_pct,
+    goals_per_60,
+    assists_per_60,
+    points_per_60,
+    es_goals_per_60,
+    es_assists_per_60,
+    es_points_per_60,
+    pp_goals_per_60,
+    pp_assists_per_60,
+    pp_points_per_60,
+    goals_per_game,
+    assists_per_game,
+    points_per_game,
+    shots_on_goal,
+    shooting_pct,
+    hits,
+    blocked_shots,
+    faceoffs_won,
+    faceoffs_lost,
+    faceoff_pct,
+    nationality
+FROM qh_player_season_stats
+ORDER BY season_id, player_name, team_abbrev, snapshot_date DESC;
+
+COMMENT ON VIEW v_qh_latest_stats IS 'Most recent QuantHockey snapshot for each player per season';
+
+
+-- =============================================================================
+-- View: QuantHockey Scoring Leaders
+-- =============================================================================
+
+CREATE OR REPLACE VIEW v_qh_scoring_leaders AS
+SELECT
+    season_id,
+    snapshot_date,
+    rank,
+    player_name,
+    team_abbrev,
+    position,
+    games_played,
+    goals,
+    assists,
+    points,
+    plus_minus,
+    points_per_game,
+    pp_points,
+    ppp_pct
+FROM v_qh_latest_stats
+ORDER BY season_id DESC, points DESC, goals DESC;
+
+COMMENT ON VIEW v_qh_scoring_leaders IS 'QuantHockey scoring leaders by season';

--- a/src/nhl_api/downloaders/sources/external/quanthockey/__init__.py
+++ b/src/nhl_api/downloaders/sources/external/quanthockey/__init__.py
@@ -11,11 +11,13 @@ from nhl_api.downloaders.sources.external.quanthockey.career_stats import (
     QuantHockeyCareerStatsDownloader,
 )
 from nhl_api.downloaders.sources.external.quanthockey.player_stats import (
+    QuantHockeyConfig,
     QuantHockeyPlayerStatsDownloader,
 )
 
 __all__ = [
     "CareerStatCategory",
     "QuantHockeyCareerStatsDownloader",
+    "QuantHockeyConfig",
     "QuantHockeyPlayerStatsDownloader",
 ]

--- a/src/nhl_api/viewer/main.py
+++ b/src/nhl_api/viewer/main.py
@@ -36,6 +36,7 @@ from nhl_api.viewer.routers import (
     entities,
     health,
     monitoring,
+    quanthockey,
     reconciliation,
     validation,
 )
@@ -124,6 +125,7 @@ def create_app() -> FastAPI:
     app.include_router(coverage.router, prefix=f"/api/{settings.api_version}")
     app.include_router(dailyfaceoff.router, prefix=f"/api/{settings.api_version}")
     app.include_router(downloads.router, prefix=f"/api/{settings.api_version}")
+    app.include_router(quanthockey.router, prefix=f"/api/{settings.api_version}")
     app.include_router(monitoring.router, prefix=f"/api/{settings.api_version}")
     app.include_router(entities.router, prefix=f"/api/{settings.api_version}")
     app.include_router(reconciliation.router, prefix=f"/api/{settings.api_version}")

--- a/src/nhl_api/viewer/routers/__init__.py
+++ b/src/nhl_api/viewer/routers/__init__.py
@@ -7,6 +7,7 @@ from nhl_api.viewer.routers import (
     entities,
     health,
     monitoring,
+    quanthockey,
     reconciliation,
     validation,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "entities",
     "health",
     "monitoring",
+    "quanthockey",
     "reconciliation",
     "validation",
 ]

--- a/src/nhl_api/viewer/routers/downloads.py
+++ b/src/nhl_api/viewer/routers/downloads.py
@@ -68,6 +68,8 @@ SOURCE_DISPLAY_NAMES = {
     "dailyfaceoff_penalty_kill": "Penalty Kill Units",
     "dailyfaceoff_injuries": "Injuries",
     "dailyfaceoff_starting_goalies": "Starting Goalies",
+    # QuantHockey sources
+    "quanthockey_player_stats": "Player Season Stats",
 }
 
 

--- a/src/nhl_api/viewer/routers/quanthockey.py
+++ b/src/nhl_api/viewer/routers/quanthockey.py
@@ -1,0 +1,535 @@
+"""QuantHockey player statistics endpoints.
+
+Provides access to QuantHockey 51-field player statistics including:
+- Season leaders (points, goals, assists)
+- Team player stats
+- Individual player stats
+- Historical snapshot data
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from nhl_api.services.db import DatabaseService
+from nhl_api.viewer.dependencies import get_db
+
+# Type alias for dependency injection
+DbDep = Annotated[DatabaseService, Depends(get_db)]
+
+router = APIRouter(prefix="/quanthockey", tags=["quanthockey"])
+
+
+# =============================================================================
+# Schemas
+# =============================================================================
+
+
+class PlayerStatsEntry(BaseModel):
+    """Comprehensive 51-field player statistics."""
+
+    # Core Identity
+    rank: int
+    player_name: str
+    team_abbrev: str
+    age: int | None
+    position: str
+    games_played: int
+    goals: int
+    assists: int
+    points: int
+    pim: int
+    plus_minus: int
+
+    # Time on Ice
+    toi_avg: float | None
+    toi_es: float | None
+    toi_pp: float | None
+    toi_sh: float | None
+
+    # Goal Breakdowns
+    es_goals: int | None
+    pp_goals: int | None
+    sh_goals: int | None
+    gw_goals: int | None
+    ot_goals: int | None
+
+    # Assist Breakdowns
+    es_assists: int | None
+    pp_assists: int | None
+    sh_assists: int | None
+    gw_assists: int | None
+    ot_assists: int | None
+
+    # Point Breakdowns
+    es_points: int | None
+    pp_points: int | None
+    sh_points: int | None
+    gw_points: int | None
+    ot_points: int | None
+    ppp_pct: float | None
+
+    # Per-60 Rates
+    goals_per_60: float | None
+    assists_per_60: float | None
+    points_per_60: float | None
+    es_goals_per_60: float | None
+    es_assists_per_60: float | None
+    es_points_per_60: float | None
+    pp_goals_per_60: float | None
+    pp_assists_per_60: float | None
+    pp_points_per_60: float | None
+
+    # Per-Game Rates
+    goals_per_game: float | None
+    assists_per_game: float | None
+    points_per_game: float | None
+
+    # Shooting
+    shots_on_goal: int | None
+    shooting_pct: float | None
+
+    # Physical
+    hits: int | None
+    blocked_shots: int | None
+
+    # Faceoffs
+    faceoffs_won: int | None
+    faceoffs_lost: int | None
+    faceoff_pct: float | None
+
+    # Metadata
+    nationality: str | None
+    player_id: int | None  # NHL player_id if linked
+
+
+class ScoringLeadersResponse(BaseModel):
+    """Scoring leaders for a season."""
+
+    season_id: int
+    snapshot_date: date
+    leaders: list[PlayerStatsEntry]
+    total_players: int
+
+
+class TeamStatsResponse(BaseModel):
+    """Player stats for a specific team."""
+
+    team_abbrev: str
+    season_id: int
+    snapshot_date: date
+    players: list[PlayerStatsEntry]
+    player_count: int
+
+
+class PlayerHistoryEntry(BaseModel):
+    """A single snapshot of player stats."""
+
+    snapshot_date: date
+    rank: int
+    games_played: int
+    goals: int
+    assists: int
+    points: int
+    plus_minus: int
+    points_per_game: float | None
+
+
+class PlayerHistoryResponse(BaseModel):
+    """Historical snapshots for a player."""
+
+    player_name: str
+    season_id: int
+    snapshots: list[PlayerHistoryEntry]
+    snapshot_count: int
+
+
+class AvailableSeasonsResponse(BaseModel):
+    """Available seasons with QuantHockey data."""
+
+    seasons: list[int]
+    latest_season: int | None
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+def _row_to_player_stats(row: dict[str, Any]) -> PlayerStatsEntry:
+    """Convert a database row to PlayerStatsEntry."""
+    return PlayerStatsEntry(
+        rank=row["rank"],
+        player_name=row["player_name"],
+        team_abbrev=row["team_abbrev"],
+        age=row["age"],
+        position=row["position"],
+        games_played=row["games_played"],
+        goals=row["goals"],
+        assists=row["assists"],
+        points=row["points"],
+        pim=row["pim"],
+        plus_minus=row["plus_minus"],
+        toi_avg=float(row["toi_avg"]) if row["toi_avg"] else None,
+        toi_es=float(row["toi_es"]) if row["toi_es"] else None,
+        toi_pp=float(row["toi_pp"]) if row["toi_pp"] else None,
+        toi_sh=float(row["toi_sh"]) if row["toi_sh"] else None,
+        es_goals=row["es_goals"],
+        pp_goals=row["pp_goals"],
+        sh_goals=row["sh_goals"],
+        gw_goals=row["gw_goals"],
+        ot_goals=row["ot_goals"],
+        es_assists=row["es_assists"],
+        pp_assists=row["pp_assists"],
+        sh_assists=row["sh_assists"],
+        gw_assists=row["gw_assists"],
+        ot_assists=row["ot_assists"],
+        es_points=row["es_points"],
+        pp_points=row["pp_points"],
+        sh_points=row["sh_points"],
+        gw_points=row["gw_points"],
+        ot_points=row["ot_points"],
+        ppp_pct=float(row["ppp_pct"]) if row["ppp_pct"] else None,
+        goals_per_60=float(row["goals_per_60"]) if row["goals_per_60"] else None,
+        assists_per_60=float(row["assists_per_60"]) if row["assists_per_60"] else None,
+        points_per_60=float(row["points_per_60"]) if row["points_per_60"] else None,
+        es_goals_per_60=float(row["es_goals_per_60"])
+        if row["es_goals_per_60"]
+        else None,
+        es_assists_per_60=float(row["es_assists_per_60"])
+        if row["es_assists_per_60"]
+        else None,
+        es_points_per_60=float(row["es_points_per_60"])
+        if row["es_points_per_60"]
+        else None,
+        pp_goals_per_60=float(row["pp_goals_per_60"])
+        if row["pp_goals_per_60"]
+        else None,
+        pp_assists_per_60=float(row["pp_assists_per_60"])
+        if row["pp_assists_per_60"]
+        else None,
+        pp_points_per_60=float(row["pp_points_per_60"])
+        if row["pp_points_per_60"]
+        else None,
+        goals_per_game=float(row["goals_per_game"]) if row["goals_per_game"] else None,
+        assists_per_game=float(row["assists_per_game"])
+        if row["assists_per_game"]
+        else None,
+        points_per_game=float(row["points_per_game"])
+        if row["points_per_game"]
+        else None,
+        shots_on_goal=row["shots_on_goal"],
+        shooting_pct=float(row["shooting_pct"]) if row["shooting_pct"] else None,
+        hits=row["hits"],
+        blocked_shots=row["blocked_shots"],
+        faceoffs_won=row["faceoffs_won"],
+        faceoffs_lost=row["faceoffs_lost"],
+        faceoff_pct=float(row["faceoff_pct"]) if row["faceoff_pct"] else None,
+        nationality=row["nationality"],
+        player_id=row["player_id"],
+    )
+
+
+# =============================================================================
+# Scoring Leaders
+# =============================================================================
+
+
+@router.get(
+    "/leaders",
+    response_model=ScoringLeadersResponse,
+    summary="Get Scoring Leaders",
+    description="Get top scoring players for a season",
+)
+async def get_scoring_leaders(
+    db: DbDep,
+    season_id: Annotated[
+        int | None, Query(description="Season ID (defaults to current)")
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=500, description="Max players")] = 50,
+    position: Annotated[
+        str | None, Query(description="Filter by position (C, LW, RW, D)")
+    ] = None,
+    sort_by: Annotated[
+        str,
+        Query(description="Sort field: points, goals, assists, plus_minus"),
+    ] = "points",
+) -> ScoringLeadersResponse:
+    """Get top scoring players for a season."""
+    # Get latest season if not specified
+    if season_id is None:
+        season_row = await db.fetchrow(
+            """
+            SELECT MAX(season_id) as latest_season
+            FROM qh_player_season_stats
+            """
+        )
+        if not season_row or not season_row["latest_season"]:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No QuantHockey data available",
+            )
+        season_id = season_row["latest_season"]
+
+    # Get latest snapshot date for this season
+    snapshot_row = await db.fetchrow(
+        """
+        SELECT MAX(snapshot_date) as latest_date
+        FROM qh_player_season_stats
+        WHERE season_id = $1
+        """,
+        season_id,
+    )
+    if not snapshot_row or not snapshot_row["latest_date"]:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No QuantHockey data found for season {season_id}",
+        )
+    snapshot_date = snapshot_row["latest_date"]
+
+    # Validate sort_by
+    valid_sorts = {"points", "goals", "assists", "plus_minus"}
+    if sort_by not in valid_sorts:
+        sort_by = "points"
+
+    # Build query
+    query = """
+        SELECT *
+        FROM qh_player_season_stats
+        WHERE season_id = $1 AND snapshot_date = $2
+    """
+    params: list[Any] = [season_id, snapshot_date]
+
+    if position:
+        query += " AND position = $3"
+        params.append(position.upper())
+
+    query += f" ORDER BY {sort_by} DESC LIMIT ${len(params) + 1}"
+    params.append(limit)
+
+    rows = await db.fetch(query, *params)
+
+    leaders = [_row_to_player_stats(row) for row in rows]
+
+    # Get total count
+    count_query = """
+        SELECT COUNT(*) as total
+        FROM qh_player_season_stats
+        WHERE season_id = $1 AND snapshot_date = $2
+    """
+    count_params: list[Any] = [season_id, snapshot_date]
+    if position:
+        count_query += " AND position = $3"
+        count_params.append(position.upper())
+
+    count_row = await db.fetchrow(count_query, *count_params)
+    total = count_row["total"] if count_row else 0
+
+    return ScoringLeadersResponse(
+        season_id=season_id,
+        snapshot_date=snapshot_date,
+        leaders=leaders,
+        total_players=total,
+    )
+
+
+# =============================================================================
+# Team Stats
+# =============================================================================
+
+
+@router.get(
+    "/teams/{team_abbrev}",
+    response_model=TeamStatsResponse,
+    summary="Get Team Player Stats",
+    description="Get all player stats for a specific team",
+)
+async def get_team_stats(
+    team_abbrev: str,
+    db: DbDep,
+    season_id: Annotated[
+        int | None, Query(description="Season ID (defaults to current)")
+    ] = None,
+) -> TeamStatsResponse:
+    """Get player stats for a specific team."""
+    team_abbrev = team_abbrev.upper()
+
+    # Get latest season if not specified
+    if season_id is None:
+        season_row = await db.fetchrow(
+            """
+            SELECT MAX(season_id) as latest_season
+            FROM qh_player_season_stats
+            WHERE team_abbrev = $1
+            """,
+            team_abbrev,
+        )
+        if not season_row or not season_row["latest_season"]:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No QuantHockey data found for team {team_abbrev}",
+            )
+        season_id = season_row["latest_season"]
+
+    # Get latest snapshot date
+    snapshot_row = await db.fetchrow(
+        """
+        SELECT MAX(snapshot_date) as latest_date
+        FROM qh_player_season_stats
+        WHERE season_id = $1 AND team_abbrev = $2
+        """,
+        season_id,
+        team_abbrev,
+    )
+    if not snapshot_row or not snapshot_row["latest_date"]:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No QuantHockey data found for team {team_abbrev} in season {season_id}",
+        )
+    snapshot_date = snapshot_row["latest_date"]
+
+    rows = await db.fetch(
+        """
+        SELECT *
+        FROM qh_player_season_stats
+        WHERE season_id = $1 AND team_abbrev = $2 AND snapshot_date = $3
+        ORDER BY points DESC
+        """,
+        season_id,
+        team_abbrev,
+        snapshot_date,
+    )
+
+    players = [_row_to_player_stats(row) for row in rows]
+
+    return TeamStatsResponse(
+        team_abbrev=team_abbrev,
+        season_id=season_id,
+        snapshot_date=snapshot_date,
+        players=players,
+        player_count=len(players),
+    )
+
+
+# =============================================================================
+# Player History
+# =============================================================================
+
+
+@router.get(
+    "/players/{player_name}/history",
+    response_model=PlayerHistoryResponse,
+    summary="Get Player History",
+    description="Get historical snapshots for a player's season",
+)
+async def get_player_history(
+    player_name: str,
+    db: DbDep,
+    season_id: Annotated[
+        int | None, Query(description="Season ID (defaults to current)")
+    ] = None,
+) -> PlayerHistoryResponse:
+    """Get historical stat snapshots for a player."""
+    # Get latest season if not specified
+    if season_id is None:
+        season_row = await db.fetchrow(
+            """
+            SELECT MAX(season_id) as latest_season
+            FROM qh_player_season_stats
+            WHERE player_name ILIKE $1
+            """,
+            f"%{player_name}%",
+        )
+        if not season_row or not season_row["latest_season"]:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No data found for player matching '{player_name}'",
+            )
+        season_id = season_row["latest_season"]
+
+    rows = await db.fetch(
+        """
+        SELECT snapshot_date, rank, games_played, goals, assists, points,
+               plus_minus, points_per_game
+        FROM qh_player_season_stats
+        WHERE season_id = $1 AND player_name ILIKE $2
+        ORDER BY snapshot_date DESC
+        """,
+        season_id,
+        f"%{player_name}%",
+    )
+
+    if not rows:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No data found for player matching '{player_name}' in season {season_id}",
+        )
+
+    # Get exact name from first row
+    exact_name_row = await db.fetchrow(
+        """
+        SELECT player_name
+        FROM qh_player_season_stats
+        WHERE season_id = $1 AND player_name ILIKE $2
+        LIMIT 1
+        """,
+        season_id,
+        f"%{player_name}%",
+    )
+    exact_name = exact_name_row["player_name"] if exact_name_row else player_name
+
+    snapshots = [
+        PlayerHistoryEntry(
+            snapshot_date=row["snapshot_date"],
+            rank=row["rank"],
+            games_played=row["games_played"],
+            goals=row["goals"],
+            assists=row["assists"],
+            points=row["points"],
+            plus_minus=row["plus_minus"],
+            points_per_game=float(row["points_per_game"])
+            if row["points_per_game"]
+            else None,
+        )
+        for row in rows
+    ]
+
+    return PlayerHistoryResponse(
+        player_name=exact_name,
+        season_id=season_id,
+        snapshots=snapshots,
+        snapshot_count=len(snapshots),
+    )
+
+
+# =============================================================================
+# Available Seasons
+# =============================================================================
+
+
+@router.get(
+    "/seasons",
+    response_model=AvailableSeasonsResponse,
+    summary="Get Available Seasons",
+    description="Get list of seasons with QuantHockey data",
+)
+async def get_available_seasons(db: DbDep) -> AvailableSeasonsResponse:
+    """Get list of seasons that have QuantHockey data."""
+    rows = await db.fetch(
+        """
+        SELECT DISTINCT season_id
+        FROM qh_player_season_stats
+        ORDER BY season_id DESC
+        """
+    )
+
+    seasons = [row["season_id"] for row in rows]
+
+    return AvailableSeasonsResponse(
+        seasons=seasons,
+        latest_season=seasons[0] if seasons else None,
+    )


### PR DESCRIPTION
## Summary

- Add database schema for QuantHockey 51-field player statistics (migrations/023_quanthockey.sql)
- Implement persist() method in PlayerStatsDownloader for database upserts
- Add QuantHockey download flow to DownloadService
- Create API endpoints for scoring leaders, team stats, player history
- Integrate QuantHockey as a download source option in the viewer

## Test plan

- [x] Unit tests pass for QuantHockey downloader (31 tests)
- [x] Viewer unit tests pass (125 tests)
- [x] mypy type checks pass
- [ ] Run migration on database
- [ ] Test download from viewer UI
- [ ] Verify API endpoints return data

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)