### PR TITLE
feat(downloaders): Add Phase 1 missing NHL API JSON sources (#257)

### DIFF
--- a/src/nhl_api/downloaders/sources/nhl_json/__init__.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/__init__.py
@@ -5,6 +5,15 @@ at api-web.nhle.com/v1/.
 """
 
 from nhl_api.downloaders.sources.nhl_json.boxscore import BoxscoreDownloader
+from nhl_api.downloaders.sources.nhl_json.gamecenter_landing import (
+    GamecenterLandingDownloader,
+    GamecenterLandingDownloaderConfig,
+    GameHighlight,
+    ParsedGamecenterLanding,
+    TeamMatchup,
+    ThreeStar,
+    create_gamecenter_landing_downloader,
+)
 from nhl_api.downloaders.sources.nhl_json.play_by_play import (
     EventPlayer,
     GameEvent,
@@ -35,6 +44,15 @@ from nhl_api.downloaders.sources.nhl_json.player_landing import (
     SkaterRecentGame,
     SkaterSeasonStats,
 )
+from nhl_api.downloaders.sources.nhl_json.right_rail import (
+    BroadcastInfo,
+    LastGame,
+    ParsedRightRail,
+    RightRailDownloader,
+    RightRailDownloaderConfig,
+    TeamSeasonSeries,
+    create_right_rail_downloader,
+)
 from nhl_api.downloaders.sources.nhl_json.roster import (
     ALL_TEAM_ABBREVS,
     CURRENT_TEAM_ABBREVS,
@@ -48,6 +66,12 @@ from nhl_api.downloaders.sources.nhl_json.roster import (
     resolve_team_abbrev,
 )
 from nhl_api.downloaders.sources.nhl_json.schedule import ScheduleDownloader
+from nhl_api.downloaders.sources.nhl_json.season_info import (
+    SeasonInfo,
+    SeasonInfoDownloader,
+    SeasonInfoDownloaderConfig,
+    create_season_info_downloader,
+)
 from nhl_api.downloaders.sources.nhl_json.standings import (
     ParsedStandings,
     RecordSplit,
@@ -56,48 +80,90 @@ from nhl_api.downloaders.sources.nhl_json.standings import (
     TeamStandings,
     create_standings_downloader,
 )
+from nhl_api.downloaders.sources.nhl_json.team_prospects import (
+    ParsedTeamProspects,
+    ProspectInfo,
+    TeamProspectsDownloader,
+    TeamProspectsDownloaderConfig,
+    create_team_prospects_downloader,
+)
 
 __all__ = [
+    # Constants
     "ALL_TEAM_ABBREVS",
-    "BoxscoreDownloader",
     "CURRENT_TEAM_ABBREVS",
+    "NHL_TEAM_ABBREVS",
+    "PLAYOFFS",
+    "REGULAR_SEASON",
+    "TEAM_RELOCATIONS",
+    # Boxscore
+    "BoxscoreDownloader",
+    # Gamecenter Landing
+    "GamecenterLandingDownloader",
+    "GamecenterLandingDownloaderConfig",
+    "GameHighlight",
+    "ParsedGamecenterLanding",
+    "TeamMatchup",
+    "ThreeStar",
+    "create_gamecenter_landing_downloader",
+    # Play-by-Play
     "DraftDetails",
     "EventPlayer",
     "GameEvent",
-    "GoalieCareerStats",
-    "GoalieGameStats",
-    "GoalieRecentGame",
-    "GoalieSeasonStats",
-    "NHL_TEAM_ABBREVS",
-    "PLAYOFFS",
     "ParsedPlayByPlay",
-    "ParsedPlayerGameLog",
-    "ParsedPlayerLanding",
-    "ParsedRoster",
-    "ParsedStandings",
     "PlayByPlayDownloader",
     "PlayByPlayDownloaderConfig",
+    "create_play_by_play_downloader",
+    # Player Game Log
+    "GoalieGameStats",
+    "ParsedPlayerGameLog",
     "PlayerGameLogDownloader",
     "PlayerGameLogDownloaderConfig",
-    "PlayerInfo",
+    "SkaterGameStats",
+    "create_player_game_log_downloader",
+    # Player Landing
+    "GoalieCareerStats",
+    "GoalieRecentGame",
+    "GoalieSeasonStats",
+    "ParsedPlayerLanding",
     "PlayerLandingDownloader",
     "PlayerLandingDownloaderConfig",
-    "REGULAR_SEASON",
-    "RecordSplit",
-    "RosterDownloader",
-    "ScheduleDownloader",
     "SkaterCareerStats",
-    "SkaterGameStats",
     "SkaterRecentGame",
     "SkaterSeasonStats",
-    "StandingsDownloader",
-    "StreakInfo",
-    "TEAM_RELOCATIONS",
-    "TeamStandings",
-    "create_play_by_play_downloader",
-    "create_player_game_log_downloader",
+    # Right Rail
+    "BroadcastInfo",
+    "LastGame",
+    "ParsedRightRail",
+    "RightRailDownloader",
+    "RightRailDownloaderConfig",
+    "TeamSeasonSeries",
+    "create_right_rail_downloader",
+    # Roster
+    "ParsedRoster",
+    "PlayerInfo",
+    "RosterDownloader",
     "create_roster_downloader",
-    "create_standings_downloader",
     "get_teams_for_season",
     "resolve_team_abbrev",
+    # Schedule
+    "ScheduleDownloader",
+    # Season Info
+    "SeasonInfo",
+    "SeasonInfoDownloader",
+    "SeasonInfoDownloaderConfig",
+    "create_season_info_downloader",
+    # Standings
+    "ParsedStandings",
+    "RecordSplit",
+    "StandingsDownloader",
+    "StreakInfo",
+    "TeamStandings",
+    "create_standings_downloader",
+    # Team Prospects
+    "ParsedTeamProspects",
+    "ProspectInfo",
+    "TeamProspectsDownloader",
+    "TeamProspectsDownloaderConfig",
+    "create_team_prospects_downloader",
 ]

--- a/src/nhl_api/downloaders/sources/nhl_json/gamecenter_landing.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/gamecenter_landing.py
@@ -1,0 +1,524 @@
+"""NHL JSON API Gamecenter Landing Downloader.
+
+Downloads game landing page data from the NHL JSON API, including
+game overview, three stars, highlights, and matchup information.
+
+API Endpoint: GET https://api-web.nhle.com/v1/gamecenter/{game_id}/landing
+
+Example usage:
+    config = GamecenterLandingDownloaderConfig()
+    async with GamecenterLandingDownloader(config) as downloader:
+        result = await downloader.download_game(2024020500)
+        landing = result.data
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from nhl_api.downloaders.base.base_downloader import (
+    BaseDownloader,
+    DownloaderConfig,
+)
+from nhl_api.downloaders.base.protocol import DownloadError
+
+if TYPE_CHECKING:
+    from nhl_api.services.db import DatabaseService
+
+logger = logging.getLogger(__name__)
+
+# NHL JSON API base URL
+NHL_API_BASE_URL = "https://api-web.nhle.com"
+
+# Default rate limit for NHL API (requests per second)
+DEFAULT_RATE_LIMIT = 5.0
+
+
+@dataclass
+class GamecenterLandingDownloaderConfig(DownloaderConfig):
+    """Configuration for the Gamecenter Landing Downloader.
+
+    Attributes:
+        base_url: Base URL for the NHL API
+        requests_per_second: Rate limit for API requests
+        max_retries: Maximum retry attempts for failed requests
+        retry_base_delay: Initial delay between retries in seconds
+        http_timeout: HTTP request timeout in seconds
+        health_check_url: URL path for health check endpoint
+        include_raw_response: Whether to include raw JSON in results
+    """
+
+    base_url: str = NHL_API_BASE_URL
+    requests_per_second: float = DEFAULT_RATE_LIMIT
+    max_retries: int = 3
+    retry_base_delay: float = 1.0
+    http_timeout: float = 30.0
+    health_check_url: str = "/v1/schedule/now"
+    include_raw_response: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ThreeStar:
+    """Three stars of the game player info.
+
+    Attributes:
+        star: Star number (1, 2, or 3)
+        player_id: NHL player ID
+        name: Player name
+        team_abbrev: Team abbreviation
+        position: Player position
+        goals: Goals scored
+        assists: Assists
+        points: Total points
+    """
+
+    star: int
+    player_id: int
+    name: str
+    team_abbrev: str
+    position: str
+    goals: int
+    assists: int
+    points: int
+
+
+@dataclass(frozen=True, slots=True)
+class GameHighlight:
+    """Game highlight video information.
+
+    Attributes:
+        highlight_id: Unique highlight ID
+        title: Highlight title
+        description: Highlight description
+        duration: Duration in seconds
+        thumbnail_url: URL to thumbnail image
+        video_url: URL to video
+    """
+
+    highlight_id: int
+    title: str
+    description: str
+    duration: int
+    thumbnail_url: str | None
+    video_url: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TeamMatchup:
+    """Team matchup summary info.
+
+    Attributes:
+        team_id: NHL team ID
+        abbrev: Team abbreviation
+        name: Team name
+        record: Season record (W-L-OTL)
+        goals_for: Goals for in season
+        goals_against: Goals against in season
+        power_play_pct: Power play percentage
+        penalty_kill_pct: Penalty kill percentage
+    """
+
+    team_id: int
+    abbrev: str
+    name: str
+    record: str
+    goals_for: int
+    goals_against: int
+    power_play_pct: float
+    penalty_kill_pct: float
+
+
+@dataclass
+class ParsedGamecenterLanding:
+    """Parsed gamecenter landing page data.
+
+    Attributes:
+        game_id: NHL game ID
+        season_id: Season ID (e.g., 20242025)
+        game_type: Game type (1=pre, 2=regular, 3=playoffs)
+        game_state: Game state (FUT, LIVE, OFF, FINAL)
+        venue: Venue name
+        attendance: Game attendance
+        three_stars: List of three stars (if game completed)
+        highlights: List of game highlights
+        home_team: Home team matchup info
+        away_team: Away team matchup info
+        neutral_site: Whether game is at neutral site
+        game_outcome_last_play: Description of final play
+        raw_data: Raw API response (if include_raw_response=True)
+    """
+
+    game_id: int
+    season_id: int
+    game_type: int
+    game_state: str
+    venue: str | None
+    attendance: int | None
+    three_stars: list[ThreeStar]
+    highlights: list[GameHighlight]
+    home_team: TeamMatchup | None
+    away_team: TeamMatchup | None
+    neutral_site: bool
+    game_outcome_last_play: str | None
+    raw_data: dict[str, Any] | None = None
+
+
+def _parse_three_star(star_data: dict[str, Any], star_num: int) -> ThreeStar:
+    """Parse a three stars entry.
+
+    Args:
+        star_data: Raw star data from API
+        star_num: Star number (1, 2, or 3)
+
+    Returns:
+        Parsed ThreeStar object
+    """
+    return ThreeStar(
+        star=star_num,
+        player_id=star_data.get("playerId", 0),
+        name=star_data.get("name", {}).get("default", "Unknown"),
+        team_abbrev=star_data.get("teamAbbrev", ""),
+        position=star_data.get("position", ""),
+        goals=star_data.get("goals", 0),
+        assists=star_data.get("assists", 0),
+        points=star_data.get("goals", 0) + star_data.get("assists", 0),
+    )
+
+
+def _parse_highlight(highlight_data: dict[str, Any]) -> GameHighlight:
+    """Parse a highlight entry.
+
+    Args:
+        highlight_data: Raw highlight data from API
+
+    Returns:
+        Parsed GameHighlight object
+    """
+    return GameHighlight(
+        highlight_id=highlight_data.get("id", 0),
+        title=highlight_data.get("title", ""),
+        description=highlight_data.get("description", ""),
+        duration=highlight_data.get("duration", 0),
+        thumbnail_url=highlight_data.get("thumbnail", {}).get("src"),
+        video_url=highlight_data.get("playbacks", [{}])[0].get("url")
+        if highlight_data.get("playbacks")
+        else None,
+    )
+
+
+def _parse_team_matchup(team_data: dict[str, Any]) -> TeamMatchup:
+    """Parse team matchup data.
+
+    Args:
+        team_data: Raw team data from API
+
+    Returns:
+        Parsed TeamMatchup object
+    """
+    record = team_data.get("record", "0-0-0")
+    return TeamMatchup(
+        team_id=team_data.get("id", 0),
+        abbrev=team_data.get("abbrev", ""),
+        name=team_data.get("name", {}).get("default", ""),
+        record=record,
+        goals_for=team_data.get("seasonSeriesWins", {}).get("goalsFor", 0),
+        goals_against=team_data.get("seasonSeriesWins", {}).get("goalsAgainst", 0),
+        power_play_pct=team_data.get("powerPlayPct", 0.0),
+        penalty_kill_pct=team_data.get("penaltyKillPct", 0.0),
+    )
+
+
+def _parse_landing(
+    data: dict[str, Any], include_raw: bool = False
+) -> ParsedGamecenterLanding:
+    """Parse the full landing page response.
+
+    Args:
+        data: Raw API response
+        include_raw: Whether to include raw data in result
+
+    Returns:
+        Parsed ParsedGamecenterLanding object
+    """
+    # Parse three stars
+    three_stars = []
+    for i, star_key in enumerate(["firstStar", "secondStar", "thirdStar"], 1):
+        if star_data := data.get(star_key):
+            three_stars.append(_parse_three_star(star_data, i))
+
+    # Parse highlights
+    highlights = []
+    for hl in data.get("summary", {}).get("gameVideo", {}).get("condensedGame", []):
+        highlights.append(_parse_highlight(hl))
+
+    # Parse team matchup info
+    home_team = None
+    away_team = None
+    if home_data := data.get("homeTeam"):
+        home_team = _parse_team_matchup(home_data)
+    if away_data := data.get("awayTeam"):
+        away_team = _parse_team_matchup(away_data)
+
+    return ParsedGamecenterLanding(
+        game_id=data.get("id", 0),
+        season_id=data.get("season", 0),
+        game_type=data.get("gameType", 2),
+        game_state=data.get("gameState", "FUT"),
+        venue=data.get("venue", {}).get("default"),
+        attendance=data.get("attendance"),
+        three_stars=three_stars,
+        highlights=highlights,
+        home_team=home_team,
+        away_team=away_team,
+        neutral_site=data.get("neutralSite", False),
+        game_outcome_last_play=data.get("summary", {})
+        .get("gameOutcome", {})
+        .get("lastPeriodType"),
+        raw_data=data if include_raw else None,
+    )
+
+
+class GamecenterLandingDownloader(BaseDownloader):
+    """Downloads NHL gamecenter landing page data.
+
+    The landing page contains game overview information including:
+    - Three stars of the game
+    - Highlights and video links
+    - Team matchup summaries
+    - Game metadata (venue, attendance, etc.)
+
+    Example:
+        config = GamecenterLandingDownloaderConfig()
+        async with GamecenterLandingDownloader(config) as downloader:
+            result = await downloader.download_game(2024020500)
+            landing = result.data
+    """
+
+    def __init__(
+        self,
+        config: GamecenterLandingDownloaderConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the downloader.
+
+        Args:
+            config: Downloader configuration
+            **kwargs: Additional arguments passed to BaseDownloader
+        """
+        if config is None:
+            config = GamecenterLandingDownloaderConfig()
+        self._include_raw = config.include_raw_response
+        super().__init__(config, **kwargs)
+
+    @property
+    def source_name(self) -> str:
+        """Return unique identifier for this source."""
+        return "nhl_json_gamecenter_landing"
+
+    async def _fetch_game(self, game_id: int) -> dict[str, Any]:
+        """Fetch landing page data for a specific game.
+
+        Args:
+            game_id: NHL game ID
+
+        Returns:
+            Parsed landing page data as a dictionary
+
+        Raises:
+            DownloadError: If the fetch fails
+        """
+        logger.debug("Fetching gamecenter landing for game %d", game_id)
+
+        response = await self._get(f"/v1/gamecenter/{game_id}/landing")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch landing for game {game_id}: HTTP {response.status}",
+                source=self.source_name,
+                game_id=game_id,
+            )
+
+        data = response.json()
+        parsed = _parse_landing(data, include_raw=self._include_raw)
+
+        return {
+            "game_id": parsed.game_id,
+            "season_id": parsed.season_id,
+            "game_type": parsed.game_type,
+            "game_state": parsed.game_state,
+            "venue": parsed.venue,
+            "attendance": parsed.attendance,
+            "three_stars": [
+                {
+                    "star": s.star,
+                    "player_id": s.player_id,
+                    "name": s.name,
+                    "team_abbrev": s.team_abbrev,
+                    "position": s.position,
+                    "goals": s.goals,
+                    "assists": s.assists,
+                    "points": s.points,
+                }
+                for s in parsed.three_stars
+            ],
+            "highlights": [
+                {
+                    "highlight_id": h.highlight_id,
+                    "title": h.title,
+                    "description": h.description,
+                    "duration": h.duration,
+                    "thumbnail_url": h.thumbnail_url,
+                    "video_url": h.video_url,
+                }
+                for h in parsed.highlights
+            ],
+            "home_team": {
+                "team_id": parsed.home_team.team_id,
+                "abbrev": parsed.home_team.abbrev,
+                "name": parsed.home_team.name,
+                "record": parsed.home_team.record,
+            }
+            if parsed.home_team
+            else None,
+            "away_team": {
+                "team_id": parsed.away_team.team_id,
+                "abbrev": parsed.away_team.abbrev,
+                "name": parsed.away_team.name,
+                "record": parsed.away_team.record,
+            }
+            if parsed.away_team
+            else None,
+            "neutral_site": parsed.neutral_site,
+            "game_outcome_last_play": parsed.game_outcome_last_play,
+            "raw_data": parsed.raw_data,
+        }
+
+    async def _fetch_season_games(self, season_id: int) -> AsyncGenerator[int, None]:
+        """Yield game IDs for a season.
+
+        This downloader relies on the schedule to provide game IDs.
+        Import and use ScheduleDownloader to get the list.
+
+        Args:
+            season_id: NHL season ID (e.g., 20242025)
+
+        Yields:
+            Game IDs for the season
+        """
+        from nhl_api.downloaders.sources.nhl_json.schedule import (
+            create_schedule_downloader,
+        )
+
+        schedule_dl = create_schedule_downloader()
+        async with schedule_dl:
+            games = await schedule_dl.get_season_schedule(season_id)
+            self.set_total_items(len(games))
+            for game in games:
+                yield game.game_id
+
+    async def get_landing(self, game_id: int) -> ParsedGamecenterLanding:
+        """Get parsed landing page data for a game.
+
+        Convenience method that returns typed data.
+
+        Args:
+            game_id: NHL game ID
+
+        Returns:
+            Parsed landing page data
+        """
+        response = await self._get(f"/v1/gamecenter/{game_id}/landing")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch landing for game {game_id}: HTTP {response.status}",
+                source=self.source_name,
+                game_id=game_id,
+            )
+
+        return _parse_landing(response.json(), include_raw=self._include_raw)
+
+    async def persist(
+        self,
+        db: DatabaseService,
+        landing: ParsedGamecenterLanding,
+    ) -> int:
+        """Persist landing data to the database.
+
+        Stores three stars and game metadata.
+
+        Args:
+            db: Database service instance
+            landing: Parsed landing data
+
+        Returns:
+            Number of records upserted
+        """
+        count = 0
+
+        # Update game record with attendance and venue if available
+        if landing.attendance or landing.venue:
+            await db.execute(
+                """
+                UPDATE games
+                SET attendance = COALESCE($2, attendance),
+                    venue = COALESCE($3, venue),
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE game_id = $1
+                """,
+                landing.game_id,
+                landing.attendance,
+                landing.venue,
+            )
+            count += 1
+
+        # Insert three stars
+        for star in landing.three_stars:
+            await db.execute(
+                """
+                INSERT INTO game_three_stars (
+                    game_id, star_number, player_id, goals, assists
+                ) VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (game_id, star_number) DO UPDATE SET
+                    player_id = EXCLUDED.player_id,
+                    goals = EXCLUDED.goals,
+                    assists = EXCLUDED.assists,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                landing.game_id,
+                star.star,
+                star.player_id,
+                star.goals,
+                star.assists,
+            )
+            count += 1
+
+        logger.info("Persisted %d records for game %d", count, landing.game_id)
+        return count
+
+
+def create_gamecenter_landing_downloader(
+    *,
+    requests_per_second: float = DEFAULT_RATE_LIMIT,
+    max_retries: int = 3,
+    include_raw_response: bool = False,
+) -> GamecenterLandingDownloader:
+    """Factory function to create a configured GamecenterLandingDownloader.
+
+    Args:
+        requests_per_second: Rate limit for API calls
+        max_retries: Maximum retry attempts
+        include_raw_response: Whether to include raw JSON in results
+
+    Returns:
+        Configured GamecenterLandingDownloader instance
+    """
+    config = GamecenterLandingDownloaderConfig(
+        requests_per_second=requests_per_second,
+        max_retries=max_retries,
+        include_raw_response=include_raw_response,
+    )
+    return GamecenterLandingDownloader(config)

--- a/src/nhl_api/downloaders/sources/nhl_json/right_rail.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/right_rail.py
@@ -1,0 +1,478 @@
+"""NHL JSON API Right Rail Downloader.
+
+Downloads game right rail (sidebar) data from the NHL JSON API, including
+TV broadcast info, quick stats, and game context information.
+
+API Endpoint: GET https://api-web.nhle.com/v1/gamecenter/{game_id}/right-rail
+
+Example usage:
+    config = RightRailDownloaderConfig()
+    async with RightRailDownloader(config) as downloader:
+        result = await downloader.download_game(2024020500)
+        right_rail = result.data
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from nhl_api.downloaders.base.base_downloader import (
+    BaseDownloader,
+    DownloaderConfig,
+)
+from nhl_api.downloaders.base.protocol import DownloadError
+
+if TYPE_CHECKING:
+    from nhl_api.services.db import DatabaseService
+
+logger = logging.getLogger(__name__)
+
+# NHL JSON API base URL
+NHL_API_BASE_URL = "https://api-web.nhle.com"
+
+# Default rate limit for NHL API (requests per second)
+DEFAULT_RATE_LIMIT = 5.0
+
+
+@dataclass
+class RightRailDownloaderConfig(DownloaderConfig):
+    """Configuration for the Right Rail Downloader.
+
+    Attributes:
+        base_url: Base URL for the NHL API
+        requests_per_second: Rate limit for API requests
+        max_retries: Maximum retry attempts for failed requests
+        retry_base_delay: Initial delay between retries in seconds
+        http_timeout: HTTP request timeout in seconds
+        health_check_url: URL path for health check endpoint
+        include_raw_response: Whether to include raw JSON in results
+    """
+
+    base_url: str = NHL_API_BASE_URL
+    requests_per_second: float = DEFAULT_RATE_LIMIT
+    max_retries: int = 3
+    retry_base_delay: float = 1.0
+    http_timeout: float = 30.0
+    health_check_url: str = "/v1/schedule/now"
+    include_raw_response: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class BroadcastInfo:
+    """TV/streaming broadcast information.
+
+    Attributes:
+        network: Network name (e.g., "ESPN+", "TNT")
+        country_code: Country code (e.g., "US", "CA")
+        broadcast_type: Type (national, home, away)
+        start_time: Broadcast start time
+    """
+
+    network: str
+    country_code: str
+    broadcast_type: str
+    start_time: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TeamSeasonSeries:
+    """Head-to-head season series info.
+
+    Attributes:
+        team_id: NHL team ID
+        abbrev: Team abbreviation
+        wins: Wins in season series
+        losses: Losses in season series
+        ot_losses: OT losses in season series
+    """
+
+    team_id: int
+    abbrev: str
+    wins: int
+    losses: int
+    ot_losses: int
+
+
+@dataclass(frozen=True, slots=True)
+class LastGame:
+    """Info about last game between teams.
+
+    Attributes:
+        game_id: Game ID
+        game_date: Date of game
+        home_team_abbrev: Home team abbreviation
+        away_team_abbrev: Away team abbreviation
+        home_score: Home team score
+        away_score: Away team score
+    """
+
+    game_id: int
+    game_date: str
+    home_team_abbrev: str
+    away_team_abbrev: str
+    home_score: int
+    away_score: int
+
+
+@dataclass
+class ParsedRightRail:
+    """Parsed right rail data.
+
+    Attributes:
+        game_id: NHL game ID
+        season_id: Season ID
+        broadcasts: List of broadcast info
+        home_series: Home team season series record
+        away_series: Away team season series record
+        last_games: List of recent games between teams
+        game_info: Additional game context
+        raw_data: Raw API response (if include_raw_response=True)
+    """
+
+    game_id: int
+    season_id: int
+    broadcasts: list[BroadcastInfo]
+    home_series: TeamSeasonSeries | None
+    away_series: TeamSeasonSeries | None
+    last_games: list[LastGame]
+    game_info: dict[str, Any]
+    raw_data: dict[str, Any] | None = None
+
+
+def _parse_broadcast(broadcast_data: dict[str, Any]) -> BroadcastInfo:
+    """Parse a broadcast entry.
+
+    Args:
+        broadcast_data: Raw broadcast data from API
+
+    Returns:
+        Parsed BroadcastInfo object
+    """
+    return BroadcastInfo(
+        network=broadcast_data.get("network", ""),
+        country_code=broadcast_data.get("countryCode", ""),
+        broadcast_type=broadcast_data.get("type", ""),
+        start_time=broadcast_data.get("startTime"),
+    )
+
+
+def _parse_season_series(
+    team_data: dict[str, Any], team_id: int, abbrev: str
+) -> TeamSeasonSeries:
+    """Parse season series for a team.
+
+    Args:
+        team_data: Raw team series data
+        team_id: Team ID
+        abbrev: Team abbreviation
+
+    Returns:
+        Parsed TeamSeasonSeries object
+    """
+    return TeamSeasonSeries(
+        team_id=team_id,
+        abbrev=abbrev,
+        wins=team_data.get("wins", 0),
+        losses=team_data.get("losses", 0),
+        ot_losses=team_data.get("otLosses", 0),
+    )
+
+
+def _parse_last_game(game_data: dict[str, Any]) -> LastGame:
+    """Parse a last game entry.
+
+    Args:
+        game_data: Raw game data
+
+    Returns:
+        Parsed LastGame object
+    """
+    return LastGame(
+        game_id=game_data.get("id", 0),
+        game_date=game_data.get("gameDate", ""),
+        home_team_abbrev=game_data.get("homeTeam", {}).get("abbrev", ""),
+        away_team_abbrev=game_data.get("awayTeam", {}).get("abbrev", ""),
+        home_score=game_data.get("homeTeam", {}).get("score", 0),
+        away_score=game_data.get("awayTeam", {}).get("score", 0),
+    )
+
+
+def _parse_right_rail(
+    data: dict[str, Any], include_raw: bool = False
+) -> ParsedRightRail:
+    """Parse the full right rail response.
+
+    Args:
+        data: Raw API response
+        include_raw: Whether to include raw data in result
+
+    Returns:
+        Parsed ParsedRightRail object
+    """
+    # Parse broadcasts
+    broadcasts = []
+    for bc in data.get("broadcasts", []):
+        broadcasts.append(_parse_broadcast(bc))
+
+    # Parse season series
+    season_series = data.get("seasonSeries", {})
+    home_series = None
+    away_series = None
+
+    if series_data := season_series.get("series"):
+        # Get team info from first entry if available
+        if len(series_data) >= 2:
+            home_data = series_data[0]
+            away_data = series_data[1]
+            home_series = _parse_season_series(
+                home_data,
+                home_data.get("teamId", 0),
+                home_data.get("teamAbbrev", ""),
+            )
+            away_series = _parse_season_series(
+                away_data,
+                away_data.get("teamId", 0),
+                away_data.get("teamAbbrev", ""),
+            )
+
+    # Parse last games between teams
+    last_games = []
+    for game in data.get("seasonSeriesWins", {}).get("games", []):
+        last_games.append(_parse_last_game(game))
+
+    # Extract game info
+    game_info = {
+        "ticketLink": data.get("ticketLink"),
+        "ticketText": data.get("ticketText"),
+        "gameCenterLink": data.get("gameCenterLink"),
+    }
+
+    return ParsedRightRail(
+        game_id=data.get("id", 0),
+        season_id=data.get("season", 0),
+        broadcasts=broadcasts,
+        home_series=home_series,
+        away_series=away_series,
+        last_games=last_games,
+        game_info=game_info,
+        raw_data=data if include_raw else None,
+    )
+
+
+class RightRailDownloader(BaseDownloader):
+    """Downloads NHL game right rail (sidebar) data.
+
+    The right rail contains sidebar content including:
+    - TV/streaming broadcast information
+    - Season series between teams
+    - Recent games between teams
+    - Ticket and link information
+
+    Example:
+        config = RightRailDownloaderConfig()
+        async with RightRailDownloader(config) as downloader:
+            result = await downloader.download_game(2024020500)
+            right_rail = result.data
+    """
+
+    def __init__(
+        self,
+        config: RightRailDownloaderConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the downloader.
+
+        Args:
+            config: Downloader configuration
+            **kwargs: Additional arguments passed to BaseDownloader
+        """
+        if config is None:
+            config = RightRailDownloaderConfig()
+        self._include_raw = config.include_raw_response
+        super().__init__(config, **kwargs)
+
+    @property
+    def source_name(self) -> str:
+        """Return unique identifier for this source."""
+        return "nhl_json_right_rail"
+
+    async def _fetch_game(self, game_id: int) -> dict[str, Any]:
+        """Fetch right rail data for a specific game.
+
+        Args:
+            game_id: NHL game ID
+
+        Returns:
+            Parsed right rail data as a dictionary
+
+        Raises:
+            DownloadError: If the fetch fails
+        """
+        logger.debug("Fetching right rail for game %d", game_id)
+
+        response = await self._get(f"/v1/gamecenter/{game_id}/right-rail")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch right rail for game {game_id}: HTTP {response.status}",
+                source=self.source_name,
+                game_id=game_id,
+            )
+
+        data = response.json()
+        parsed = _parse_right_rail(data, include_raw=self._include_raw)
+
+        return {
+            "game_id": parsed.game_id,
+            "season_id": parsed.season_id,
+            "broadcasts": [
+                {
+                    "network": b.network,
+                    "country_code": b.country_code,
+                    "broadcast_type": b.broadcast_type,
+                    "start_time": b.start_time,
+                }
+                for b in parsed.broadcasts
+            ],
+            "home_series": {
+                "team_id": parsed.home_series.team_id,
+                "abbrev": parsed.home_series.abbrev,
+                "wins": parsed.home_series.wins,
+                "losses": parsed.home_series.losses,
+                "ot_losses": parsed.home_series.ot_losses,
+            }
+            if parsed.home_series
+            else None,
+            "away_series": {
+                "team_id": parsed.away_series.team_id,
+                "abbrev": parsed.away_series.abbrev,
+                "wins": parsed.away_series.wins,
+                "losses": parsed.away_series.losses,
+                "ot_losses": parsed.away_series.ot_losses,
+            }
+            if parsed.away_series
+            else None,
+            "last_games": [
+                {
+                    "game_id": g.game_id,
+                    "game_date": g.game_date,
+                    "home_team_abbrev": g.home_team_abbrev,
+                    "away_team_abbrev": g.away_team_abbrev,
+                    "home_score": g.home_score,
+                    "away_score": g.away_score,
+                }
+                for g in parsed.last_games
+            ],
+            "game_info": parsed.game_info,
+            "raw_data": parsed.raw_data,
+        }
+
+    async def _fetch_season_games(self, season_id: int) -> AsyncGenerator[int, None]:
+        """Yield game IDs for a season.
+
+        This downloader relies on the schedule to provide game IDs.
+
+        Args:
+            season_id: NHL season ID (e.g., 20242025)
+
+        Yields:
+            Game IDs for the season
+        """
+        from nhl_api.downloaders.sources.nhl_json.schedule import (
+            create_schedule_downloader,
+        )
+
+        schedule_dl = create_schedule_downloader()
+        async with schedule_dl:
+            games = await schedule_dl.get_season_schedule(season_id)
+            self.set_total_items(len(games))
+            for game in games:
+                yield game.game_id
+
+    async def get_right_rail(self, game_id: int) -> ParsedRightRail:
+        """Get parsed right rail data for a game.
+
+        Convenience method that returns typed data.
+
+        Args:
+            game_id: NHL game ID
+
+        Returns:
+            Parsed right rail data
+        """
+        response = await self._get(f"/v1/gamecenter/{game_id}/right-rail")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch right rail for game {game_id}: HTTP {response.status}",
+                source=self.source_name,
+                game_id=game_id,
+            )
+
+        return _parse_right_rail(response.json(), include_raw=self._include_raw)
+
+    async def persist(
+        self,
+        db: DatabaseService,
+        right_rail: ParsedRightRail,
+    ) -> int:
+        """Persist right rail data to the database.
+
+        Stores broadcast info and season series data.
+
+        Args:
+            db: Database service instance
+            right_rail: Parsed right rail data
+
+        Returns:
+            Number of records upserted
+        """
+        count = 0
+
+        # Insert broadcasts
+        for broadcast in right_rail.broadcasts:
+            await db.execute(
+                """
+                INSERT INTO game_broadcasts (
+                    game_id, network, country_code, broadcast_type
+                ) VALUES ($1, $2, $3, $4)
+                ON CONFLICT (game_id, network, country_code) DO UPDATE SET
+                    broadcast_type = EXCLUDED.broadcast_type,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                right_rail.game_id,
+                broadcast.network,
+                broadcast.country_code,
+                broadcast.broadcast_type,
+            )
+            count += 1
+
+        logger.info("Persisted %d records for game %d", count, right_rail.game_id)
+        return count
+
+
+def create_right_rail_downloader(
+    *,
+    requests_per_second: float = DEFAULT_RATE_LIMIT,
+    max_retries: int = 3,
+    include_raw_response: bool = False,
+) -> RightRailDownloader:
+    """Factory function to create a configured RightRailDownloader.
+
+    Args:
+        requests_per_second: Rate limit for API calls
+        max_retries: Maximum retry attempts
+        include_raw_response: Whether to include raw JSON in results
+
+    Returns:
+        Configured RightRailDownloader instance
+    """
+    config = RightRailDownloaderConfig(
+        requests_per_second=requests_per_second,
+        max_retries=max_retries,
+        include_raw_response=include_raw_response,
+    )
+    return RightRailDownloader(config)

--- a/src/nhl_api/downloaders/sources/nhl_json/season_info.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/season_info.py
@@ -1,0 +1,339 @@
+"""NHL JSON API Season Info Downloader.
+
+Downloads season metadata from the NHL JSON API, including
+start/end dates, regular season and playoff structure.
+
+API Endpoint: GET https://api-web.nhle.com/v1/season
+
+Example usage:
+    config = SeasonInfoDownloaderConfig()
+    async with SeasonInfoDownloader(config) as downloader:
+        seasons = await downloader.get_all_seasons()
+        current = await downloader.get_current_season()
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from datetime import date
+from typing import TYPE_CHECKING, Any
+
+from nhl_api.downloaders.base.base_downloader import (
+    BaseDownloader,
+    DownloaderConfig,
+)
+from nhl_api.downloaders.base.protocol import DownloadError
+
+if TYPE_CHECKING:
+    from nhl_api.services.db import DatabaseService
+
+logger = logging.getLogger(__name__)
+
+# NHL JSON API base URL
+NHL_API_BASE_URL = "https://api-web.nhle.com"
+
+# Default rate limit for NHL API (requests per second)
+DEFAULT_RATE_LIMIT = 5.0
+
+
+@dataclass
+class SeasonInfoDownloaderConfig(DownloaderConfig):
+    """Configuration for the Season Info Downloader.
+
+    Attributes:
+        base_url: Base URL for the NHL API
+        requests_per_second: Rate limit for API requests
+        max_retries: Maximum retry attempts for failed requests
+        retry_base_delay: Initial delay between retries in seconds
+        http_timeout: HTTP request timeout in seconds
+        health_check_url: URL path for health check endpoint
+    """
+
+    base_url: str = NHL_API_BASE_URL
+    requests_per_second: float = DEFAULT_RATE_LIMIT
+    max_retries: int = 3
+    retry_base_delay: float = 1.0
+    http_timeout: float = 30.0
+    health_check_url: str = "/v1/schedule/now"
+
+
+@dataclass(frozen=True, slots=True)
+class SeasonInfo:
+    """Season metadata.
+
+    Attributes:
+        season_id: Season ID (e.g., 20242025)
+        regular_season_start: Start date of regular season
+        regular_season_end: End date of regular season
+        playoff_start: Start date of playoffs
+        playoff_end: End date of playoffs (estimated)
+        number_of_games: Number of regular season games per team
+        ties_in_use: Whether ties are possible (historical)
+        olympics_participation: Whether players participated in Olympics
+        conference_in_use: Whether conferences are in use
+        division_in_use: Whether divisions are in use
+    """
+
+    season_id: int
+    regular_season_start: date | None
+    regular_season_end: date | None
+    playoff_start: date | None
+    playoff_end: date | None
+    number_of_games: int
+    ties_in_use: bool
+    olympics_participation: bool
+    conference_in_use: bool
+    division_in_use: bool
+
+
+def _parse_date(date_str: str | None) -> date | None:
+    """Parse a date string to a date object.
+
+    Args:
+        date_str: Date string in YYYY-MM-DD format
+
+    Returns:
+        Parsed date or None
+    """
+    if not date_str:
+        return None
+    try:
+        return date.fromisoformat(date_str)
+    except ValueError:
+        logger.warning("Failed to parse date: %s", date_str)
+        return None
+
+
+def _parse_season(season_data: dict[str, Any]) -> SeasonInfo:
+    """Parse a season entry.
+
+    Args:
+        season_data: Raw season data from API
+
+    Returns:
+        Parsed SeasonInfo object
+    """
+    return SeasonInfo(
+        season_id=season_data.get("id", 0),
+        regular_season_start=_parse_date(season_data.get("regularSeasonStartDate")),
+        regular_season_end=_parse_date(season_data.get("regularSeasonEndDate")),
+        playoff_start=_parse_date(season_data.get("playoffEndDate")),
+        playoff_end=_parse_date(season_data.get("seasonEndDate")),
+        number_of_games=season_data.get("numberOfGames", 82),
+        ties_in_use=season_data.get("tiesInUse", False),
+        olympics_participation=season_data.get("olympicsParticipation", False),
+        conference_in_use=season_data.get("conferencesInUse", True),
+        division_in_use=season_data.get("divisionsInUse", True),
+    )
+
+
+class SeasonInfoDownloader(BaseDownloader):
+    """Downloads NHL season metadata.
+
+    The season endpoint provides information about:
+    - All NHL seasons and their dates
+    - Regular season and playoff windows
+    - League structure (conferences, divisions)
+
+    Example:
+        config = SeasonInfoDownloaderConfig()
+        async with SeasonInfoDownloader(config) as downloader:
+            seasons = await downloader.get_all_seasons()
+            current = await downloader.get_current_season()
+    """
+
+    def __init__(
+        self,
+        config: SeasonInfoDownloaderConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the downloader.
+
+        Args:
+            config: Downloader configuration
+            **kwargs: Additional arguments passed to BaseDownloader
+        """
+        if config is None:
+            config = SeasonInfoDownloaderConfig()
+        super().__init__(config, **kwargs)
+        self._cached_seasons: list[SeasonInfo] | None = None
+
+    @property
+    def source_name(self) -> str:
+        """Return unique identifier for this source."""
+        return "nhl_json_season_info"
+
+    async def _fetch_game(self, game_id: int) -> dict[str, Any]:
+        """Not applicable for season info - returns empty dict.
+
+        Args:
+            game_id: Not used
+
+        Returns:
+            Empty dictionary
+        """
+        # Season info is not game-specific
+        return {}
+
+    async def _fetch_season_games(self, season_id: int) -> AsyncGenerator[int, None]:
+        """Not applicable for season info.
+
+        Args:
+            season_id: Not used
+
+        Yields:
+            Nothing
+        """
+        # This downloader doesn't iterate over games
+        return
+        yield  # Make this a generator  # noqa: B901
+
+    async def get_all_seasons(self, *, force_refresh: bool = False) -> list[SeasonInfo]:
+        """Get metadata for all NHL seasons.
+
+        Args:
+            force_refresh: If True, bypass cache and fetch fresh data
+
+        Returns:
+            List of all season info objects
+        """
+        if self._cached_seasons is not None and not force_refresh:
+            return self._cached_seasons
+
+        logger.debug("Fetching all season info")
+
+        response = await self._get("/v1/season")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch season info: HTTP {response.status}",
+                source=self.source_name,
+            )
+
+        data = response.json()
+        seasons = []
+
+        # The API returns a list of season objects
+        for season_data in data if isinstance(data, list) else data.get("data", []):
+            seasons.append(_parse_season(season_data))
+
+        # Sort by season ID descending (newest first)
+        seasons.sort(key=lambda s: s.season_id, reverse=True)
+        self._cached_seasons = seasons
+
+        logger.info("Fetched info for %d seasons", len(seasons))
+        return seasons
+
+    async def get_season(self, season_id: int) -> SeasonInfo | None:
+        """Get metadata for a specific season.
+
+        Args:
+            season_id: Season ID (e.g., 20242025)
+
+        Returns:
+            Season info or None if not found
+        """
+        seasons = await self.get_all_seasons()
+        for season in seasons:
+            if season.season_id == season_id:
+                return season
+        return None
+
+    async def get_current_season(self) -> SeasonInfo | None:
+        """Get the current NHL season.
+
+        Returns the season whose regular season window contains today's date,
+        or the most recent season if between seasons.
+
+        Returns:
+            Current season info or None
+        """
+        seasons = await self.get_all_seasons()
+        today = date.today()
+
+        # Find season where today falls within the dates
+        for season in seasons:
+            if season.regular_season_start and season.playoff_end:
+                if season.regular_season_start <= today <= season.playoff_end:
+                    return season
+
+        # If not in any season, return the most recent
+        return seasons[0] if seasons else None
+
+    async def persist(
+        self,
+        db: DatabaseService,
+        seasons: list[SeasonInfo] | None = None,
+    ) -> int:
+        """Persist season info to the database.
+
+        Args:
+            db: Database service instance
+            seasons: List of seasons to persist (fetches if not provided)
+
+        Returns:
+            Number of records upserted
+        """
+        if seasons is None:
+            seasons = await self.get_all_seasons()
+
+        count = 0
+        for season in seasons:
+            await db.execute(
+                """
+                INSERT INTO seasons (
+                    season_id, regular_season_start, regular_season_end,
+                    playoff_start, playoff_end, number_of_games,
+                    ties_in_use, olympics_participation,
+                    conferences_in_use, divisions_in_use
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                ON CONFLICT (season_id) DO UPDATE SET
+                    regular_season_start = EXCLUDED.regular_season_start,
+                    regular_season_end = EXCLUDED.regular_season_end,
+                    playoff_start = EXCLUDED.playoff_start,
+                    playoff_end = EXCLUDED.playoff_end,
+                    number_of_games = EXCLUDED.number_of_games,
+                    ties_in_use = EXCLUDED.ties_in_use,
+                    olympics_participation = EXCLUDED.olympics_participation,
+                    conferences_in_use = EXCLUDED.conferences_in_use,
+                    divisions_in_use = EXCLUDED.divisions_in_use,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                season.season_id,
+                season.regular_season_start,
+                season.regular_season_end,
+                season.playoff_start,
+                season.playoff_end,
+                season.number_of_games,
+                season.ties_in_use,
+                season.olympics_participation,
+                season.conference_in_use,
+                season.division_in_use,
+            )
+            count += 1
+
+        logger.info("Persisted %d season records", count)
+        return count
+
+
+def create_season_info_downloader(
+    *,
+    requests_per_second: float = DEFAULT_RATE_LIMIT,
+    max_retries: int = 3,
+) -> SeasonInfoDownloader:
+    """Factory function to create a configured SeasonInfoDownloader.
+
+    Args:
+        requests_per_second: Rate limit for API calls
+        max_retries: Maximum retry attempts
+
+    Returns:
+        Configured SeasonInfoDownloader instance
+    """
+    config = SeasonInfoDownloaderConfig(
+        requests_per_second=requests_per_second,
+        max_retries=max_retries,
+    )
+    return SeasonInfoDownloader(config)

--- a/src/nhl_api/downloaders/sources/nhl_json/team_prospects.py
+++ b/src/nhl_api/downloaders/sources/nhl_json/team_prospects.py
@@ -1,0 +1,443 @@
+"""NHL JSON API Team Prospects Downloader.
+
+Downloads team prospect pipeline data from the NHL JSON API.
+
+API Endpoint: GET https://api-web.nhle.com/v1/roster/{team}/prospects
+
+Example usage:
+    config = TeamProspectsDownloaderConfig()
+    async with TeamProspectsDownloader(config) as downloader:
+        prospects = await downloader.get_team_prospects("TOR")
+        all_prospects = await downloader.get_all_prospects()
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from nhl_api.downloaders.base.base_downloader import (
+    BaseDownloader,
+    DownloaderConfig,
+)
+from nhl_api.downloaders.base.protocol import DownloadError
+
+if TYPE_CHECKING:
+    from nhl_api.services.db import DatabaseService
+
+logger = logging.getLogger(__name__)
+
+# NHL JSON API base URL
+NHL_API_BASE_URL = "https://api-web.nhle.com"
+
+# Default rate limit for NHL API (requests per second)
+DEFAULT_RATE_LIMIT = 5.0
+
+# Current NHL team abbreviations
+CURRENT_TEAM_ABBREVS = [
+    "ANA",
+    "ARI",
+    "BOS",
+    "BUF",
+    "CGY",
+    "CAR",
+    "CHI",
+    "COL",
+    "CBJ",
+    "DAL",
+    "DET",
+    "EDM",
+    "FLA",
+    "LAK",
+    "MIN",
+    "MTL",
+    "NSH",
+    "NJD",
+    "NYI",
+    "NYR",
+    "OTT",
+    "PHI",
+    "PIT",
+    "SJS",
+    "SEA",
+    "STL",
+    "TBL",
+    "TOR",
+    "UTA",
+    "VAN",
+    "VGK",
+    "WSH",
+    "WPG",
+]
+
+
+@dataclass
+class TeamProspectsDownloaderConfig(DownloaderConfig):
+    """Configuration for the Team Prospects Downloader.
+
+    Attributes:
+        base_url: Base URL for the NHL API
+        requests_per_second: Rate limit for API requests
+        max_retries: Maximum retry attempts for failed requests
+        retry_base_delay: Initial delay between retries in seconds
+        http_timeout: HTTP request timeout in seconds
+        health_check_url: URL path for health check endpoint
+    """
+
+    base_url: str = NHL_API_BASE_URL
+    requests_per_second: float = DEFAULT_RATE_LIMIT
+    max_retries: int = 3
+    retry_base_delay: float = 1.0
+    http_timeout: float = 30.0
+    health_check_url: str = "/v1/schedule/now"
+
+
+@dataclass(frozen=True, slots=True)
+class ProspectInfo:
+    """Prospect player information.
+
+    Attributes:
+        player_id: NHL player ID
+        first_name: First name
+        last_name: Last name
+        full_name: Full display name
+        sweater_number: Jersey number (if assigned)
+        position: Position code (C, L, R, D, G)
+        height_inches: Height in inches
+        weight_lbs: Weight in pounds
+        birth_date: Birth date string
+        birth_city: Birth city
+        birth_country: Birth country code
+        shoots_catches: Shoots/catches (L or R)
+        team_abbrev: Team abbreviation
+        current_team_name: Current team/league (AHL, NCAA, etc.)
+        draft_year: Year drafted
+        draft_round: Round drafted
+        draft_pick: Pick number in round
+        draft_overall: Overall pick number
+    """
+
+    player_id: int
+    first_name: str
+    last_name: str
+    full_name: str
+    sweater_number: int | None
+    position: str
+    height_inches: int
+    weight_lbs: int
+    birth_date: str | None
+    birth_city: str | None
+    birth_country: str | None
+    shoots_catches: str
+    team_abbrev: str
+    current_team_name: str | None
+    draft_year: int | None
+    draft_round: int | None
+    draft_pick: int | None
+    draft_overall: int | None
+
+
+@dataclass
+class ParsedTeamProspects:
+    """Parsed team prospects data.
+
+    Attributes:
+        team_abbrev: Team abbreviation
+        forwards: List of forward prospects
+        defensemen: List of defenseman prospects
+        goalies: List of goalie prospects
+    """
+
+    team_abbrev: str
+    forwards: list[ProspectInfo]
+    defensemen: list[ProspectInfo]
+    goalies: list[ProspectInfo]
+
+    @property
+    def all_prospects(self) -> list[ProspectInfo]:
+        """Get all prospects across all positions."""
+        return self.forwards + self.defensemen + self.goalies
+
+
+def _parse_prospect(player_data: dict[str, Any], team_abbrev: str) -> ProspectInfo:
+    """Parse a prospect entry.
+
+    Args:
+        player_data: Raw player data from API
+        team_abbrev: Team abbreviation
+
+    Returns:
+        Parsed ProspectInfo object
+    """
+    # Parse height from feet-inches format (e.g., "6' 2\"")
+    height_str = player_data.get("heightInInches", 0)
+    if isinstance(height_str, str):
+        try:
+            # Handle format like 74 (just inches) or "6' 2\""
+            height_inches = int(height_str)
+        except ValueError:
+            height_inches = 0
+    else:
+        height_inches = height_str or 0
+
+    # Parse draft info
+    draft_details = player_data.get("draftDetails", {})
+
+    return ProspectInfo(
+        player_id=player_data.get("id", 0),
+        first_name=player_data.get("firstName", {}).get("default", ""),
+        last_name=player_data.get("lastName", {}).get("default", ""),
+        full_name=f"{player_data.get('firstName', {}).get('default', '')} {player_data.get('lastName', {}).get('default', '')}".strip(),
+        sweater_number=player_data.get("sweaterNumber"),
+        position=player_data.get("positionCode", ""),
+        height_inches=height_inches,
+        weight_lbs=player_data.get("weightInPounds", 0),
+        birth_date=player_data.get("birthDate"),
+        birth_city=player_data.get("birthCity", {}).get("default"),
+        birth_country=player_data.get("birthCountry"),
+        shoots_catches=player_data.get("shootsCatches", ""),
+        team_abbrev=team_abbrev,
+        current_team_name=player_data.get("currentTeamAbbrev"),
+        draft_year=draft_details.get("year"),
+        draft_round=draft_details.get("round"),
+        draft_pick=draft_details.get("pickInRound"),
+        draft_overall=draft_details.get("overallPick"),
+    )
+
+
+def _parse_team_prospects(
+    data: dict[str, Any], team_abbrev: str
+) -> ParsedTeamProspects:
+    """Parse the full prospects response.
+
+    Args:
+        data: Raw API response
+        team_abbrev: Team abbreviation
+
+    Returns:
+        Parsed ParsedTeamProspects object
+    """
+    forwards = []
+    defensemen = []
+    goalies = []
+
+    # Parse forwards
+    for player_data in data.get("forwards", []):
+        forwards.append(_parse_prospect(player_data, team_abbrev))
+
+    # Parse defensemen
+    for player_data in data.get("defensemen", []):
+        defensemen.append(_parse_prospect(player_data, team_abbrev))
+
+    # Parse goalies
+    for player_data in data.get("goalies", []):
+        goalies.append(_parse_prospect(player_data, team_abbrev))
+
+    return ParsedTeamProspects(
+        team_abbrev=team_abbrev,
+        forwards=forwards,
+        defensemen=defensemen,
+        goalies=goalies,
+    )
+
+
+class TeamProspectsDownloader(BaseDownloader):
+    """Downloads NHL team prospect pipeline data.
+
+    Provides access to prospect information for each team including:
+    - Basic player info (name, position, size)
+    - Draft information
+    - Current team/league
+
+    Example:
+        config = TeamProspectsDownloaderConfig()
+        async with TeamProspectsDownloader(config) as downloader:
+            prospects = await downloader.get_team_prospects("TOR")
+            all_prospects = await downloader.get_all_prospects()
+    """
+
+    def __init__(
+        self,
+        config: TeamProspectsDownloaderConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the downloader.
+
+        Args:
+            config: Downloader configuration
+            **kwargs: Additional arguments passed to BaseDownloader
+        """
+        if config is None:
+            config = TeamProspectsDownloaderConfig()
+        super().__init__(config, **kwargs)
+
+    @property
+    def source_name(self) -> str:
+        """Return unique identifier for this source."""
+        return "nhl_json_team_prospects"
+
+    async def _fetch_game(self, game_id: int) -> dict[str, Any]:
+        """Not applicable for prospects - returns empty dict.
+
+        Args:
+            game_id: Not used
+
+        Returns:
+            Empty dictionary
+        """
+        # Prospects are not game-specific
+        return {}
+
+    async def _fetch_season_games(self, season_id: int) -> AsyncGenerator[int, None]:
+        """Not applicable for prospects.
+
+        Args:
+            season_id: Not used
+
+        Yields:
+            Nothing
+        """
+        # This downloader doesn't iterate over games
+        return
+        yield  # Make this a generator  # noqa: B901
+
+    async def get_team_prospects(self, team_abbrev: str) -> ParsedTeamProspects:
+        """Get prospects for a specific team.
+
+        Args:
+            team_abbrev: Team abbreviation (e.g., "TOR", "MTL")
+
+        Returns:
+            Parsed team prospects data
+
+        Raises:
+            DownloadError: If the fetch fails
+        """
+        logger.debug("Fetching prospects for %s", team_abbrev)
+
+        response = await self._get(f"/v1/roster/{team_abbrev}/prospects")
+
+        if not response.is_success:
+            raise DownloadError(
+                f"Failed to fetch prospects for {team_abbrev}: HTTP {response.status}",
+                source=self.source_name,
+            )
+
+        data = response.json()
+        return _parse_team_prospects(data, team_abbrev)
+
+    async def get_all_prospects(
+        self,
+        *,
+        teams: list[str] | None = None,
+    ) -> dict[str, ParsedTeamProspects]:
+        """Get prospects for all teams.
+
+        Args:
+            teams: Optional list of team abbreviations to fetch.
+                   If None, fetches all current NHL teams.
+
+        Returns:
+            Dictionary mapping team abbreviation to prospects data
+        """
+        if teams is None:
+            teams = CURRENT_TEAM_ABBREVS
+
+        self.set_total_items(len(teams))
+        results = {}
+
+        for team in teams:
+            try:
+                prospects = await self.get_team_prospects(team)
+                results[team] = prospects
+                logger.debug(
+                    "Fetched %d prospects for %s",
+                    len(prospects.all_prospects),
+                    team,
+                )
+            except DownloadError as e:
+                logger.warning("Failed to fetch prospects for %s: %s", team, e)
+                continue
+
+        logger.info("Fetched prospects for %d teams", len(results))
+        return results
+
+    async def persist(
+        self,
+        db: DatabaseService,
+        prospects: ParsedTeamProspects,
+    ) -> int:
+        """Persist prospect data to the database.
+
+        Args:
+            db: Database service instance
+            prospects: Parsed prospects data
+
+        Returns:
+            Number of records upserted
+        """
+        count = 0
+
+        for prospect in prospects.all_prospects:
+            await db.execute(
+                """
+                INSERT INTO prospects (
+                    player_id, first_name, last_name, position,
+                    height_inches, weight_lbs, birth_date, birth_country,
+                    shoots_catches, team_abbrev, current_team_name,
+                    draft_year, draft_round, draft_pick, draft_overall
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+                ON CONFLICT (player_id) DO UPDATE SET
+                    team_abbrev = EXCLUDED.team_abbrev,
+                    current_team_name = EXCLUDED.current_team_name,
+                    height_inches = EXCLUDED.height_inches,
+                    weight_lbs = EXCLUDED.weight_lbs,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                prospect.player_id,
+                prospect.first_name,
+                prospect.last_name,
+                prospect.position,
+                prospect.height_inches,
+                prospect.weight_lbs,
+                prospect.birth_date,
+                prospect.birth_country,
+                prospect.shoots_catches,
+                prospect.team_abbrev,
+                prospect.current_team_name,
+                prospect.draft_year,
+                prospect.draft_round,
+                prospect.draft_pick,
+                prospect.draft_overall,
+            )
+            count += 1
+
+        logger.info(
+            "Persisted %d prospects for %s",
+            count,
+            prospects.team_abbrev,
+        )
+        return count
+
+
+def create_team_prospects_downloader(
+    *,
+    requests_per_second: float = DEFAULT_RATE_LIMIT,
+    max_retries: int = 3,
+) -> TeamProspectsDownloader:
+    """Factory function to create a configured TeamProspectsDownloader.
+
+    Args:
+        requests_per_second: Rate limit for API calls
+        max_retries: Maximum retry attempts
+
+    Returns:
+        Configured TeamProspectsDownloader instance
+    """
+    config = TeamProspectsDownloaderConfig(
+        requests_per_second=requests_per_second,
+        max_retries=max_retries,
+    )
+    return TeamProspectsDownloader(config)

--- a/tests/unit/downloaders/sources/nhl_json/test_gamecenter_landing.py
+++ b/tests/unit/downloaders/sources/nhl_json/test_gamecenter_landing.py
@@ -1,0 +1,307 @@
+"""Tests for Gamecenter Landing Downloader."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nhl_api.downloaders.sources.nhl_json.gamecenter_landing import (
+    GamecenterLandingDownloader,
+    GamecenterLandingDownloaderConfig,
+    _parse_highlight,
+    _parse_landing,
+    _parse_team_matchup,
+    _parse_three_star,
+    create_gamecenter_landing_downloader,
+)
+
+
+@pytest.mark.unit
+class TestParseThreeStar:
+    """Tests for _parse_three_star function."""
+
+    def test_parse_three_star_complete(self) -> None:
+        """Test parsing a complete three star entry."""
+        star_data = {
+            "playerId": 8478402,
+            "name": {"default": "Connor McDavid"},
+            "teamAbbrev": "EDM",
+            "position": "C",
+            "goals": 2,
+            "assists": 3,
+        }
+
+        result = _parse_three_star(star_data, 1)
+
+        assert result.star == 1
+        assert result.player_id == 8478402
+        assert result.name == "Connor McDavid"
+        assert result.team_abbrev == "EDM"
+        assert result.position == "C"
+        assert result.goals == 2
+        assert result.assists == 3
+        assert result.points == 5
+
+    def test_parse_three_star_minimal(self) -> None:
+        """Test parsing a minimal three star entry."""
+        star_data: dict[str, Any] = {}
+
+        result = _parse_three_star(star_data, 2)
+
+        assert result.star == 2
+        assert result.player_id == 0
+        assert result.name == "Unknown"
+        assert result.team_abbrev == ""
+        assert result.points == 0
+
+
+@pytest.mark.unit
+class TestParseHighlight:
+    """Tests for _parse_highlight function."""
+
+    def test_parse_highlight_complete(self) -> None:
+        """Test parsing a complete highlight entry."""
+        highlight_data = {
+            "id": 12345,
+            "title": "McDavid Goal",
+            "description": "Connor McDavid scores a beauty",
+            "duration": 45,
+            "thumbnail": {"src": "https://example.com/thumb.jpg"},
+            "playbacks": [{"url": "https://example.com/video.mp4"}],
+        }
+
+        result = _parse_highlight(highlight_data)
+
+        assert result.highlight_id == 12345
+        assert result.title == "McDavid Goal"
+        assert result.description == "Connor McDavid scores a beauty"
+        assert result.duration == 45
+        assert result.thumbnail_url == "https://example.com/thumb.jpg"
+        assert result.video_url == "https://example.com/video.mp4"
+
+    def test_parse_highlight_no_playbacks(self) -> None:
+        """Test parsing highlight without playbacks."""
+        highlight_data = {
+            "id": 12346,
+            "title": "Game Recap",
+            "description": "Full game highlights",
+            "duration": 120,
+        }
+
+        result = _parse_highlight(highlight_data)
+
+        assert result.highlight_id == 12346
+        assert result.video_url is None
+        assert result.thumbnail_url is None
+
+
+@pytest.mark.unit
+class TestParseTeamMatchup:
+    """Tests for _parse_team_matchup function."""
+
+    def test_parse_team_matchup_complete(self) -> None:
+        """Test parsing complete team matchup data."""
+        team_data = {
+            "id": 22,
+            "abbrev": "EDM",
+            "name": {"default": "Oilers"},
+            "record": "25-10-3",
+            "powerPlayPct": 25.5,
+            "penaltyKillPct": 82.3,
+        }
+
+        result = _parse_team_matchup(team_data)
+
+        assert result.team_id == 22
+        assert result.abbrev == "EDM"
+        assert result.name == "Oilers"
+        assert result.record == "25-10-3"
+        assert result.power_play_pct == 25.5
+        assert result.penalty_kill_pct == 82.3
+
+
+@pytest.mark.unit
+class TestParseLanding:
+    """Tests for _parse_landing function."""
+
+    def test_parse_landing_completed_game(self) -> None:
+        """Test parsing a completed game landing page."""
+        data = {
+            "id": 2024020500,
+            "season": 20242025,
+            "gameType": 2,
+            "gameState": "OFF",
+            "venue": {"default": "Rogers Place"},
+            "attendance": 18347,
+            "neutralSite": False,
+            "firstStar": {
+                "playerId": 8478402,
+                "name": {"default": "Connor McDavid"},
+                "teamAbbrev": "EDM",
+                "position": "C",
+                "goals": 2,
+                "assists": 1,
+            },
+            "secondStar": {
+                "playerId": 8477934,
+                "name": {"default": "Leon Draisaitl"},
+                "teamAbbrev": "EDM",
+                "position": "C",
+                "goals": 1,
+                "assists": 2,
+            },
+            "thirdStar": {
+                "playerId": 8479339,
+                "name": {"default": "Evan Bouchard"},
+                "teamAbbrev": "EDM",
+                "position": "D",
+                "goals": 0,
+                "assists": 3,
+            },
+            "homeTeam": {
+                "id": 22,
+                "abbrev": "EDM",
+                "name": {"default": "Oilers"},
+                "record": "25-10-3",
+            },
+            "awayTeam": {
+                "id": 20,
+                "abbrev": "CGY",
+                "name": {"default": "Flames"},
+                "record": "15-20-5",
+            },
+        }
+
+        result = _parse_landing(data)
+
+        assert result.game_id == 2024020500
+        assert result.season_id == 20242025
+        assert result.game_type == 2
+        assert result.game_state == "OFF"
+        assert result.venue == "Rogers Place"
+        assert result.attendance == 18347
+        assert len(result.three_stars) == 3
+        assert result.three_stars[0].star == 1
+        assert result.three_stars[0].name == "Connor McDavid"
+        assert result.home_team is not None
+        assert result.home_team.abbrev == "EDM"
+        assert result.away_team is not None
+        assert result.away_team.abbrev == "CGY"
+        assert result.neutral_site is False
+
+    def test_parse_landing_future_game(self) -> None:
+        """Test parsing a future game landing page."""
+        data = {
+            "id": 2024020600,
+            "season": 20242025,
+            "gameType": 2,
+            "gameState": "FUT",
+            "venue": {"default": "Madison Square Garden"},
+            "homeTeam": {"id": 3, "abbrev": "NYR", "name": {"default": "Rangers"}},
+            "awayTeam": {"id": 4, "abbrev": "PHI", "name": {"default": "Flyers"}},
+        }
+
+        result = _parse_landing(data)
+
+        assert result.game_state == "FUT"
+        assert len(result.three_stars) == 0
+        assert result.attendance is None
+
+    def test_parse_landing_include_raw(self) -> None:
+        """Test parsing with raw data inclusion."""
+        data = {"id": 2024020500, "season": 20242025}
+
+        result = _parse_landing(data, include_raw=True)
+
+        assert result.raw_data is not None
+        assert result.raw_data["id"] == 2024020500
+
+
+@pytest.mark.unit
+class TestGamecenterLandingDownloader:
+    """Tests for GamecenterLandingDownloader class."""
+
+    @pytest.fixture
+    def mock_http_client(self) -> MagicMock:
+        """Create a mock HTTP client."""
+        client = MagicMock()
+        client.get = AsyncMock()
+        client.close = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mock_rate_limiter(self) -> MagicMock:
+        """Create a mock rate limiter."""
+        limiter = MagicMock()
+        limiter.wait = AsyncMock()
+        return limiter
+
+    @pytest.fixture
+    def downloader(
+        self, mock_http_client: MagicMock, mock_rate_limiter: MagicMock
+    ) -> GamecenterLandingDownloader:
+        """Create a downloader instance with mocks."""
+        config = GamecenterLandingDownloaderConfig()
+        dl = GamecenterLandingDownloader(
+            config,
+            http_client=mock_http_client,
+            rate_limiter=mock_rate_limiter,
+        )
+        dl._owns_http_client = False  # Don't close the mock
+        return dl
+
+    def test_source_name(self, downloader: GamecenterLandingDownloader) -> None:
+        """Test that source_name returns correct identifier."""
+        assert downloader.source_name == "nhl_json_gamecenter_landing"
+
+    @pytest.mark.asyncio
+    async def test_fetch_game_success(
+        self,
+        downloader: GamecenterLandingDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test successful game fetch."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "id": 2024020500,
+            "season": 20242025,
+            "gameType": 2,
+            "gameState": "OFF",
+        }
+        mock_http_client.get.return_value = mock_response
+
+        result = await downloader._fetch_game(2024020500)
+
+        assert result["game_id"] == 2024020500
+        assert result["season_id"] == 20242025
+
+
+@pytest.mark.unit
+class TestFactoryFunction:
+    """Tests for create_gamecenter_landing_downloader factory."""
+
+    def test_create_with_defaults(self) -> None:
+        """Test factory with default parameters."""
+        downloader = create_gamecenter_landing_downloader()
+
+        assert isinstance(downloader, GamecenterLandingDownloader)
+        assert downloader.config.requests_per_second == 5.0
+        assert downloader.config.max_retries == 3
+
+    def test_create_with_custom_params(self) -> None:
+        """Test factory with custom parameters."""
+        downloader = create_gamecenter_landing_downloader(
+            requests_per_second=2.0,
+            max_retries=5,
+            include_raw_response=True,
+        )
+
+        assert downloader.config.requests_per_second == 2.0
+        assert downloader.config.max_retries == 5

--- a/tests/unit/downloaders/sources/nhl_json/test_right_rail.py
+++ b/tests/unit/downloaders/sources/nhl_json/test_right_rail.py
@@ -1,0 +1,233 @@
+"""Tests for Right Rail Downloader."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nhl_api.downloaders.sources.nhl_json.right_rail import (
+    RightRailDownloader,
+    RightRailDownloaderConfig,
+    _parse_broadcast,
+    _parse_last_game,
+    _parse_right_rail,
+    _parse_season_series,
+    create_right_rail_downloader,
+)
+
+
+@pytest.mark.unit
+class TestParseBroadcast:
+    """Tests for _parse_broadcast function."""
+
+    def test_parse_broadcast_complete(self) -> None:
+        """Test parsing a complete broadcast entry."""
+        broadcast_data = {
+            "network": "ESPN+",
+            "countryCode": "US",
+            "type": "national",
+            "startTime": "2024-12-21T00:00:00Z",
+        }
+
+        result = _parse_broadcast(broadcast_data)
+
+        assert result.network == "ESPN+"
+        assert result.country_code == "US"
+        assert result.broadcast_type == "national"
+        assert result.start_time == "2024-12-21T00:00:00Z"
+
+    def test_parse_broadcast_minimal(self) -> None:
+        """Test parsing minimal broadcast data."""
+        broadcast_data: dict[str, Any] = {}
+
+        result = _parse_broadcast(broadcast_data)
+
+        assert result.network == ""
+        assert result.country_code == ""
+        assert result.start_time is None
+
+
+@pytest.mark.unit
+class TestParseSeasonSeries:
+    """Tests for _parse_season_series function."""
+
+    def test_parse_season_series_complete(self) -> None:
+        """Test parsing complete season series data."""
+        team_data = {
+            "wins": 2,
+            "losses": 1,
+            "otLosses": 0,
+        }
+
+        result = _parse_season_series(team_data, 22, "EDM")
+
+        assert result.team_id == 22
+        assert result.abbrev == "EDM"
+        assert result.wins == 2
+        assert result.losses == 1
+        assert result.ot_losses == 0
+
+
+@pytest.mark.unit
+class TestParseLastGame:
+    """Tests for _parse_last_game function."""
+
+    def test_parse_last_game_complete(self) -> None:
+        """Test parsing a complete last game entry."""
+        game_data = {
+            "id": 2024020300,
+            "gameDate": "2024-12-01",
+            "homeTeam": {"abbrev": "EDM", "score": 5},
+            "awayTeam": {"abbrev": "CGY", "score": 3},
+        }
+
+        result = _parse_last_game(game_data)
+
+        assert result.game_id == 2024020300
+        assert result.game_date == "2024-12-01"
+        assert result.home_team_abbrev == "EDM"
+        assert result.away_team_abbrev == "CGY"
+        assert result.home_score == 5
+        assert result.away_score == 3
+
+
+@pytest.mark.unit
+class TestParseRightRail:
+    """Tests for _parse_right_rail function."""
+
+    def test_parse_right_rail_complete(self) -> None:
+        """Test parsing complete right rail data."""
+        data = {
+            "id": 2024020500,
+            "season": 20242025,
+            "broadcasts": [
+                {"network": "ESPN+", "countryCode": "US", "type": "national"},
+                {"network": "SN", "countryCode": "CA", "type": "national"},
+            ],
+            "seasonSeries": {
+                "series": [
+                    {"teamId": 22, "teamAbbrev": "EDM", "wins": 2, "losses": 1},
+                    {"teamId": 20, "teamAbbrev": "CGY", "wins": 1, "losses": 2},
+                ]
+            },
+        }
+
+        result = _parse_right_rail(data)
+
+        assert result.game_id == 2024020500
+        assert result.season_id == 20242025
+        assert len(result.broadcasts) == 2
+        assert result.broadcasts[0].network == "ESPN+"
+        assert result.home_series is not None
+        assert result.home_series.abbrev == "EDM"
+        assert result.away_series is not None
+        assert result.away_series.abbrev == "CGY"
+
+    def test_parse_right_rail_minimal(self) -> None:
+        """Test parsing minimal right rail data."""
+        data = {"id": 2024020500}
+
+        result = _parse_right_rail(data)
+
+        assert result.game_id == 2024020500
+        assert len(result.broadcasts) == 0
+        assert result.home_series is None
+        assert result.away_series is None
+
+    def test_parse_right_rail_include_raw(self) -> None:
+        """Test parsing with raw data inclusion."""
+        data = {"id": 2024020500, "season": 20242025}
+
+        result = _parse_right_rail(data, include_raw=True)
+
+        assert result.raw_data is not None
+        assert result.raw_data["id"] == 2024020500
+
+
+@pytest.mark.unit
+class TestRightRailDownloader:
+    """Tests for RightRailDownloader class."""
+
+    @pytest.fixture
+    def mock_http_client(self) -> MagicMock:
+        """Create a mock HTTP client."""
+        client = MagicMock()
+        client.get = AsyncMock()
+        client.close = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mock_rate_limiter(self) -> MagicMock:
+        """Create a mock rate limiter."""
+        limiter = MagicMock()
+        limiter.wait = AsyncMock()
+        return limiter
+
+    @pytest.fixture
+    def downloader(
+        self, mock_http_client: MagicMock, mock_rate_limiter: MagicMock
+    ) -> RightRailDownloader:
+        """Create a downloader instance with mocks."""
+        config = RightRailDownloaderConfig()
+        dl = RightRailDownloader(
+            config,
+            http_client=mock_http_client,
+            rate_limiter=mock_rate_limiter,
+        )
+        dl._owns_http_client = False  # Don't close the mock
+        return dl
+
+    def test_source_name(self, downloader: RightRailDownloader) -> None:
+        """Test that source_name returns correct identifier."""
+        assert downloader.source_name == "nhl_json_right_rail"
+
+    @pytest.mark.asyncio
+    async def test_fetch_game_success(
+        self,
+        downloader: RightRailDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test successful game fetch."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "id": 2024020500,
+            "season": 20242025,
+            "broadcasts": [],
+        }
+        mock_http_client.get.return_value = mock_response
+
+        result = await downloader._fetch_game(2024020500)
+
+        assert result["game_id"] == 2024020500
+        assert result["season_id"] == 20242025
+
+
+@pytest.mark.unit
+class TestFactoryFunction:
+    """Tests for create_right_rail_downloader factory."""
+
+    def test_create_with_defaults(self) -> None:
+        """Test factory with default parameters."""
+        downloader = create_right_rail_downloader()
+
+        assert isinstance(downloader, RightRailDownloader)
+        assert downloader.config.requests_per_second == 5.0
+        assert downloader.config.max_retries == 3
+
+    def test_create_with_custom_params(self) -> None:
+        """Test factory with custom parameters."""
+        downloader = create_right_rail_downloader(
+            requests_per_second=2.0,
+            max_retries=5,
+            include_raw_response=True,
+        )
+
+        assert downloader.config.requests_per_second == 2.0
+        assert downloader.config.max_retries == 5

--- a/tests/unit/downloaders/sources/nhl_json/test_season_info.py
+++ b/tests/unit/downloaders/sources/nhl_json/test_season_info.py
@@ -1,0 +1,278 @@
+"""Tests for Season Info Downloader."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nhl_api.downloaders.sources.nhl_json.season_info import (
+    SeasonInfoDownloader,
+    SeasonInfoDownloaderConfig,
+    _parse_date,
+    _parse_season,
+    create_season_info_downloader,
+)
+
+
+@pytest.mark.unit
+class TestParseDate:
+    """Tests for _parse_date function."""
+
+    def test_parse_valid_date(self) -> None:
+        """Test parsing a valid date string."""
+        result = _parse_date("2024-10-04")
+
+        assert result == date(2024, 10, 4)
+
+    def test_parse_none(self) -> None:
+        """Test parsing None returns None."""
+        result = _parse_date(None)
+
+        assert result is None
+
+    def test_parse_invalid_date(self) -> None:
+        """Test parsing invalid date returns None."""
+        result = _parse_date("not-a-date")
+
+        assert result is None
+
+
+@pytest.mark.unit
+class TestParseSeason:
+    """Tests for _parse_season function."""
+
+    def test_parse_season_complete(self) -> None:
+        """Test parsing complete season data."""
+        season_data = {
+            "id": 20242025,
+            "regularSeasonStartDate": "2024-10-04",
+            "regularSeasonEndDate": "2025-04-17",
+            "playoffEndDate": "2025-04-19",
+            "seasonEndDate": "2025-06-30",
+            "numberOfGames": 82,
+            "tiesInUse": False,
+            "olympicsParticipation": False,
+            "conferencesInUse": True,
+            "divisionsInUse": True,
+        }
+
+        result = _parse_season(season_data)
+
+        assert result.season_id == 20242025
+        assert result.regular_season_start == date(2024, 10, 4)
+        assert result.regular_season_end == date(2025, 4, 17)
+        assert result.number_of_games == 82
+        assert result.ties_in_use is False
+        assert result.conference_in_use is True
+        assert result.division_in_use is True
+
+    def test_parse_season_minimal(self) -> None:
+        """Test parsing minimal season data."""
+        season_data = {"id": 20242025}
+
+        result = _parse_season(season_data)
+
+        assert result.season_id == 20242025
+        assert result.regular_season_start is None
+        assert result.number_of_games == 82  # default
+        assert result.ties_in_use is False
+
+    def test_parse_historical_season(self) -> None:
+        """Test parsing a historical season with ties."""
+        season_data = {
+            "id": 19992000,
+            "regularSeasonStartDate": "1999-10-01",
+            "regularSeasonEndDate": "2000-04-09",
+            "numberOfGames": 82,
+            "tiesInUse": True,
+            "conferencesInUse": True,
+            "divisionsInUse": True,
+        }
+
+        result = _parse_season(season_data)
+
+        assert result.season_id == 19992000
+        assert result.ties_in_use is True
+
+
+@pytest.mark.unit
+class TestSeasonInfoDownloader:
+    """Tests for SeasonInfoDownloader class."""
+
+    @pytest.fixture
+    def mock_http_client(self) -> MagicMock:
+        """Create a mock HTTP client."""
+        client = MagicMock()
+        client.get = AsyncMock()
+        client.close = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mock_rate_limiter(self) -> MagicMock:
+        """Create a mock rate limiter."""
+        limiter = MagicMock()
+        limiter.wait = AsyncMock()
+        return limiter
+
+    @pytest.fixture
+    def downloader(
+        self, mock_http_client: MagicMock, mock_rate_limiter: MagicMock
+    ) -> SeasonInfoDownloader:
+        """Create a downloader instance with mocks."""
+        config = SeasonInfoDownloaderConfig()
+        dl = SeasonInfoDownloader(
+            config,
+            http_client=mock_http_client,
+            rate_limiter=mock_rate_limiter,
+        )
+        dl._owns_http_client = False  # Don't close the mock
+        return dl
+
+    def test_source_name(self, downloader: SeasonInfoDownloader) -> None:
+        """Test that source_name returns correct identifier."""
+        assert downloader.source_name == "nhl_json_season_info"
+
+    @pytest.mark.asyncio
+    async def test_get_all_seasons(
+        self,
+        downloader: SeasonInfoDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test fetching all seasons."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = [
+            {"id": 20242025, "numberOfGames": 82},
+            {"id": 20232024, "numberOfGames": 82},
+            {"id": 20222023, "numberOfGames": 82},
+        ]
+        mock_http_client.get.return_value = mock_response
+
+        result = await downloader.get_all_seasons()
+
+        assert len(result) == 3
+        # Should be sorted newest first
+        assert result[0].season_id == 20242025
+        assert result[1].season_id == 20232024
+        assert result[2].season_id == 20222023
+
+    @pytest.mark.asyncio
+    async def test_get_season_specific(
+        self,
+        downloader: SeasonInfoDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test fetching a specific season."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = [
+            {"id": 20242025, "numberOfGames": 82},
+            {"id": 20232024, "numberOfGames": 82},
+        ]
+        mock_http_client.get.return_value = mock_response
+
+        result = await downloader.get_season(20232024)
+
+        assert result is not None
+        assert result.season_id == 20232024
+
+    @pytest.mark.asyncio
+    async def test_get_season_not_found(
+        self,
+        downloader: SeasonInfoDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test fetching a non-existent season."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = [
+            {"id": 20242025, "numberOfGames": 82},
+        ]
+        mock_http_client.get.return_value = mock_response
+
+        result = await downloader.get_season(19001901)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_caching(
+        self,
+        downloader: SeasonInfoDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test that results are cached."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = [{"id": 20242025}]
+        mock_http_client.get.return_value = mock_response
+
+        # First call should fetch
+        await downloader.get_all_seasons()
+        # Second call should use cache
+        await downloader.get_all_seasons()
+
+        # HTTP should only be called once
+        assert mock_http_client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_force_refresh(
+        self,
+        downloader: SeasonInfoDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test force refresh bypasses cache."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = [{"id": 20242025}]
+        mock_http_client.get.return_value = mock_response
+
+        await downloader.get_all_seasons()
+        await downloader.get_all_seasons(force_refresh=True)
+
+        # Should be called twice
+        assert mock_http_client.get.call_count == 2
+
+
+@pytest.mark.unit
+class TestFactoryFunction:
+    """Tests for create_season_info_downloader factory."""
+
+    def test_create_with_defaults(self) -> None:
+        """Test factory with default parameters."""
+        downloader = create_season_info_downloader()
+
+        assert isinstance(downloader, SeasonInfoDownloader)
+        assert downloader.config.requests_per_second == 5.0
+        assert downloader.config.max_retries == 3
+
+    def test_create_with_custom_params(self) -> None:
+        """Test factory with custom parameters."""
+        downloader = create_season_info_downloader(
+            requests_per_second=2.0,
+            max_retries=5,
+        )
+
+        assert downloader.config.requests_per_second == 2.0
+        assert downloader.config.max_retries == 5

--- a/tests/unit/downloaders/sources/nhl_json/test_team_prospects.py
+++ b/tests/unit/downloaders/sources/nhl_json/test_team_prospects.py
@@ -1,0 +1,284 @@
+"""Tests for Team Prospects Downloader."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nhl_api.downloaders.sources.nhl_json.team_prospects import (
+    TeamProspectsDownloader,
+    TeamProspectsDownloaderConfig,
+    _parse_prospect,
+    _parse_team_prospects,
+    create_team_prospects_downloader,
+)
+
+
+@pytest.mark.unit
+class TestParseProspect:
+    """Tests for _parse_prospect function."""
+
+    def test_parse_prospect_complete(self) -> None:
+        """Test parsing a complete prospect entry."""
+        player_data = {
+            "id": 8484144,
+            "firstName": {"default": "Connor"},
+            "lastName": {"default": "Bedard"},
+            "sweaterNumber": 98,
+            "positionCode": "C",
+            "heightInInches": 70,
+            "weightInPounds": 185,
+            "birthDate": "2005-07-17",
+            "birthCity": {"default": "North Vancouver"},
+            "birthCountry": "CAN",
+            "shootsCatches": "R",
+            "currentTeamAbbrev": "CHI",
+            "draftDetails": {
+                "year": 2023,
+                "round": 1,
+                "pickInRound": 1,
+                "overallPick": 1,
+            },
+        }
+
+        result = _parse_prospect(player_data, "CHI")
+
+        assert result.player_id == 8484144
+        assert result.first_name == "Connor"
+        assert result.last_name == "Bedard"
+        assert result.full_name == "Connor Bedard"
+        assert result.sweater_number == 98
+        assert result.position == "C"
+        assert result.height_inches == 70
+        assert result.weight_lbs == 185
+        assert result.birth_date == "2005-07-17"
+        assert result.birth_country == "CAN"
+        assert result.shoots_catches == "R"
+        assert result.team_abbrev == "CHI"
+        assert result.draft_year == 2023
+        assert result.draft_round == 1
+        assert result.draft_pick == 1
+        assert result.draft_overall == 1
+
+    def test_parse_prospect_minimal(self) -> None:
+        """Test parsing minimal prospect data."""
+        player_data = {
+            "id": 8484000,
+            "firstName": {"default": "Test"},
+            "lastName": {"default": "Player"},
+        }
+
+        result = _parse_prospect(player_data, "TOR")
+
+        assert result.player_id == 8484000
+        assert result.first_name == "Test"
+        assert result.last_name == "Player"
+        assert result.team_abbrev == "TOR"
+        assert result.draft_year is None
+        assert result.draft_overall is None
+
+    def test_parse_prospect_undrafted(self) -> None:
+        """Test parsing an undrafted prospect."""
+        player_data = {
+            "id": 8484001,
+            "firstName": {"default": "Undrafted"},
+            "lastName": {"default": "Player"},
+            "positionCode": "D",
+            "draftDetails": {},  # Empty draft details
+        }
+
+        result = _parse_prospect(player_data, "MTL")
+
+        assert result.draft_year is None
+        assert result.draft_round is None
+        assert result.draft_pick is None
+        assert result.draft_overall is None
+
+
+@pytest.mark.unit
+class TestParseTeamProspects:
+    """Tests for _parse_team_prospects function."""
+
+    def test_parse_team_prospects_complete(self) -> None:
+        """Test parsing complete team prospects data."""
+        data = {
+            "forwards": [
+                {
+                    "id": 8484144,
+                    "firstName": {"default": "Connor"},
+                    "lastName": {"default": "Bedard"},
+                    "positionCode": "C",
+                },
+                {
+                    "id": 8484145,
+                    "firstName": {"default": "Test"},
+                    "lastName": {"default": "Forward"},
+                    "positionCode": "L",
+                },
+            ],
+            "defensemen": [
+                {
+                    "id": 8484146,
+                    "firstName": {"default": "Test"},
+                    "lastName": {"default": "Defenseman"},
+                    "positionCode": "D",
+                },
+            ],
+            "goalies": [
+                {
+                    "id": 8484147,
+                    "firstName": {"default": "Test"},
+                    "lastName": {"default": "Goalie"},
+                    "positionCode": "G",
+                },
+            ],
+        }
+
+        result = _parse_team_prospects(data, "CHI")
+
+        assert result.team_abbrev == "CHI"
+        assert len(result.forwards) == 2
+        assert len(result.defensemen) == 1
+        assert len(result.goalies) == 1
+        assert len(result.all_prospects) == 4
+
+    def test_parse_team_prospects_empty(self) -> None:
+        """Test parsing empty prospects data."""
+        data: dict[str, Any] = {}
+
+        result = _parse_team_prospects(data, "TOR")
+
+        assert result.team_abbrev == "TOR"
+        assert len(result.forwards) == 0
+        assert len(result.defensemen) == 0
+        assert len(result.goalies) == 0
+        assert len(result.all_prospects) == 0
+
+
+@pytest.mark.unit
+class TestTeamProspectsDownloader:
+    """Tests for TeamProspectsDownloader class."""
+
+    @pytest.fixture
+    def mock_http_client(self) -> MagicMock:
+        """Create a mock HTTP client."""
+        client = MagicMock()
+        client.get = AsyncMock()
+        client.close = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mock_rate_limiter(self) -> MagicMock:
+        """Create a mock rate limiter."""
+        limiter = MagicMock()
+        limiter.wait = AsyncMock()
+        return limiter
+
+    @pytest.fixture
+    def downloader(
+        self, mock_http_client: MagicMock, mock_rate_limiter: MagicMock
+    ) -> TeamProspectsDownloader:
+        """Create a downloader instance with mocks."""
+        config = TeamProspectsDownloaderConfig()
+        dl = TeamProspectsDownloader(
+            config,
+            http_client=mock_http_client,
+            rate_limiter=mock_rate_limiter,
+        )
+        dl._owns_http_client = False  # Don't close the mock
+        return dl
+
+    def test_source_name(self, downloader: TeamProspectsDownloader) -> None:
+        """Test that source_name returns correct identifier."""
+        assert downloader.source_name == "nhl_json_team_prospects"
+
+    @pytest.mark.asyncio
+    async def test_get_team_prospects(
+        self,
+        downloader: TeamProspectsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test fetching team prospects."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "forwards": [
+                {
+                    "id": 8484144,
+                    "firstName": {"default": "Connor"},
+                    "lastName": {"default": "Bedard"},
+                    "positionCode": "C",
+                }
+            ],
+            "defensemen": [],
+            "goalies": [],
+        }
+        mock_http_client.get.return_value = mock_response
+
+        result = await downloader.get_team_prospects("CHI")
+
+        assert result.team_abbrev == "CHI"
+        assert len(result.forwards) == 1
+        assert result.forwards[0].first_name == "Connor"
+
+    @pytest.mark.asyncio
+    async def test_get_all_prospects(
+        self,
+        downloader: TeamProspectsDownloader,
+        mock_http_client: MagicMock,
+    ) -> None:
+        """Test fetching all teams' prospects."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.is_rate_limited = False
+        mock_response.is_server_error = False
+        mock_response.status = 200
+        mock_response.retry_after = None
+        mock_response.json.return_value = {
+            "forwards": [
+                {
+                    "id": 8484144,
+                    "firstName": {"default": "Test"},
+                    "lastName": {"default": "Player"},
+                }
+            ],
+            "defensemen": [],
+            "goalies": [],
+        }
+        mock_http_client.get.return_value = mock_response
+
+        # Limit to 2 teams for testing
+        result = await downloader.get_all_prospects(teams=["TOR", "MTL"])
+
+        assert len(result) == 2
+        assert "TOR" in result
+        assert "MTL" in result
+
+
+@pytest.mark.unit
+class TestFactoryFunction:
+    """Tests for create_team_prospects_downloader factory."""
+
+    def test_create_with_defaults(self) -> None:
+        """Test factory with default parameters."""
+        downloader = create_team_prospects_downloader()
+
+        assert isinstance(downloader, TeamProspectsDownloader)
+        assert downloader.config.requests_per_second == 5.0
+        assert downloader.config.max_retries == 3
+
+    def test_create_with_custom_params(self) -> None:
+        """Test factory with custom parameters."""
+        downloader = create_team_prospects_downloader(
+            requests_per_second=2.0,
+            max_retries=5,
+        )
+
+        assert downloader.config.requests_per_second == 2.0
+        assert downloader.config.max_retries == 5


### PR DESCRIPTION
## Summary

Implements Phase 1 of issue #257, adding four new NHL JSON API downloaders for high-priority endpoints:

- **GamecenterLandingDownloader** - Game overview, three stars, highlights, matchup info (`/v1/gamecenter/{game_id}/landing`)
- **RightRailDownloader** - Broadcast info, season series, game context (`/v1/gamecenter/{game_id}/right-rail`)
- **SeasonInfoDownloader** - Season metadata with caching (`/v1/season`)
- **TeamProspectsDownloader** - Team prospect pipeline data (`/v1/roster/{team}/prospects`)

Each downloader follows the established patterns with:
- Typed dataclasses for parsed data
- Factory functions for easy instantiation
- Comprehensive unit tests (47 new tests)
- Exports in __init__.py

## Test Plan

- [x] All 47 new unit tests pass
- [x] Mypy type checking passes
- [x] Ruff linting passes
- [x] Pre-commit hooks pass

## Closes

Partially addresses #257 (Phase 1 endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)