### PR TITLE
feat(viewer): Add validation runs dashboard UI (#230)

### DIFF
--- a/viewer-frontend/src/App.tsx
+++ b/viewer-frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { GameDetail } from '@/pages/GameDetail'
 import { Teams } from '@/pages/Teams'
 import { TeamDetail } from '@/pages/TeamDetail'
 import { Validation } from '@/pages/Validation'
+import { ValidationRunDetail } from '@/pages/ValidationRunDetail'
 import { GameReconciliation } from '@/pages/GameReconciliation'
 import { Lineups } from '@/pages/Lineups'
 import { Injuries } from '@/pages/Injuries'
@@ -34,6 +35,7 @@ function App() {
             <Route path="lineups" element={<Lineups />} />
             <Route path="injuries" element={<Injuries />} />
             <Route path="validation" element={<Validation />} />
+            <Route path="validation/run/:runId" element={<ValidationRunDetail />} />
             <Route path="validation/game/:gameId" element={<GameReconciliation />} />
             <Route path="help" element={<Help />} />
           </Route>

--- a/viewer-frontend/src/hooks/useValidation.ts
+++ b/viewer-frontend/src/hooks/useValidation.ts
@@ -1,0 +1,279 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+
+// =============================================================================
+// Types - Based on backend Pydantic schemas
+// =============================================================================
+
+interface ValidationRule {
+  rule_id: number
+  name: string
+  description: string | null
+  category: string
+  severity: string
+  is_active: boolean
+  config: Record<string, unknown> | null
+}
+
+interface ValidationRulesResponse {
+  rules: ValidationRule[]
+  total: number
+}
+
+interface ValidationResult {
+  result_id: number
+  rule_id: number
+  rule_name: string
+  game_id: number | null
+  passed: boolean
+  severity: string | null
+  message: string | null
+  details: Record<string, unknown> | null
+  source_values: Record<string, unknown> | null
+  created_at: string
+}
+
+interface ValidationRunSummary {
+  run_id: number
+  season_id: number | null
+  started_at: string
+  completed_at: string | null
+  status: 'running' | 'completed' | 'failed'
+  rules_checked: number
+  total_passed: number
+  total_failed: number
+  total_warnings: number
+}
+
+interface ValidationRunDetail extends ValidationRunSummary {
+  results: ValidationResult[]
+  metadata: Record<string, unknown> | null
+}
+
+interface ValidationRunsResponse {
+  runs: ValidationRunSummary[]
+  total: number
+  page: number
+  page_size: number
+  pages: number
+}
+
+interface QualityScore {
+  score_id: number
+  season_id: number
+  game_id: number | null
+  entity_type: 'season' | 'game'
+  entity_id: string
+  completeness_score: number | null
+  accuracy_score: number | null
+  consistency_score: number | null
+  timeliness_score: number | null
+  overall_score: number | null
+  total_checks: number
+  passed_checks: number
+  failed_checks: number
+  warning_checks: number
+  calculated_at: string
+}
+
+interface QualityScoresResponse {
+  scores: QualityScore[]
+  total: number
+  page: number
+  page_size: number
+  pages: number
+}
+
+interface DiscrepancySummary {
+  discrepancy_id: number
+  rule_id: number
+  rule_name: string
+  game_id: number | null
+  season_id: number | null
+  entity_type: string | null
+  entity_id: string | null
+  field_name: string | null
+  source_a: string | null
+  source_b: string | null
+  resolution_status: 'open' | 'resolved' | 'ignored'
+  created_at: string
+}
+
+interface DiscrepancyDetail extends DiscrepancySummary {
+  source_a_value: string | null
+  source_b_value: string | null
+  resolution_notes: string | null
+  resolved_at: string | null
+  result_id: number | null
+}
+
+interface DiscrepanciesResponse {
+  discrepancies: DiscrepancySummary[]
+  total: number
+  page: number
+  page_size: number
+  pages: number
+}
+
+// =============================================================================
+// Hooks
+// =============================================================================
+
+/**
+ * Fetch validation rules list.
+ */
+export function useValidationRules(options?: {
+  category?: string
+  isActive?: boolean
+}) {
+  const { category, isActive } = options ?? {}
+
+  return useQuery({
+    queryKey: ['validation', 'rules', category, isActive],
+    queryFn: () => {
+      const params: Record<string, string> = {}
+      if (category) params.category = category
+      if (isActive !== undefined) params.is_active = String(isActive)
+      return api.get<ValidationRulesResponse>('/validation/rules', params)
+    },
+    staleTime: 60000, // Rules change rarely
+  })
+}
+
+/**
+ * Fetch paginated list of validation runs.
+ */
+export function useValidationRuns(options?: {
+  seasonId?: number
+  page?: number
+  pageSize?: number
+}) {
+  const { seasonId, page = 1, pageSize = 20 } = options ?? {}
+
+  return useQuery({
+    queryKey: ['validation', 'runs', seasonId, page, pageSize],
+    queryFn: () => {
+      const params: Record<string, string> = {
+        page: String(page),
+        page_size: String(pageSize),
+      }
+      if (seasonId) params.season_id = String(seasonId)
+      return api.get<ValidationRunsResponse>('/validation/runs', params)
+    },
+    staleTime: 10000, // Refresh more often for live status
+    refetchInterval: 30000, // Auto-refetch for running validations
+  })
+}
+
+/**
+ * Fetch detailed validation run with results.
+ */
+export function useValidationRun(runId: number) {
+  return useQuery({
+    queryKey: ['validation', 'run', runId],
+    queryFn: () => api.get<ValidationRunDetail>(`/validation/runs/${runId}`),
+    staleTime: 30000,
+    enabled: !!runId,
+  })
+}
+
+/**
+ * Fetch paginated quality scores.
+ */
+export function useQualityScores(options?: {
+  seasonId?: number
+  entityType?: 'season' | 'game'
+  page?: number
+  pageSize?: number
+}) {
+  const { seasonId, entityType, page = 1, pageSize = 20 } = options ?? {}
+
+  return useQuery({
+    queryKey: ['validation', 'scores', seasonId, entityType, page, pageSize],
+    queryFn: () => {
+      const params: Record<string, string> = {
+        page: String(page),
+        page_size: String(pageSize),
+      }
+      if (seasonId) params.season_id = String(seasonId)
+      if (entityType) params.entity_type = entityType
+      return api.get<QualityScoresResponse>('/validation/scores', params)
+    },
+    staleTime: 30000,
+  })
+}
+
+/**
+ * Fetch quality score for a specific entity.
+ */
+export function useEntityQualityScore(
+  entityType: 'season' | 'game',
+  entityId: string
+) {
+  return useQuery({
+    queryKey: ['validation', 'score', entityType, entityId],
+    queryFn: () =>
+      api.get<QualityScore>(`/validation/scores/${entityType}/${entityId}`),
+    staleTime: 60000,
+    enabled: !!entityType && !!entityId,
+  })
+}
+
+/**
+ * Fetch paginated discrepancies list.
+ */
+export function useDiscrepancies(options?: {
+  seasonId?: number
+  status?: 'open' | 'resolved' | 'ignored'
+  entityType?: string
+  page?: number
+  pageSize?: number
+}) {
+  const { seasonId, status, entityType, page = 1, pageSize = 20 } = options ?? {}
+
+  return useQuery({
+    queryKey: ['validation', 'discrepancies', seasonId, status, entityType, page, pageSize],
+    queryFn: () => {
+      const params: Record<string, string> = {
+        page: String(page),
+        page_size: String(pageSize),
+      }
+      if (seasonId) params.season_id = String(seasonId)
+      if (status) params.status = status
+      if (entityType) params.entity_type = entityType
+      return api.get<DiscrepanciesResponse>('/validation/discrepancies', params)
+    },
+    staleTime: 30000,
+  })
+}
+
+/**
+ * Fetch detailed discrepancy with source values.
+ */
+export function useDiscrepancy(discrepancyId: number) {
+  return useQuery({
+    queryKey: ['validation', 'discrepancy', discrepancyId],
+    queryFn: () =>
+      api.get<DiscrepancyDetail>(`/validation/discrepancies/${discrepancyId}`),
+    staleTime: 60000,
+    enabled: !!discrepancyId,
+  })
+}
+
+// =============================================================================
+// Export Types
+// =============================================================================
+
+export type {
+  ValidationRule,
+  ValidationRulesResponse,
+  ValidationResult,
+  ValidationRunSummary,
+  ValidationRunDetail,
+  ValidationRunsResponse,
+  QualityScore,
+  QualityScoresResponse,
+  DiscrepancySummary,
+  DiscrepancyDetail,
+  DiscrepanciesResponse,
+}

--- a/viewer-frontend/src/pages/Validation.tsx
+++ b/viewer-frontend/src/pages/Validation.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   Select,
   SelectContent,
@@ -28,6 +29,11 @@ import {
   type DiscrepancyType,
 } from '@/hooks/useReconciliation'
 import {
+  useValidationRuns,
+  useDiscrepancies,
+  type ValidationRunSummary,
+} from '@/hooks/useValidation'
+import {
   CheckCircle2,
   XCircle,
   AlertTriangle,
@@ -38,6 +44,8 @@ import {
   TrendingUp,
   Clock,
   FileWarning,
+  ClipboardCheck,
+  ListChecks,
 } from 'lucide-react'
 
 // Available seasons - could be fetched from API in future
@@ -51,7 +59,9 @@ export function Validation() {
   const [seasonId, setSeasonId] = useState(20242025)
   const [discrepancyFilter, setDiscrepancyFilter] = useState<DiscrepancyType | 'all'>('all')
   const [page, setPage] = useState(1)
+  const [runsPage, setRunsPage] = useState(1)
 
+  // Reconciliation hooks
   const { data: dashboard, isLoading: dashboardLoading, error: dashboardError } = useReconciliationDashboard(seasonId)
   const { data: games, isLoading: gamesLoading } = useGameReconciliations(seasonId, {
     discrepancyType: discrepancyFilter === 'all' ? undefined : discrepancyFilter,
@@ -60,6 +70,19 @@ export function Validation() {
   })
   const triggerReconciliation = useTriggerReconciliation()
   const exportReconciliation = useExportReconciliation()
+
+  // Validation runs hooks
+  const { data: validationRuns, isLoading: runsLoading } = useValidationRuns({
+    seasonId,
+    page: runsPage,
+    pageSize: 10,
+  })
+  const { data: discrepancies, isLoading: discrepanciesLoading } = useDiscrepancies({
+    seasonId,
+    status: 'open',
+    page: 1,
+    pageSize: 5,
+  })
 
   const handleRunReconciliation = async () => {
     try {
@@ -91,7 +114,35 @@ export function Validation() {
     }
   }
 
+  const getRunStatusBadge = (status: ValidationRunSummary['status']) => {
+    switch (status) {
+      case 'completed':
+        return <Badge variant="success">Completed</Badge>
+      case 'running':
+        return <Badge variant="warning">Running</Badge>
+      case 'failed':
+        return <Badge variant="error">Failed</Badge>
+      default:
+        return <Badge variant="secondary">{status}</Badge>
+    }
+  }
+
   const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr)
+    return date.toLocaleString()
+  }
+
+  const formatDuration = (startedAt: string, completedAt: string | null) => {
+    if (!completedAt) return 'In progress...'
+    const start = new Date(startedAt).getTime()
+    const end = new Date(completedAt).getTime()
+    const durationMs = end - start
+    if (durationMs < 1000) return `${durationMs}ms`
+    if (durationMs < 60000) return `${(durationMs / 1000).toFixed(1)}s`
+    return `${(durationMs / 60000).toFixed(1)}m`
+  }
 
   return (
     <div className="space-y-6">
@@ -146,271 +197,535 @@ export function Validation() {
         </Card>
       )}
 
-      {/* Quality Score Card */}
-      <Card className="bg-gradient-to-br from-primary/5 to-primary/10">
-        <CardContent className="pt-6">
-          {dashboardLoading ? (
-            <div className="flex items-center justify-center h-24">
-              <Skeleton className="h-16 w-32" />
-            </div>
-          ) : dashboard ? (
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-sm font-medium text-muted-foreground mb-1">
-                  Data Quality Score
-                </div>
-                <div className="flex items-baseline gap-3">
-                  <span className="text-5xl font-bold">
-                    {dashboard.quality_score.toFixed(1)}%
-                  </span>
-                  {getStatusBadge(dashboard.quality_score / 100)}
-                </div>
-                <div className="text-sm text-muted-foreground mt-2">
-                  {dashboard.summary.total_games} games analyzed
-                  {dashboard.last_run && (
-                    <> • Last run: {new Date(dashboard.last_run).toLocaleString()}</>
-                  )}
-                </div>
-              </div>
-              <Target className="h-16 w-16 text-primary/20" />
-            </div>
-          ) : null}
-        </CardContent>
-      </Card>
+      {/* Tabs */}
+      <Tabs defaultValue="reconciliation" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="reconciliation" className="gap-2">
+            <ClipboardCheck className="h-4 w-4" />
+            Reconciliation
+          </TabsTrigger>
+          <TabsTrigger value="validation-runs" className="gap-2">
+            <ListChecks className="h-4 w-4" />
+            Validation Runs
+          </TabsTrigger>
+        </TabsList>
 
-      {/* Category Cards Grid */}
-      <div className="grid gap-4 md:grid-cols-3">
-        {/* Goal Reconciliation */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <TrendingUp className="h-4 w-4 text-muted-foreground" />
-              Goal Reconciliation
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {dashboardLoading ? (
-              <Skeleton className="h-8 w-full" />
-            ) : dashboard ? (
-              <div className="space-y-2">
+        {/* Reconciliation Tab */}
+        <TabsContent value="reconciliation" className="space-y-6">
+          {/* Quality Score Card */}
+          <Card className="bg-gradient-to-br from-primary/5 to-primary/10">
+            <CardContent className="pt-6">
+              {dashboardLoading ? (
+                <div className="flex items-center justify-center h-24">
+                  <Skeleton className="h-16 w-32" />
+                </div>
+              ) : dashboard ? (
                 <div className="flex items-center justify-between">
-                  <span className="text-2xl font-bold">
-                    {formatPercent(dashboard.summary.goal_reconciliation_rate)}
-                  </span>
-                  {dashboard.summary.goal_reconciliation_rate >= 0.95 ? (
-                    <CheckCircle2 className="h-5 w-5 text-green-500" />
-                  ) : (
-                    <XCircle className="h-5 w-5 text-yellow-500" />
-                  )}
+                  <div>
+                    <div className="text-sm font-medium text-muted-foreground mb-1">
+                      Data Quality Score
+                    </div>
+                    <div className="flex items-baseline gap-3">
+                      <span className="text-5xl font-bold">
+                        {dashboard.quality_score.toFixed(1)}%
+                      </span>
+                      {getStatusBadge(dashboard.quality_score / 100)}
+                    </div>
+                    <div className="text-sm text-muted-foreground mt-2">
+                      {dashboard.summary.total_games} games analyzed
+                      {dashboard.last_run && (
+                        <> • Last run: {new Date(dashboard.last_run).toLocaleString()}</>
+                      )}
+                    </div>
+                  </div>
+                  <Target className="h-16 w-16 text-primary/20" />
                 </div>
-                <Progress value={dashboard.summary.goal_reconciliation_rate * 100} />
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
+              ) : null}
+            </CardContent>
+          </Card>
 
-        {/* Penalty Reconciliation */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <Clock className="h-4 w-4 text-muted-foreground" />
-              Penalty Reconciliation
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {dashboardLoading ? (
-              <Skeleton className="h-8 w-full" />
-            ) : dashboard ? (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-2xl font-bold">
-                    {formatPercent(dashboard.summary.penalty_reconciliation_rate)}
-                  </span>
-                  {dashboard.summary.penalty_reconciliation_rate >= 0.95 ? (
-                    <CheckCircle2 className="h-5 w-5 text-green-500" />
-                  ) : (
-                    <XCircle className="h-5 w-5 text-yellow-500" />
-                  )}
-                </div>
-                <Progress value={dashboard.summary.penalty_reconciliation_rate * 100} />
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
+          {/* Category Cards Grid */}
+          <div className="grid gap-4 md:grid-cols-3">
+            {/* Goal Reconciliation */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <TrendingUp className="h-4 w-4 text-muted-foreground" />
+                  Goal Reconciliation
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {dashboardLoading ? (
+                  <Skeleton className="h-8 w-full" />
+                ) : dashboard ? (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-2xl font-bold">
+                        {formatPercent(dashboard.summary.goal_reconciliation_rate)}
+                      </span>
+                      {dashboard.summary.goal_reconciliation_rate >= 0.95 ? (
+                        <CheckCircle2 className="h-5 w-5 text-green-500" />
+                      ) : (
+                        <XCircle className="h-5 w-5 text-yellow-500" />
+                      )}
+                    </div>
+                    <Progress value={dashboard.summary.goal_reconciliation_rate * 100} />
+                  </div>
+                ) : null}
+              </CardContent>
+            </Card>
 
-        {/* TOI Reconciliation */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <FileWarning className="h-4 w-4 text-muted-foreground" />
-              TOI Reconciliation
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {dashboardLoading ? (
-              <Skeleton className="h-8 w-full" />
-            ) : dashboard ? (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-2xl font-bold">
-                    {formatPercent(dashboard.summary.toi_reconciliation_rate)}
-                  </span>
-                  {dashboard.summary.toi_reconciliation_rate >= 0.95 ? (
-                    <CheckCircle2 className="h-5 w-5 text-green-500" />
-                  ) : (
-                    <XCircle className="h-5 w-5 text-yellow-500" />
-                  )}
-                </div>
-                <Progress value={dashboard.summary.toi_reconciliation_rate * 100} />
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
-      </div>
+            {/* Penalty Reconciliation */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <Clock className="h-4 w-4 text-muted-foreground" />
+                  Penalty Reconciliation
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {dashboardLoading ? (
+                  <Skeleton className="h-8 w-full" />
+                ) : dashboard ? (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-2xl font-bold">
+                        {formatPercent(dashboard.summary.penalty_reconciliation_rate)}
+                      </span>
+                      {dashboard.summary.penalty_reconciliation_rate >= 0.95 ? (
+                        <CheckCircle2 className="h-5 w-5 text-green-500" />
+                      ) : (
+                        <XCircle className="h-5 w-5 text-yellow-500" />
+                      )}
+                    </div>
+                    <Progress value={dashboard.summary.penalty_reconciliation_rate * 100} />
+                  </div>
+                ) : null}
+              </CardContent>
+            </Card>
 
-      {/* Problem Games Table */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div>
-              <CardTitle>Games with Discrepancies</CardTitle>
-              <CardDescription>
-                Games where data sources don't match
-              </CardDescription>
-            </div>
-            <div className="flex items-center gap-2">
-              <Select
-                value={discrepancyFilter}
-                onValueChange={(v) => {
-                  setDiscrepancyFilter(v as DiscrepancyType | 'all')
-                  setPage(1)
-                }}
-              >
-                <SelectTrigger className="w-36">
-                  <SelectValue placeholder="Filter by type" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Types</SelectItem>
-                  <SelectItem value="goal">Goals</SelectItem>
-                  <SelectItem value="penalty">Penalties</SelectItem>
-                  <SelectItem value="toi">TOI</SelectItem>
-                  <SelectItem value="shot">Shots</SelectItem>
-                </SelectContent>
-              </Select>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleExport('csv')}
-                disabled={exportReconciliation.isPending}
-              >
-                <Download className="mr-2 h-4 w-4" />
-                Export CSV
-              </Button>
-            </div>
+            {/* TOI Reconciliation */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <FileWarning className="h-4 w-4 text-muted-foreground" />
+                  TOI Reconciliation
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {dashboardLoading ? (
+                  <Skeleton className="h-8 w-full" />
+                ) : dashboard ? (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-2xl font-bold">
+                        {formatPercent(dashboard.summary.toi_reconciliation_rate)}
+                      </span>
+                      {dashboard.summary.toi_reconciliation_rate >= 0.95 ? (
+                        <CheckCircle2 className="h-5 w-5 text-green-500" />
+                      ) : (
+                        <XCircle className="h-5 w-5 text-yellow-500" />
+                      )}
+                    </div>
+                    <Progress value={dashboard.summary.toi_reconciliation_rate * 100} />
+                  </div>
+                ) : null}
+              </CardContent>
+            </Card>
           </div>
-        </CardHeader>
-        <CardContent>
-          {gamesLoading ? (
-            <div className="space-y-2">
-              <Skeleton className="h-12 w-full" />
-              <Skeleton className="h-12 w-full" />
-              <Skeleton className="h-12 w-full" />
-            </div>
-          ) : !games?.games.length ? (
-            <div className="flex h-32 items-center justify-center text-muted-foreground">
-              <div className="text-center">
-                <CheckCircle2 className="h-8 w-8 mx-auto mb-2 text-green-500" />
-                <p>No discrepancies found</p>
-              </div>
-            </div>
-          ) : (
-            <>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Game</TableHead>
-                    <TableHead>Date</TableHead>
-                    <TableHead className="text-center">Passed</TableHead>
-                    <TableHead className="text-center">Failed</TableHead>
-                    <TableHead>Discrepancies</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {games.games.map((game) => (
-                    <TableRow key={game.game_id}>
-                      <TableCell className="font-medium">
-                        {game.away_team} @ {game.home_team}
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {new Date(game.game_date).toLocaleDateString()}
-                      </TableCell>
-                      <TableCell className="text-center">
-                        <Badge variant="outline" className="text-green-600">
-                          {game.checks_passed}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-center">
-                        <Badge variant="outline" className="text-red-600">
-                          {game.checks_failed}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex flex-wrap gap-1">
-                          {game.discrepancies.slice(0, 3).map((d, i) => (
-                            <Badge key={i} variant="secondary" className="text-xs">
-                              {d.rule_name}
-                            </Badge>
-                          ))}
-                          {game.discrepancies.length > 3 && (
-                            <Badge variant="secondary" className="text-xs">
-                              +{game.discrepancies.length - 3} more
-                            </Badge>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <Button variant="ghost" size="sm" asChild>
-                          <Link to={`/validation/game/${game.game_id}`}>
-                            View Details
-                          </Link>
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
 
-              {/* Pagination */}
-              {games.pages > 1 && (
-                <div className="flex items-center justify-between mt-4">
-                  <div className="text-sm text-muted-foreground">
-                    Page {games.page} of {games.pages} ({games.total} games)
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setPage((p) => Math.max(1, p - 1))}
-                      disabled={page === 1}
-                    >
-                      Previous
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setPage((p) => Math.min(games.pages, p + 1))}
-                      disabled={page === games.pages}
-                    >
-                      Next
-                    </Button>
+          {/* Problem Games Table */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>Games with Discrepancies</CardTitle>
+                  <CardDescription>
+                    Games where data sources don't match
+                  </CardDescription>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={discrepancyFilter}
+                    onValueChange={(v) => {
+                      setDiscrepancyFilter(v as DiscrepancyType | 'all')
+                      setPage(1)
+                    }}
+                  >
+                    <SelectTrigger className="w-36">
+                      <SelectValue placeholder="Filter by type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Types</SelectItem>
+                      <SelectItem value="goal">Goals</SelectItem>
+                      <SelectItem value="penalty">Penalties</SelectItem>
+                      <SelectItem value="toi">TOI</SelectItem>
+                      <SelectItem value="shot">Shots</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleExport('csv')}
+                    disabled={exportReconciliation.isPending}
+                  >
+                    <Download className="mr-2 h-4 w-4" />
+                    Export CSV
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {gamesLoading ? (
+                <div className="space-y-2">
+                  <Skeleton className="h-12 w-full" />
+                  <Skeleton className="h-12 w-full" />
+                  <Skeleton className="h-12 w-full" />
+                </div>
+              ) : !games?.games.length ? (
+                <div className="flex h-32 items-center justify-center text-muted-foreground">
+                  <div className="text-center">
+                    <CheckCircle2 className="h-8 w-8 mx-auto mb-2 text-green-500" />
+                    <p>No discrepancies found</p>
                   </div>
                 </div>
+              ) : (
+                <>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Game</TableHead>
+                        <TableHead>Date</TableHead>
+                        <TableHead className="text-center">Passed</TableHead>
+                        <TableHead className="text-center">Failed</TableHead>
+                        <TableHead>Discrepancies</TableHead>
+                        <TableHead className="text-right">Actions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {games.games.map((game) => (
+                        <TableRow key={game.game_id}>
+                          <TableCell className="font-medium">
+                            {game.away_team} @ {game.home_team}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {new Date(game.game_date).toLocaleDateString()}
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <Badge variant="outline" className="text-green-600">
+                              {game.checks_passed}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <Badge variant="outline" className="text-red-600">
+                              {game.checks_failed}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-wrap gap-1">
+                              {game.discrepancies.slice(0, 3).map((d, i) => (
+                                <Badge key={i} variant="secondary" className="text-xs">
+                                  {d.rule_name}
+                                </Badge>
+                              ))}
+                              {game.discrepancies.length > 3 && (
+                                <Badge variant="secondary" className="text-xs">
+                                  +{game.discrepancies.length - 3} more
+                                </Badge>
+                              )}
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button variant="ghost" size="sm" asChild>
+                              <Link to={`/validation/game/${game.game_id}`}>
+                                View Details
+                              </Link>
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+
+                  {/* Pagination */}
+                  {games.pages > 1 && (
+                    <div className="flex items-center justify-between mt-4">
+                      <div className="text-sm text-muted-foreground">
+                        Page {games.page} of {games.pages} ({games.total} games)
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setPage((p) => Math.max(1, p - 1))}
+                          disabled={page === 1}
+                        >
+                          Previous
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setPage((p) => Math.min(games.pages, p + 1))}
+                          disabled={page === games.pages}
+                        >
+                          Next
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </>
               )}
-            </>
-          )}
-        </CardContent>
-      </Card>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Validation Runs Tab */}
+        <TabsContent value="validation-runs" className="space-y-6">
+          {/* Summary Cards */}
+          <div className="grid gap-4 md:grid-cols-4">
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  Total Runs
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {runsLoading ? (
+                  <Skeleton className="h-8 w-20" />
+                ) : (
+                  <div className="text-2xl font-bold">
+                    {validationRuns?.total ?? 0}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  Open Discrepancies
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {discrepanciesLoading ? (
+                  <Skeleton className="h-8 w-20" />
+                ) : (
+                  <div className="text-2xl font-bold text-yellow-600">
+                    {discrepancies?.total ?? 0}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  Last Run Status
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {runsLoading ? (
+                  <Skeleton className="h-8 w-24" />
+                ) : validationRuns?.runs[0] ? (
+                  getRunStatusBadge(validationRuns.runs[0].status)
+                ) : (
+                  <span className="text-muted-foreground">No runs yet</span>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  Last Run Pass Rate
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {runsLoading ? (
+                  <Skeleton className="h-8 w-20" />
+                ) : validationRuns?.runs[0] ? (
+                  <div className="text-2xl font-bold">
+                    {validationRuns.runs[0].total_passed + validationRuns.runs[0].total_failed > 0
+                      ? `${((validationRuns.runs[0].total_passed / (validationRuns.runs[0].total_passed + validationRuns.runs[0].total_failed)) * 100).toFixed(1)}%`
+                      : 'N/A'}
+                  </div>
+                ) : (
+                  <span className="text-muted-foreground">N/A</span>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Validation Runs Table */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Validation Run History</CardTitle>
+              <CardDescription>
+                Recent validation runs with pass/fail counts
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {runsLoading ? (
+                <div className="space-y-2">
+                  <Skeleton className="h-12 w-full" />
+                  <Skeleton className="h-12 w-full" />
+                  <Skeleton className="h-12 w-full" />
+                </div>
+              ) : !validationRuns?.runs.length ? (
+                <div className="flex h-32 items-center justify-center text-muted-foreground">
+                  <div className="text-center">
+                    <ListChecks className="h-8 w-8 mx-auto mb-2" />
+                    <p>No validation runs yet</p>
+                    <p className="text-sm">Run a validation to see results here</p>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Run ID</TableHead>
+                        <TableHead>Started</TableHead>
+                        <TableHead>Duration</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-center">Passed</TableHead>
+                        <TableHead className="text-center">Failed</TableHead>
+                        <TableHead className="text-center">Warnings</TableHead>
+                        <TableHead className="text-right">Actions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {validationRuns.runs.map((run) => (
+                        <TableRow key={run.run_id}>
+                          <TableCell className="font-medium">
+                            #{run.run_id}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {formatDate(run.started_at)}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {formatDuration(run.started_at, run.completed_at)}
+                          </TableCell>
+                          <TableCell>
+                            {getRunStatusBadge(run.status)}
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <Badge variant="outline" className="text-green-600">
+                              {run.total_passed}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <Badge variant="outline" className="text-red-600">
+                              {run.total_failed}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <Badge variant="outline" className="text-yellow-600">
+                              {run.total_warnings}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button variant="ghost" size="sm" asChild>
+                              <Link to={`/validation/run/${run.run_id}`}>
+                                View Details
+                              </Link>
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+
+                  {/* Pagination */}
+                  {validationRuns.pages > 1 && (
+                    <div className="flex items-center justify-between mt-4">
+                      <div className="text-sm text-muted-foreground">
+                        Page {validationRuns.page} of {validationRuns.pages} ({validationRuns.total} runs)
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setRunsPage((p) => Math.max(1, p - 1))}
+                          disabled={runsPage === 1}
+                        >
+                          Previous
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setRunsPage((p) => Math.min(validationRuns.pages, p + 1))}
+                          disabled={runsPage === validationRuns.pages}
+                        >
+                          Next
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Recent Discrepancies */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent Open Discrepancies</CardTitle>
+              <CardDescription>
+                Data mismatches that need attention
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {discrepanciesLoading ? (
+                <div className="space-y-2">
+                  <Skeleton className="h-12 w-full" />
+                  <Skeleton className="h-12 w-full" />
+                </div>
+              ) : !discrepancies?.discrepancies.length ? (
+                <div className="flex h-24 items-center justify-center text-muted-foreground">
+                  <div className="text-center">
+                    <CheckCircle2 className="h-6 w-6 mx-auto mb-2 text-green-500" />
+                    <p>No open discrepancies</p>
+                  </div>
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Rule</TableHead>
+                      <TableHead>Entity</TableHead>
+                      <TableHead>Field</TableHead>
+                      <TableHead>Sources</TableHead>
+                      <TableHead>Found</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {discrepancies.discrepancies.map((d) => (
+                      <TableRow key={d.discrepancy_id}>
+                        <TableCell className="font-medium">
+                          {d.rule_name}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {d.entity_type}: {d.entity_id}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">{d.field_name}</Badge>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {d.source_a} vs {d.source_b}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {new Date(d.created_at).toLocaleDateString()}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/viewer-frontend/src/pages/ValidationRunDetail.tsx
+++ b/viewer-frontend/src/pages/ValidationRunDetail.tsx
@@ -1,0 +1,346 @@
+import { useParams, Link } from 'react-router-dom'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { useValidationRun, type ValidationResult } from '@/hooks/useValidation'
+import {
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  ArrowLeft,
+  Clock,
+  ListChecks,
+} from 'lucide-react'
+
+export function ValidationRunDetail() {
+  const { runId } = useParams<{ runId: string }>()
+  const { data: run, isLoading, error } = useValidationRun(Number(runId))
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case 'completed':
+        return <Badge variant="success">Completed</Badge>
+      case 'running':
+        return <Badge variant="warning">Running</Badge>
+      case 'failed':
+        return <Badge variant="error">Failed</Badge>
+      default:
+        return <Badge variant="secondary">{status}</Badge>
+    }
+  }
+
+  const getSeverityBadge = (severity: string | null) => {
+    switch (severity) {
+      case 'error':
+        return <Badge variant="error">Error</Badge>
+      case 'warning':
+        return <Badge variant="warning">Warning</Badge>
+      case 'info':
+        return <Badge variant="secondary">Info</Badge>
+      default:
+        return null
+    }
+  }
+
+  const getResultIcon = (result: ValidationResult) => {
+    if (result.passed) {
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />
+    }
+    if (result.severity === 'warning') {
+      return <AlertTriangle className="h-4 w-4 text-yellow-500" />
+    }
+    return <XCircle className="h-4 w-4 text-red-500" />
+  }
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr)
+    return date.toLocaleString()
+  }
+
+  const formatDuration = (startedAt: string, completedAt: string | null) => {
+    if (!completedAt) return 'In progress...'
+    const start = new Date(startedAt).getTime()
+    const end = new Date(completedAt).getTime()
+    const durationMs = end - start
+    if (durationMs < 1000) return `${durationMs}ms`
+    if (durationMs < 60000) return `${(durationMs / 1000).toFixed(1)}s`
+    return `${(durationMs / 60000).toFixed(1)}m`
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    )
+  }
+
+  if (error || !run) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" asChild>
+          <Link to="/validation" className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            Back to Validation
+          </Link>
+        </Button>
+        <Card className="border-destructive">
+          <CardContent className="flex items-center gap-2 pt-6">
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+            <span className="text-destructive">
+              Failed to load validation run. The run may not exist.
+            </span>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const totalChecks = run.total_passed + run.total_failed
+  const passRate = totalChecks > 0 ? (run.total_passed / totalChecks) * 100 : 0
+  const failedResults = run.results.filter((r) => !r.passed)
+  const passedResults = run.results.filter((r) => r.passed)
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" asChild>
+            <Link to="/validation" className="gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </Link>
+          </Button>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">
+              Validation Run #{run.run_id}
+            </h1>
+            <p className="text-muted-foreground">
+              {run.season_id ? `Season ${run.season_id}` : 'All seasons'}
+            </p>
+          </div>
+        </div>
+        {getStatusBadge(run.status)}
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Clock className="h-4 w-4" />
+              Started
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-lg font-semibold">
+              {formatDate(run.started_at)}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Duration
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-lg font-semibold">
+              {formatDuration(run.started_at, run.completed_at)}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Rules Checked
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-lg font-semibold">{run.rules_checked}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Pass Rate
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <div className="text-lg font-semibold">
+                {passRate.toFixed(1)}%
+              </div>
+              <Progress value={passRate} />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Results Summary */}
+      <Card className="bg-gradient-to-br from-primary/5 to-primary/10">
+        <CardContent className="pt-6">
+          <div className="flex items-center justify-around">
+            <div className="text-center">
+              <div className="flex items-center justify-center gap-2 mb-1">
+                <CheckCircle2 className="h-5 w-5 text-green-500" />
+                <span className="text-sm font-medium text-muted-foreground">Passed</span>
+              </div>
+              <div className="text-3xl font-bold text-green-600">{run.total_passed}</div>
+            </div>
+            <div className="text-center">
+              <div className="flex items-center justify-center gap-2 mb-1">
+                <XCircle className="h-5 w-5 text-red-500" />
+                <span className="text-sm font-medium text-muted-foreground">Failed</span>
+              </div>
+              <div className="text-3xl font-bold text-red-600">{run.total_failed}</div>
+            </div>
+            <div className="text-center">
+              <div className="flex items-center justify-center gap-2 mb-1">
+                <AlertTriangle className="h-5 w-5 text-yellow-500" />
+                <span className="text-sm font-medium text-muted-foreground">Warnings</span>
+              </div>
+              <div className="text-3xl font-bold text-yellow-600">{run.total_warnings}</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Failed Results */}
+      {failedResults.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-red-600">
+              <XCircle className="h-5 w-5" />
+              Failed Checks ({failedResults.length})
+            </CardTitle>
+            <CardDescription>
+              Validation checks that did not pass
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8"></TableHead>
+                  <TableHead>Rule</TableHead>
+                  <TableHead>Game</TableHead>
+                  <TableHead>Severity</TableHead>
+                  <TableHead>Message</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {failedResults.map((result) => (
+                  <TableRow key={result.result_id}>
+                    <TableCell>{getResultIcon(result)}</TableCell>
+                    <TableCell className="font-medium">
+                      {result.rule_name}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {result.game_id ? (
+                        <Link
+                          to={`/games/${result.game_id}`}
+                          className="hover:underline"
+                        >
+                          #{result.game_id}
+                        </Link>
+                      ) : (
+                        'N/A'
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {getSeverityBadge(result.severity)}
+                    </TableCell>
+                    <TableCell className="max-w-md truncate">
+                      {result.message || 'No message'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Passed Results */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-green-600">
+            <CheckCircle2 className="h-5 w-5" />
+            Passed Checks ({passedResults.length})
+          </CardTitle>
+          <CardDescription>
+            Validation checks that passed successfully
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {passedResults.length === 0 ? (
+            <div className="flex h-24 items-center justify-center text-muted-foreground">
+              <div className="text-center">
+                <ListChecks className="h-6 w-6 mx-auto mb-2" />
+                <p>No passed checks to display</p>
+              </div>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8"></TableHead>
+                  <TableHead>Rule</TableHead>
+                  <TableHead>Game</TableHead>
+                  <TableHead>Message</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {passedResults.slice(0, 20).map((result) => (
+                  <TableRow key={result.result_id}>
+                    <TableCell>{getResultIcon(result)}</TableCell>
+                    <TableCell className="font-medium">
+                      {result.rule_name}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {result.game_id ? (
+                        <Link
+                          to={`/games/${result.game_id}`}
+                          className="hover:underline"
+                        >
+                          #{result.game_id}
+                        </Link>
+                      ) : (
+                        'N/A'
+                      )}
+                    </TableCell>
+                    <TableCell className="max-w-md truncate text-muted-foreground">
+                      {result.message || 'Check passed'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+          {passedResults.length > 20 && (
+            <div className="mt-4 text-center text-sm text-muted-foreground">
+              Showing 20 of {passedResults.length} passed checks
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add "Validation Runs" tab to the Validation page
- Create validation run detail page
- New React Query hooks for validation API endpoints

## Changes

**New Files:**
- `viewer-frontend/src/hooks/useValidation.ts` - React Query hooks for validation API
- `viewer-frontend/src/pages/ValidationRunDetail.tsx` - Run detail page

**Modified Files:**
- `viewer-frontend/src/pages/Validation.tsx` - Added tabs, validation runs section
- `viewer-frontend/src/App.tsx` - Added route for run detail page

## Features

### Validation Runs Tab
- Summary cards: Total runs, open discrepancies, last run status, pass rate
- Runs history table with pagination
- Recent open discrepancies section
- Click through to run details

### Validation Run Detail Page
- Run timing and duration info
- Pass/Fail/Warning summary with visual indicators
- Failed checks table (sorted first)
- Passed checks table (limited to 20)

## Test Plan

- [ ] Navigate to /validation and switch to "Validation Runs" tab
- [ ] Verify summary cards display correctly (or show placeholder if no data)
- [ ] Verify runs table displays with correct columns
- [ ] Click "View Details" on a run to navigate to detail page
- [ ] Verify detail page shows run summary and results
- [ ] Verify pagination works on runs list
- [ ] TypeScript compiles without errors
- [ ] ESLint passes on new files

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)