### PR TITLE
feat(analytics): Add Wave 3 matchup analysis (#261)

### DIFF
--- a/src/nhl_api/models/matchups.py
+++ b/src/nhl_api/models/matchups.py
@@ -1,0 +1,202 @@
+"""Data models for player matchup analysis.
+
+This module defines dataclass models for tracking player matchups,
+including time-on-ice together/against and zone-based metrics.
+
+Example usage:
+    # Get matchup data
+    matchup = PlayerMatchup(
+        player1_id=8478402,
+        player2_id=8477934,
+        matchup_type=MatchupType.TEAMMATE,
+        toi_seconds=1250,
+    )
+
+Issue: #261 - Wave 3: Matchup Analysis
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class MatchupType(str, Enum):
+    """Type of player matchup."""
+
+    TEAMMATE = "teammate"  # Players on same team
+    OPPONENT = "opponent"  # Players on opposing teams
+
+
+class Zone(str, Enum):
+    """Ice zone classification."""
+
+    OFFENSIVE = "O"  # Attacking zone
+    DEFENSIVE = "D"  # Defending zone
+    NEUTRAL = "N"  # Neutral zone
+
+
+@dataclass(frozen=True, slots=True)
+class PlayerMatchup:
+    """A matchup record between two players.
+
+    Represents shared ice time between two players, either as
+    teammates or opponents.
+
+    Attributes:
+        player1_id: First player ID (lower ID for consistency).
+        player2_id: Second player ID (higher ID for consistency).
+        matchup_type: Whether players are teammates or opponents.
+        toi_seconds: Total time on ice together in seconds.
+        game_count: Number of games with shared ice time.
+        situation_breakdown: TOI by situation code (e.g., {"5v5": 800}).
+    """
+
+    player1_id: int
+    player2_id: int
+    matchup_type: MatchupType
+    toi_seconds: int = 0
+    game_count: int = 0
+    situation_breakdown: dict[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Ensure player1_id < player2_id for consistency."""
+        if self.player1_id > self.player2_id:
+            # Swap using object.__setattr__ since frozen
+            # Must save both values first before swapping
+            p1, p2 = self.player1_id, self.player2_id
+            object.__setattr__(self, "player1_id", p2)
+            object.__setattr__(self, "player2_id", p1)
+
+    @property
+    def toi_minutes(self) -> float:
+        """Time on ice in minutes."""
+        return self.toi_seconds / 60.0
+
+    @property
+    def toi_display(self) -> str:
+        """Display time as MM:SS."""
+        minutes = self.toi_seconds // 60
+        seconds = self.toi_seconds % 60
+        return f"{minutes}:{seconds:02d}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "player1_id": self.player1_id,
+            "player2_id": self.player2_id,
+            "matchup_type": self.matchup_type.value,
+            "toi_seconds": self.toi_seconds,
+            "toi_minutes": round(self.toi_minutes, 2),
+            "game_count": self.game_count,
+            "situation_breakdown": self.situation_breakdown,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneMatchup:
+    """A zone-specific matchup record.
+
+    Extends PlayerMatchup with zone-based time tracking.
+
+    Attributes:
+        player1_id: First player ID.
+        player2_id: Second player ID.
+        matchup_type: Whether players are teammates or opponents.
+        zone: The zone where this matchup occurred.
+        toi_seconds: Time on ice in this zone.
+        event_count: Number of events in this zone during matchup.
+    """
+
+    player1_id: int
+    player2_id: int
+    matchup_type: MatchupType
+    zone: Zone
+    toi_seconds: int = 0
+    event_count: int = 0
+
+    @property
+    def toi_minutes(self) -> float:
+        """Time on ice in minutes."""
+        return self.toi_seconds / 60.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "player1_id": self.player1_id,
+            "player2_id": self.player2_id,
+            "matchup_type": self.matchup_type.value,
+            "zone": self.zone.value,
+            "toi_seconds": self.toi_seconds,
+            "toi_minutes": round(self.toi_minutes, 2),
+            "event_count": self.event_count,
+        }
+
+
+@dataclass
+class MatchupResult:
+    """Result of querying matchup data.
+
+    Attributes:
+        player_id: The focus player.
+        teammates: List of teammate matchups.
+        opponents: List of opponent matchups.
+        total_games: Total games in the dataset.
+        filters_applied: Filters used in the query.
+    """
+
+    player_id: int
+    teammates: list[PlayerMatchup] = field(default_factory=list)
+    opponents: list[PlayerMatchup] = field(default_factory=list)
+    total_games: int = 0
+    filters_applied: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def top_teammates(self) -> list[PlayerMatchup]:
+        """Get top 5 teammates by TOI."""
+        return sorted(self.teammates, key=lambda m: m.toi_seconds, reverse=True)[:5]
+
+    @property
+    def top_opponents(self) -> list[PlayerMatchup]:
+        """Get top 5 opponents by TOI."""
+        return sorted(self.opponents, key=lambda m: m.toi_seconds, reverse=True)[:5]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "player_id": self.player_id,
+            "teammates": [m.to_dict() for m in self.teammates],
+            "opponents": [m.to_dict() for m in self.opponents],
+            "total_games": self.total_games,
+            "filters_applied": self.filters_applied,
+        }
+
+
+@dataclass
+class GameMatchupSummary:
+    """Summary of matchups for a single game.
+
+    Attributes:
+        game_id: NHL game ID.
+        home_team_id: Home team ID.
+        away_team_id: Away team ID.
+        matchup_count: Total number of unique matchups.
+        top_matchups: Top matchups by TOI.
+    """
+
+    game_id: int
+    home_team_id: int
+    away_team_id: int
+    matchup_count: int = 0
+    top_matchups: list[PlayerMatchup] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "game_id": self.game_id,
+            "home_team_id": self.home_team_id,
+            "away_team_id": self.away_team_id,
+            "matchup_count": self.matchup_count,
+            "top_matchups": [m.to_dict() for m in self.top_matchups],
+        }

--- a/src/nhl_api/services/analytics/__init__.py
+++ b/src/nhl_api/services/analytics/__init__.py
@@ -13,7 +13,12 @@ Example usage:
         attributor = EventAttributor(db)
         events = await attributor.get_game_events(game_id=2024020500)
 
+        # Matchup analysis (Wave 3)
+        matchup_service = MatchupService(db)
+        matchups = await matchup_service.get_player_matchups(8478402)
+
 Issue: #259 - Second-by-Second Analytics
+Issue: #261 - Wave 3: Matchup Analysis
 """
 
 from nhl_api.services.analytics.event_attributor import (
@@ -21,6 +26,11 @@ from nhl_api.services.analytics.event_attributor import (
     EventAttribution,
     EventAttributor,
     GameEvent,
+)
+from nhl_api.services.analytics.matchup_service import (
+    MatchupAggregation,
+    MatchupQueryFilters,
+    MatchupService,
 )
 from nhl_api.services.analytics.shift_expander import (
     ExpandedSecond,
@@ -31,6 +41,11 @@ from nhl_api.services.analytics.situation import (
     Situation,
     SituationCalculator,
     SituationType,
+)
+from nhl_api.services.analytics.zone_detection import (
+    Zone,
+    ZoneDetector,
+    ZoneResult,
 )
 
 __all__ = [
@@ -47,4 +62,12 @@ __all__ = [
     "SituationCalculator",
     "Situation",
     "SituationType",
+    # Matchup analysis (Wave 3)
+    "MatchupService",
+    "MatchupQueryFilters",
+    "MatchupAggregation",
+    # Zone detection (Wave 3)
+    "ZoneDetector",
+    "Zone",
+    "ZoneResult",
 ]

--- a/src/nhl_api/services/analytics/matchup_service.py
+++ b/src/nhl_api/services/analytics/matchup_service.py
@@ -1,0 +1,808 @@
+"""Matchup analysis service for player pair ice time tracking.
+
+Provides functionality for analyzing player matchups including:
+- Time on ice together (teammates)
+- Time on ice against (opponents)
+- Zone-based matchup filtering
+- Situation-based breakdowns
+
+The service queries the second_snapshots table to calculate
+shared ice time between player pairs.
+
+Example usage:
+    async with DatabaseService() as db:
+        service = MatchupService(db)
+
+        # Get all matchups for a player
+        result = await service.get_player_matchups(
+            player_id=8478402,
+            season_id=20242025,
+        )
+
+        # Get defensive zone matchups only
+        def_matchups = await service.get_defensive_zone_matchups(
+            player_id=8478402,
+            game_id=2024020500,
+        )
+
+Issue: #261 - Wave 3: Matchup Analysis (T019-T023)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from itertools import combinations
+from typing import TYPE_CHECKING, Any
+
+from nhl_api.models.matchups import (
+    GameMatchupSummary,
+    MatchupResult,
+    MatchupType,
+    PlayerMatchup,
+    ZoneMatchup,
+)
+from nhl_api.services.analytics.zone_detection import Zone, ZoneDetector
+
+if TYPE_CHECKING:
+    from nhl_api.services.db.connection import DatabaseService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MatchupQueryFilters:
+    """Filters for matchup queries.
+
+    Attributes:
+        game_id: Filter to specific game.
+        season_id: Filter to specific season.
+        situation_codes: Filter to specific situations (e.g., ["5v5"]).
+        zone: Filter to specific zone.
+        min_toi_seconds: Minimum TOI threshold.
+        exclude_empty_net: Exclude empty net situations.
+    """
+
+    game_id: int | None = None
+    season_id: int | None = None
+    situation_codes: list[str] | None = None
+    zone: Zone | None = None
+    min_toi_seconds: int = 0
+    exclude_empty_net: bool = False
+
+
+@dataclass
+class MatchupAggregation:
+    """Aggregated matchup data for a player pair.
+
+    Attributes:
+        player1_id: First player ID.
+        player2_id: Second player ID.
+        matchup_type: Teammate or opponent.
+        total_toi: Total time on ice together.
+        game_count: Number of games with shared ice time.
+        by_situation: Breakdown by situation code.
+        by_zone: Breakdown by zone.
+    """
+
+    player1_id: int
+    player2_id: int
+    matchup_type: MatchupType
+    total_toi: int = 0
+    game_count: int = 0
+    by_situation: dict[str, int] = field(default_factory=dict)
+    by_zone: dict[str, int] = field(default_factory=dict)
+
+
+class MatchupService:
+    """Service for analyzing player matchups.
+
+    Provides methods for querying and aggregating player pair
+    ice time from second_snapshots data.
+
+    Attributes:
+        db: Database service for data access.
+        zone_detector: Zone detection service.
+
+    Example:
+        >>> service = MatchupService(db)
+        >>> matchups = await service.get_player_matchups(8478402)
+        >>> print(f"Top opponent: {matchups.top_opponents[0]}")
+    """
+
+    def __init__(self, db: DatabaseService) -> None:
+        """Initialize the MatchupService.
+
+        Args:
+            db: Database service for data access.
+        """
+        self.db = db
+        self.zone_detector = ZoneDetector()
+
+    async def get_player_matchups(
+        self,
+        player_id: int,
+        *,
+        season_id: int | None = None,
+        game_id: int | None = None,
+        situation_codes: list[str] | None = None,
+        min_toi_seconds: int = 60,
+    ) -> MatchupResult:
+        """Get all matchups for a player.
+
+        Returns both teammate and opponent matchups with TOI.
+
+        Args:
+            player_id: The player to analyze.
+            season_id: Filter to specific season.
+            game_id: Filter to specific game.
+            situation_codes: Filter to specific situations.
+            min_toi_seconds: Minimum TOI threshold (default 60s).
+
+        Returns:
+            MatchupResult with teammates and opponents.
+        """
+        filters = MatchupQueryFilters(
+            game_id=game_id,
+            season_id=season_id,
+            situation_codes=situation_codes,
+            min_toi_seconds=min_toi_seconds,
+        )
+
+        # Get teammate matchups
+        teammates = await self._get_teammate_matchups(player_id, filters)
+
+        # Get opponent matchups
+        opponents = await self._get_opponent_matchups(player_id, filters)
+
+        # Get game count
+        game_count = await self._get_game_count(player_id, filters)
+
+        return MatchupResult(
+            player_id=player_id,
+            teammates=teammates,
+            opponents=opponents,
+            total_games=game_count,
+            filters_applied={
+                "season_id": season_id,
+                "game_id": game_id,
+                "situation_codes": situation_codes,
+                "min_toi_seconds": min_toi_seconds,
+            },
+        )
+
+    async def get_ice_time_together(
+        self,
+        player1_id: int,
+        player2_id: int,
+        *,
+        season_id: int | None = None,
+        game_id: int | None = None,
+        situation_code: str | None = None,
+    ) -> int:
+        """Calculate total ice time together for two players.
+
+        Works for both teammates and opponents.
+
+        Args:
+            player1_id: First player ID.
+            player2_id: Second player ID.
+            season_id: Filter to specific season.
+            game_id: Filter to specific game.
+            situation_code: Filter to specific situation.
+
+        Returns:
+            Total seconds on ice together.
+        """
+        # Build WHERE clause
+        conditions = ["1=1"]
+        params: list[Any] = []
+        param_idx = 1
+
+        if game_id:
+            conditions.append(f"game_id = ${param_idx}")
+            params.append(game_id)
+            param_idx += 1
+
+        if season_id:
+            conditions.append(f"season_id = ${param_idx}")
+            params.append(season_id)
+            param_idx += 1
+
+        if situation_code:
+            conditions.append(f"situation_code = ${param_idx}")
+            params.append(situation_code)
+            param_idx += 1
+
+        # Check both players on ice (either team)
+        conditions.append(
+            f"(${param_idx} = ANY(home_skater_ids) OR ${param_idx} = ANY(away_skater_ids))"
+        )
+        params.append(player1_id)
+        param_idx += 1
+
+        conditions.append(
+            f"(${param_idx} = ANY(home_skater_ids) OR ${param_idx} = ANY(away_skater_ids))"
+        )
+        params.append(player2_id)
+
+        query = f"""
+            SELECT COUNT(*) as toi_seconds
+            FROM second_snapshots
+            WHERE {' AND '.join(conditions)}
+        """
+
+        result = await self.db.fetchval(query, *params)
+        return result or 0
+
+    async def get_defensive_zone_matchups(
+        self,
+        player_id: int,
+        *,
+        game_id: int | None = None,
+        season_id: int | None = None,
+    ) -> list[ZoneMatchup]:
+        """Get matchups in defensive zone only.
+
+        Filters to seconds where events occurred in the player's
+        defensive zone.
+
+        Args:
+            player_id: The player to analyze.
+            game_id: Filter to specific game.
+            season_id: Filter to specific season.
+
+        Returns:
+            List of ZoneMatchup objects for defensive zone.
+        """
+        # Get game info to determine which team the player is on
+        filters = MatchupQueryFilters(game_id=game_id, season_id=season_id)
+
+        # For defensive zone, we need to join with game_events
+        # and filter by zone = 'D' from the player's perspective
+        opponents = await self._get_zone_matchups(
+            player_id,
+            filters,
+            zone=Zone.DEFENSIVE,
+            matchup_type=MatchupType.OPPONENT,
+        )
+
+        return opponents
+
+    async def get_game_matchup_summary(
+        self,
+        game_id: int,
+    ) -> GameMatchupSummary:
+        """Get matchup summary for a game.
+
+        Args:
+            game_id: NHL game ID.
+
+        Returns:
+            GameMatchupSummary with top matchups.
+        """
+        # Get game info
+        game_info = await self.db.fetchrow(
+            """
+            SELECT game_id, home_team_id, away_team_id
+            FROM games WHERE game_id = $1
+            """,
+            game_id,
+        )
+
+        if not game_info:
+            raise ValueError(f"Game {game_id} not found")
+
+        # Get all opponent matchups for this game
+        matchups = await self._get_all_opponent_matchups(game_id)
+
+        # Sort by TOI and get top 10
+        top_matchups = sorted(matchups, key=lambda m: m.toi_seconds, reverse=True)[:10]
+
+        return GameMatchupSummary(
+            game_id=game_id,
+            home_team_id=game_info["home_team_id"],
+            away_team_id=game_info["away_team_id"],
+            matchup_count=len(matchups),
+            top_matchups=top_matchups,
+        )
+
+    async def aggregate_matchups(
+        self,
+        player_id: int,
+        filters: MatchupQueryFilters,
+    ) -> list[MatchupAggregation]:
+        """Aggregate matchup data with multiple breakdowns.
+
+        Args:
+            player_id: Player to analyze.
+            filters: Query filters.
+
+        Returns:
+            List of MatchupAggregation objects.
+        """
+        # Get raw matchup data
+        opponents = await self._get_opponent_matchups(player_id, filters)
+        teammates = await self._get_teammate_matchups(player_id, filters)
+
+        aggregations = []
+
+        for matchup in opponents:
+            aggregations.append(
+                MatchupAggregation(
+                    player1_id=matchup.player1_id,
+                    player2_id=matchup.player2_id,
+                    matchup_type=MatchupType.OPPONENT,
+                    total_toi=matchup.toi_seconds,
+                    game_count=matchup.game_count,
+                    by_situation=matchup.situation_breakdown,
+                )
+            )
+
+        for matchup in teammates:
+            aggregations.append(
+                MatchupAggregation(
+                    player1_id=matchup.player1_id,
+                    player2_id=matchup.player2_id,
+                    matchup_type=MatchupType.TEAMMATE,
+                    total_toi=matchup.toi_seconds,
+                    game_count=matchup.game_count,
+                    by_situation=matchup.situation_breakdown,
+                )
+            )
+
+        return aggregations
+
+    async def _get_teammate_matchups(
+        self,
+        player_id: int,
+        filters: MatchupQueryFilters,
+    ) -> list[PlayerMatchup]:
+        """Get teammate matchups for a player.
+
+        Args:
+            player_id: Player to analyze.
+            filters: Query filters.
+
+        Returns:
+            List of PlayerMatchup for teammates.
+        """
+        # Build WHERE clause
+        conditions = ["is_stoppage = false"]
+        params: list[Any] = []
+        param_idx = 1
+
+        if filters.game_id:
+            conditions.append(f"game_id = ${param_idx}")
+            params.append(filters.game_id)
+            param_idx += 1
+
+        if filters.season_id:
+            conditions.append(f"season_id = ${param_idx}")
+            params.append(filters.season_id)
+            param_idx += 1
+
+        if filters.situation_codes:
+            placeholders = ", ".join(f"${param_idx + i}" for i in range(len(filters.situation_codes)))
+            conditions.append(f"situation_code IN ({placeholders})")
+            params.extend(filters.situation_codes)
+            param_idx += len(filters.situation_codes)
+
+        if filters.exclude_empty_net:
+            conditions.append("is_empty_net = false")
+
+        # Query for home team teammates
+        home_query = f"""
+            SELECT
+                unnest(home_skater_ids) as teammate_id,
+                situation_code,
+                COUNT(*) as toi_seconds,
+                COUNT(DISTINCT game_id) as game_count
+            FROM second_snapshots
+            WHERE {' AND '.join(conditions)}
+                AND ${param_idx} = ANY(home_skater_ids)
+            GROUP BY teammate_id, situation_code
+            HAVING unnest(home_skater_ids) != ${param_idx}
+        """
+
+        # Query for away team teammates
+        away_query = f"""
+            SELECT
+                unnest(away_skater_ids) as teammate_id,
+                situation_code,
+                COUNT(*) as toi_seconds,
+                COUNT(DISTINCT game_id) as game_count
+            FROM second_snapshots
+            WHERE {' AND '.join(conditions)}
+                AND ${param_idx} = ANY(away_skater_ids)
+            GROUP BY teammate_id, situation_code
+            HAVING unnest(away_skater_ids) != ${param_idx}
+        """
+
+        params.append(player_id)
+
+        # Execute both queries
+        home_results = await self.db.fetch(home_query, *params)
+        away_results = await self.db.fetch(away_query, *params)
+
+        # Combine results
+        teammate_data: dict[int, dict[str, Any]] = {}
+
+        for row in list(home_results) + list(away_results):
+            teammate_id = row["teammate_id"]
+            situation = row["situation_code"]
+            toi = row["toi_seconds"]
+            games = row["game_count"]
+
+            if teammate_id not in teammate_data:
+                teammate_data[teammate_id] = {
+                    "toi_seconds": 0,
+                    "game_count": 0,
+                    "situations": {},
+                }
+
+            teammate_data[teammate_id]["toi_seconds"] += toi
+            teammate_data[teammate_id]["game_count"] = max(
+                teammate_data[teammate_id]["game_count"], games
+            )
+            if situation not in teammate_data[teammate_id]["situations"]:
+                teammate_data[teammate_id]["situations"][situation] = 0
+            teammate_data[teammate_id]["situations"][situation] += toi
+
+        # Convert to PlayerMatchup objects
+        matchups = []
+        for teammate_id, data in teammate_data.items():
+            if data["toi_seconds"] >= filters.min_toi_seconds:
+                matchups.append(
+                    PlayerMatchup(
+                        player1_id=player_id,
+                        player2_id=teammate_id,
+                        matchup_type=MatchupType.TEAMMATE,
+                        toi_seconds=data["toi_seconds"],
+                        game_count=data["game_count"],
+                        situation_breakdown=data["situations"],
+                    )
+                )
+
+        return matchups
+
+    async def _get_opponent_matchups(
+        self,
+        player_id: int,
+        filters: MatchupQueryFilters,
+    ) -> list[PlayerMatchup]:
+        """Get opponent matchups for a player.
+
+        Args:
+            player_id: Player to analyze.
+            filters: Query filters.
+
+        Returns:
+            List of PlayerMatchup for opponents.
+        """
+        # Build WHERE clause
+        conditions = ["is_stoppage = false"]
+        params: list[Any] = []
+        param_idx = 1
+
+        if filters.game_id:
+            conditions.append(f"game_id = ${param_idx}")
+            params.append(filters.game_id)
+            param_idx += 1
+
+        if filters.season_id:
+            conditions.append(f"season_id = ${param_idx}")
+            params.append(filters.season_id)
+            param_idx += 1
+
+        if filters.situation_codes:
+            placeholders = ", ".join(f"${param_idx + i}" for i in range(len(filters.situation_codes)))
+            conditions.append(f"situation_code IN ({placeholders})")
+            params.extend(filters.situation_codes)
+            param_idx += len(filters.situation_codes)
+
+        if filters.exclude_empty_net:
+            conditions.append("is_empty_net = false")
+
+        # Query: player on home team, get away opponents
+        home_query = f"""
+            SELECT
+                unnest(away_skater_ids) as opponent_id,
+                situation_code,
+                COUNT(*) as toi_seconds,
+                COUNT(DISTINCT game_id) as game_count
+            FROM second_snapshots
+            WHERE {' AND '.join(conditions)}
+                AND ${param_idx} = ANY(home_skater_ids)
+            GROUP BY opponent_id, situation_code
+        """
+
+        # Query: player on away team, get home opponents
+        away_query = f"""
+            SELECT
+                unnest(home_skater_ids) as opponent_id,
+                situation_code,
+                COUNT(*) as toi_seconds,
+                COUNT(DISTINCT game_id) as game_count
+            FROM second_snapshots
+            WHERE {' AND '.join(conditions)}
+                AND ${param_idx} = ANY(away_skater_ids)
+            GROUP BY opponent_id, situation_code
+        """
+
+        params.append(player_id)
+
+        # Execute both queries
+        home_results = await self.db.fetch(home_query, *params)
+        away_results = await self.db.fetch(away_query, *params)
+
+        # Combine results
+        opponent_data: dict[int, dict[str, Any]] = {}
+
+        for row in list(home_results) + list(away_results):
+            opponent_id = row["opponent_id"]
+            situation = row["situation_code"]
+            toi = row["toi_seconds"]
+            games = row["game_count"]
+
+            if opponent_id not in opponent_data:
+                opponent_data[opponent_id] = {
+                    "toi_seconds": 0,
+                    "game_count": 0,
+                    "situations": {},
+                }
+
+            opponent_data[opponent_id]["toi_seconds"] += toi
+            opponent_data[opponent_id]["game_count"] = max(
+                opponent_data[opponent_id]["game_count"], games
+            )
+            if situation not in opponent_data[opponent_id]["situations"]:
+                opponent_data[opponent_id]["situations"][situation] = 0
+            opponent_data[opponent_id]["situations"][situation] += toi
+
+        # Convert to PlayerMatchup objects
+        matchups = []
+        for opponent_id, data in opponent_data.items():
+            if data["toi_seconds"] >= filters.min_toi_seconds:
+                matchups.append(
+                    PlayerMatchup(
+                        player1_id=player_id,
+                        player2_id=opponent_id,
+                        matchup_type=MatchupType.OPPONENT,
+                        toi_seconds=data["toi_seconds"],
+                        game_count=data["game_count"],
+                        situation_breakdown=data["situations"],
+                    )
+                )
+
+        return matchups
+
+    async def _get_zone_matchups(
+        self,
+        player_id: int,
+        filters: MatchupQueryFilters,
+        zone: Zone,
+        matchup_type: MatchupType,
+    ) -> list[ZoneMatchup]:
+        """Get zone-specific matchups.
+
+        Joins with game_events to filter by zone.
+
+        Args:
+            player_id: Player to analyze.
+            filters: Query filters.
+            zone: Zone to filter to.
+            matchup_type: Teammate or opponent.
+
+        Returns:
+            List of ZoneMatchup objects.
+        """
+        # Build WHERE clause for snapshots
+        conditions = ["s.is_stoppage = false"]
+        params: list[Any] = []
+        param_idx = 1
+
+        if filters.game_id:
+            conditions.append(f"s.game_id = ${param_idx}")
+            params.append(filters.game_id)
+            param_idx += 1
+
+        if filters.season_id:
+            conditions.append(f"s.season_id = ${param_idx}")
+            params.append(filters.season_id)
+            param_idx += 1
+
+        # Zone filter on events
+        conditions.append(f"e.zone = ${param_idx}")
+        params.append(zone.value)
+        param_idx += 1
+
+        # Player on ice
+        params.append(player_id)
+        player_param = param_idx
+
+        if matchup_type == MatchupType.OPPONENT:
+            # Get opponents when player on home
+            query = f"""
+                SELECT
+                    unnest(s.away_skater_ids) as other_player_id,
+                    COUNT(DISTINCT e.id) as event_count,
+                    COUNT(*) as toi_seconds
+                FROM second_snapshots s
+                JOIN game_events e ON s.game_id = e.game_id
+                    AND s.game_second = (
+                        (e.period - 1) * 1200 +
+                        (1200 - CAST(SPLIT_PART(e.time_in_period, ':', 1) AS INTEGER) * 60
+                         - CAST(SPLIT_PART(e.time_in_period, ':', 2) AS INTEGER))
+                    )
+                WHERE {' AND '.join(conditions)}
+                    AND ${player_param} = ANY(s.home_skater_ids)
+                GROUP BY other_player_id
+
+                UNION ALL
+
+                SELECT
+                    unnest(s.home_skater_ids) as other_player_id,
+                    COUNT(DISTINCT e.id) as event_count,
+                    COUNT(*) as toi_seconds
+                FROM second_snapshots s
+                JOIN game_events e ON s.game_id = e.game_id
+                    AND s.game_second = (
+                        (e.period - 1) * 1200 +
+                        (1200 - CAST(SPLIT_PART(e.time_in_period, ':', 1) AS INTEGER) * 60
+                         - CAST(SPLIT_PART(e.time_in_period, ':', 2) AS INTEGER))
+                    )
+                WHERE {' AND '.join(conditions)}
+                    AND ${player_param} = ANY(s.away_skater_ids)
+                GROUP BY other_player_id
+            """
+        else:
+            # Get teammates
+            query = f"""
+                SELECT
+                    unnest(s.home_skater_ids) as other_player_id,
+                    COUNT(DISTINCT e.id) as event_count,
+                    COUNT(*) as toi_seconds
+                FROM second_snapshots s
+                JOIN game_events e ON s.game_id = e.game_id
+                    AND s.game_second = (
+                        (e.period - 1) * 1200 +
+                        (1200 - CAST(SPLIT_PART(e.time_in_period, ':', 1) AS INTEGER) * 60
+                         - CAST(SPLIT_PART(e.time_in_period, ':', 2) AS INTEGER))
+                    )
+                WHERE {' AND '.join(conditions)}
+                    AND ${player_param} = ANY(s.home_skater_ids)
+                GROUP BY other_player_id
+                HAVING unnest(s.home_skater_ids) != ${player_param}
+
+                UNION ALL
+
+                SELECT
+                    unnest(s.away_skater_ids) as other_player_id,
+                    COUNT(DISTINCT e.id) as event_count,
+                    COUNT(*) as toi_seconds
+                FROM second_snapshots s
+                JOIN game_events e ON s.game_id = e.game_id
+                    AND s.game_second = (
+                        (e.period - 1) * 1200 +
+                        (1200 - CAST(SPLIT_PART(e.time_in_period, ':', 1) AS INTEGER) * 60
+                         - CAST(SPLIT_PART(e.time_in_period, ':', 2) AS INTEGER))
+                    )
+                WHERE {' AND '.join(conditions)}
+                    AND ${player_param} = ANY(s.away_skater_ids)
+                GROUP BY other_player_id
+                HAVING unnest(s.away_skater_ids) != ${player_param}
+            """
+
+        results = await self.db.fetch(query, *params)
+
+        # Aggregate by player
+        player_data: dict[int, dict[str, int]] = {}
+        for row in results:
+            pid = row["other_player_id"]
+            if pid not in player_data:
+                player_data[pid] = {"toi_seconds": 0, "event_count": 0}
+            player_data[pid]["toi_seconds"] += row["toi_seconds"]
+            player_data[pid]["event_count"] += row["event_count"]
+
+        # Convert to ZoneMatchup objects
+        return [
+            ZoneMatchup(
+                player1_id=player_id,
+                player2_id=pid,
+                matchup_type=matchup_type,
+                zone=zone,
+                toi_seconds=data["toi_seconds"],
+                event_count=data["event_count"],
+            )
+            for pid, data in player_data.items()
+        ]
+
+    async def _get_all_opponent_matchups(
+        self,
+        game_id: int,
+    ) -> list[PlayerMatchup]:
+        """Get all opponent matchups for a game.
+
+        Args:
+            game_id: NHL game ID.
+
+        Returns:
+            List of all opponent PlayerMatchups.
+        """
+        query = """
+            WITH home_vs_away AS (
+                SELECT
+                    h.player_id as home_player,
+                    a.player_id as away_player,
+                    s.situation_code,
+                    COUNT(*) as toi_seconds
+                FROM second_snapshots s
+                CROSS JOIN LATERAL unnest(s.home_skater_ids) AS h(player_id)
+                CROSS JOIN LATERAL unnest(s.away_skater_ids) AS a(player_id)
+                WHERE s.game_id = $1
+                    AND s.is_stoppage = false
+                GROUP BY h.player_id, a.player_id, s.situation_code
+            )
+            SELECT
+                home_player,
+                away_player,
+                SUM(toi_seconds) as total_toi
+            FROM home_vs_away
+            GROUP BY home_player, away_player
+            ORDER BY total_toi DESC
+        """
+
+        results = await self.db.fetch(query, game_id)
+
+        return [
+            PlayerMatchup(
+                player1_id=row["home_player"],
+                player2_id=row["away_player"],
+                matchup_type=MatchupType.OPPONENT,
+                toi_seconds=row["total_toi"],
+                game_count=1,
+            )
+            for row in results
+        ]
+
+    async def _get_game_count(
+        self,
+        player_id: int,
+        filters: MatchupQueryFilters,
+    ) -> int:
+        """Get number of games with player appearances.
+
+        Args:
+            player_id: Player ID.
+            filters: Query filters.
+
+        Returns:
+            Count of games.
+        """
+        conditions = ["1=1"]
+        params: list[Any] = []
+        param_idx = 1
+
+        if filters.game_id:
+            conditions.append(f"game_id = ${param_idx}")
+            params.append(filters.game_id)
+            param_idx += 1
+
+        if filters.season_id:
+            conditions.append(f"season_id = ${param_idx}")
+            params.append(filters.season_id)
+            param_idx += 1
+
+        params.append(player_id)
+
+        query = f"""
+            SELECT COUNT(DISTINCT game_id)
+            FROM second_snapshots
+            WHERE {' AND '.join(conditions)}
+                AND (${param_idx} = ANY(home_skater_ids)
+                     OR ${param_idx} = ANY(away_skater_ids))
+        """
+
+        result = await self.db.fetchval(query, *params)
+        return result or 0

--- a/src/nhl_api/services/analytics/zone_detection.py
+++ b/src/nhl_api/services/analytics/zone_detection.py
@@ -1,0 +1,246 @@
+"""Zone detection service for determining ice zone from coordinates.
+
+NHL rink dimensions:
+- Length: 200 feet (-100 to +100 on x-axis)
+- Width: 85 feet (-42.5 to +42.5 on y-axis)
+- Blue lines: at -25 and +25 on x-axis
+- Center ice: x=0
+
+Zone classification:
+- Offensive zone (O): x > 25 for home team attacking right
+- Defensive zone (D): x < -25 for home team defending left
+- Neutral zone (N): -25 <= x <= 25
+
+Note: Zone attribution depends on which team is being analyzed.
+Home team attacks right (positive x) in P1/P3, left in P2.
+
+Example usage:
+    detector = ZoneDetector()
+    zone = detector.get_zone(x_coord=75.0, period=1, is_home_team=True)
+    # Returns Zone.OFFENSIVE
+
+Issue: #261 - Wave 3: Matchup Analysis (T022)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+class Zone(str, Enum):
+    """Ice zone classification."""
+
+    OFFENSIVE = "O"
+    DEFENSIVE = "D"
+    NEUTRAL = "N"
+
+
+# NHL rink zone boundaries (blue lines)
+BLUE_LINE_DISTANCE = 25.0  # Distance from center ice to blue line
+CENTER_ICE = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneResult:
+    """Result of zone detection.
+
+    Attributes:
+        zone: The detected zone.
+        x_coord: Original x coordinate.
+        y_coord: Original y coordinate.
+        period: Game period.
+        is_home_perspective: True if zone is from home team perspective.
+    """
+
+    zone: Zone
+    x_coord: float
+    y_coord: float
+    period: int
+    is_home_perspective: bool
+
+
+class ZoneDetector:
+    """Service for detecting ice zone from coordinates.
+
+    Handles the complexity of zone attribution based on:
+    - Period (home team attacks right in P1/P3, left in P2)
+    - Team perspective (offensive/defensive is relative to team)
+
+    Attributes:
+        neutral_zone_width: Width of neutral zone in feet (default 50).
+
+    Example:
+        >>> detector = ZoneDetector()
+        >>> zone = detector.get_zone(75.0, 10.0, period=1, is_home_team=True)
+        Zone.OFFENSIVE
+    """
+
+    def __init__(self, neutral_zone_width: float = 50.0) -> None:
+        """Initialize the ZoneDetector.
+
+        Args:
+            neutral_zone_width: Width of neutral zone (default 50 feet).
+        """
+        self.blue_line = neutral_zone_width / 2  # 25 feet from center
+
+    def get_zone(
+        self,
+        x_coord: float,
+        y_coord: float | None = None,
+        *,
+        period: int = 1,
+        is_home_team: bool = True,
+    ) -> Zone:
+        """Determine the ice zone from coordinates.
+
+        Args:
+            x_coord: X coordinate on ice (-100 to 100).
+            y_coord: Y coordinate on ice (not used but available).
+            period: Game period (1, 2, 3, etc.).
+            is_home_team: True if analyzing from home team perspective.
+
+        Returns:
+            Zone classification (OFFENSIVE, DEFENSIVE, or NEUTRAL).
+        """
+        # Handle missing coordinates
+        if x_coord is None:
+            return Zone.NEUTRAL
+
+        # Determine attacking direction based on period
+        # Home team attacks right (positive x) in P1, P3, OT periods
+        # Home team attacks left (negative x) in P2
+        home_attacks_right = period % 2 == 1  # Odd periods attack right
+
+        # For away team, flip the direction
+        team_attacks_right = home_attacks_right if is_home_team else not home_attacks_right
+
+        # Neutral zone check first
+        if abs(x_coord) <= self.blue_line:
+            return Zone.NEUTRAL
+
+        # Determine zone based on attacking direction
+        if team_attacks_right:
+            # Team attacks right (positive x)
+            if x_coord > self.blue_line:
+                return Zone.OFFENSIVE
+            else:  # x_coord < -self.blue_line
+                return Zone.DEFENSIVE
+        else:
+            # Team attacks left (negative x)
+            if x_coord < -self.blue_line:
+                return Zone.OFFENSIVE
+            else:  # x_coord > self.blue_line
+                return Zone.DEFENSIVE
+
+    def get_zone_result(
+        self,
+        x_coord: float,
+        y_coord: float | None = None,
+        *,
+        period: int = 1,
+        is_home_team: bool = True,
+    ) -> ZoneResult:
+        """Get detailed zone result with context.
+
+        Args:
+            x_coord: X coordinate on ice.
+            y_coord: Y coordinate on ice.
+            period: Game period.
+            is_home_team: True if analyzing from home team perspective.
+
+        Returns:
+            ZoneResult with full context.
+        """
+        zone = self.get_zone(
+            x_coord,
+            y_coord,
+            period=period,
+            is_home_team=is_home_team,
+        )
+        return ZoneResult(
+            zone=zone,
+            x_coord=x_coord,
+            y_coord=y_coord or 0.0,
+            period=period,
+            is_home_perspective=is_home_team,
+        )
+
+    def classify_event_zone(
+        self,
+        x_coord: float | None,
+        zone_from_api: str | None = None,
+    ) -> Zone:
+        """Classify zone, preferring API-provided zone if available.
+
+        The NHL API provides a zone field (O/D/N) which is already
+        calculated from the team's perspective. Use this when available.
+
+        Args:
+            x_coord: X coordinate (fallback if no API zone).
+            zone_from_api: Zone string from NHL API (O/D/N).
+
+        Returns:
+            Zone classification.
+        """
+        # Prefer API-provided zone
+        if zone_from_api:
+            try:
+                return Zone(zone_from_api.upper())
+            except ValueError:
+                pass  # Fall through to coordinate-based detection
+
+        # Fall back to coordinate-based detection
+        if x_coord is not None:
+            if x_coord > self.blue_line:
+                return Zone.OFFENSIVE
+            elif x_coord < -self.blue_line:
+                return Zone.DEFENSIVE
+
+        return Zone.NEUTRAL
+
+    @staticmethod
+    def is_defensive_zone(zone: Zone | str) -> bool:
+        """Check if zone is defensive.
+
+        Args:
+            zone: Zone enum or string.
+
+        Returns:
+            True if defensive zone.
+        """
+        if isinstance(zone, str):
+            return zone.upper() == "D"
+        return zone == Zone.DEFENSIVE
+
+    @staticmethod
+    def is_offensive_zone(zone: Zone | str) -> bool:
+        """Check if zone is offensive.
+
+        Args:
+            zone: Zone enum or string.
+
+        Returns:
+            True if offensive zone.
+        """
+        if isinstance(zone, str):
+            return zone.upper() == "O"
+        return zone == Zone.OFFENSIVE
+
+    @staticmethod
+    def is_neutral_zone(zone: Zone | str) -> bool:
+        """Check if zone is neutral.
+
+        Args:
+            zone: Zone enum or string.
+
+        Returns:
+            True if neutral zone.
+        """
+        if isinstance(zone, str):
+            return zone.upper() == "N"
+        return zone == Zone.NEUTRAL

--- a/tests/integration/analytics/test_matchup_service.py
+++ b/tests/integration/analytics/test_matchup_service.py
@@ -1,0 +1,311 @@
+"""Integration tests for matchup service (T019-T023).
+
+Validates matchup analysis functionality including:
+- Player matchup queries
+- Ice time calculations
+- Zone-based filtering
+- Aggregation queries
+
+Issue: #261 - Wave 3: Matchup Analysis
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.integration.analytics.conftest import make_record, make_records
+from nhl_api.models.matchups import MatchupType, PlayerMatchup
+from nhl_api.services.analytics.matchup_service import (
+    MatchupQueryFilters,
+    MatchupService,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestMatchupServiceBasic:
+    """Basic tests for MatchupService."""
+
+    @pytest.mark.asyncio
+    async def test_get_ice_time_together(self) -> None:
+        """Should calculate ice time between two players."""
+        db = AsyncMock()
+        db.fetchval = AsyncMock(return_value=1250)
+
+        service = MatchupService(db)
+        toi = await service.get_ice_time_together(
+            player1_id=8478402,
+            player2_id=8477934,
+            game_id=2024020500,
+        )
+
+        assert toi == 1250
+        db.fetchval.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_ice_time_together_no_overlap(self) -> None:
+        """Should return 0 when players never on ice together."""
+        db = AsyncMock()
+        db.fetchval = AsyncMock(return_value=0)
+
+        service = MatchupService(db)
+        toi = await service.get_ice_time_together(
+            player1_id=8478402,
+            player2_id=9999999,
+            game_id=2024020500,
+        )
+
+        assert toi == 0
+
+
+class TestMatchupServiceQueries:
+    """Tests for matchup query functionality."""
+
+    @pytest.mark.asyncio
+    async def test_get_player_matchups_teammates(
+        self, sample_game_info: dict
+    ) -> None:
+        """Should return teammate matchups."""
+        db = AsyncMock()
+
+        # The service makes multiple queries - teammate and opponent queries
+        # We need to return appropriate data for each
+        call_count = [0]
+
+        async def mock_fetch(*args, **kwargs):
+            call_count[0] += 1
+            # First two calls are teammate queries (home and away)
+            if call_count[0] <= 2:
+                return make_records([
+                    {
+                        "teammate_id": 8477934,
+                        "situation_code": "5v5",
+                        "toi_seconds": 800,
+                        "game_count": 10,
+                    },
+                ])
+            # Next two are opponent queries
+            return []
+
+        db.fetch = mock_fetch
+        db.fetchval = AsyncMock(return_value=10)
+
+        service = MatchupService(db)
+        result = await service.get_player_matchups(
+            player_id=8478402,
+            season_id=20242025,
+            min_toi_seconds=60,
+        )
+
+        assert result.player_id == 8478402
+        assert result.total_games == 10
+
+    @pytest.mark.asyncio
+    async def test_get_player_matchups_opponents(
+        self, sample_game_info: dict
+    ) -> None:
+        """Should return opponent matchups."""
+        db = AsyncMock()
+
+        call_count = [0]
+
+        async def mock_fetch(*args, **kwargs):
+            call_count[0] += 1
+            # First two calls are teammate queries
+            if call_count[0] <= 2:
+                return []
+            # Next two are opponent queries
+            return make_records([
+                {
+                    "opponent_id": 8477846,
+                    "situation_code": "5v5",
+                    "toi_seconds": 500,
+                    "game_count": 5,
+                },
+            ])
+
+        db.fetch = mock_fetch
+        db.fetchval = AsyncMock(return_value=5)
+
+        service = MatchupService(db)
+        result = await service.get_player_matchups(
+            player_id=8478402,
+            game_id=2024020500,
+            min_toi_seconds=60,
+        )
+
+        assert result.player_id == 8478402
+
+
+class TestMatchupServiceGameSummary:
+    """Tests for game matchup summary."""
+
+    @pytest.mark.asyncio
+    async def test_get_game_matchup_summary(
+        self, sample_game_info: dict
+    ) -> None:
+        """Should return game matchup summary."""
+        db = AsyncMock()
+
+        async def mock_fetchrow(query: str, *args):
+            if "FROM games" in query:
+                return make_record(sample_game_info)
+            return None
+
+        db.fetchrow = mock_fetchrow
+
+        db.fetch = AsyncMock(
+            return_value=make_records([
+                {
+                    "home_player": 8478402,
+                    "away_player": 8477846,
+                    "total_toi": 1200,
+                },
+                {
+                    "home_player": 8477934,
+                    "away_player": 8477846,
+                    "total_toi": 1000,
+                },
+            ])
+        )
+
+        service = MatchupService(db)
+        summary = await service.get_game_matchup_summary(game_id=2024020500)
+
+        assert summary.game_id == 2024020500
+        assert summary.home_team_id == sample_game_info["home_team_id"]
+        assert summary.away_team_id == sample_game_info["away_team_id"]
+        assert summary.matchup_count == 2
+        assert len(summary.top_matchups) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_game_matchup_summary_game_not_found(self) -> None:
+        """Should raise ValueError for missing game."""
+        db = AsyncMock()
+        db.fetchrow = AsyncMock(return_value=None)
+
+        service = MatchupService(db)
+
+        with pytest.raises(ValueError, match="Game 9999999 not found"):
+            await service.get_game_matchup_summary(game_id=9999999)
+
+
+class TestMatchupServiceDefensiveZone:
+    """Tests for defensive zone matchup filtering."""
+
+    @pytest.mark.asyncio
+    async def test_get_defensive_zone_matchups(
+        self, sample_game_info: dict
+    ) -> None:
+        """Should filter to defensive zone matchups."""
+        db = AsyncMock()
+
+        db.fetch = AsyncMock(
+            return_value=make_records([
+                {
+                    "other_player_id": 8477846,
+                    "event_count": 5,
+                    "toi_seconds": 120,
+                },
+            ])
+        )
+
+        service = MatchupService(db)
+        matchups = await service.get_defensive_zone_matchups(
+            player_id=8478402,
+            game_id=2024020500,
+        )
+
+        # Should return zone matchups
+        assert isinstance(matchups, list)
+
+
+class TestMatchupServiceAggregation:
+    """Tests for matchup aggregation."""
+
+    @pytest.mark.asyncio
+    async def test_aggregate_matchups(self, sample_game_info: dict) -> None:
+        """Should aggregate matchup data."""
+        db = AsyncMock()
+
+        call_count = [0]
+
+        async def mock_fetch(*args, **kwargs):
+            call_count[0] += 1
+            # Calls 1-2: opponent queries (home + away)
+            if call_count[0] <= 2:
+                return make_records([
+                    {
+                        "opponent_id": 8477846,
+                        "situation_code": "5v5",
+                        "toi_seconds": 800,
+                        "game_count": 5,
+                    },
+                ])
+            # Calls 3-4: teammate queries (home + away)
+            return []
+
+        db.fetch = mock_fetch
+
+        service = MatchupService(db)
+        filters = MatchupQueryFilters(season_id=20242025)
+        aggregations = await service.aggregate_matchups(
+            player_id=8478402,
+            filters=filters,
+        )
+
+        assert isinstance(aggregations, list)
+        # Should have opponent aggregations from our mock data
+        assert len(aggregations) >= 0
+
+
+class TestMatchupQueryFilters:
+    """Tests for MatchupQueryFilters."""
+
+    def test_default_filters(self) -> None:
+        """Should have sensible defaults."""
+        filters = MatchupQueryFilters()
+
+        assert filters.game_id is None
+        assert filters.season_id is None
+        assert filters.situation_codes is None
+        assert filters.zone is None
+        assert filters.min_toi_seconds == 0
+        assert filters.exclude_empty_net is False
+
+    def test_with_all_filters(self) -> None:
+        """Should accept all filter options."""
+        from nhl_api.services.analytics.zone_detection import Zone
+
+        filters = MatchupQueryFilters(
+            game_id=2024020500,
+            season_id=20242025,
+            situation_codes=["5v5", "5v4"],
+            zone=Zone.DEFENSIVE,
+            min_toi_seconds=60,
+            exclude_empty_net=True,
+        )
+
+        assert filters.game_id == 2024020500
+        assert filters.season_id == 20242025
+        assert filters.situation_codes == ["5v5", "5v4"]
+        assert filters.zone == Zone.DEFENSIVE
+        assert filters.min_toi_seconds == 60
+        assert filters.exclude_empty_net is True
+
+
+# Fixture from conftest.py
+@pytest.fixture
+def sample_game_info() -> dict:
+    """Sample game metadata."""
+    return {
+        "game_id": 2024020500,
+        "season_id": 20242025,
+        "home_team_id": 22,
+        "away_team_id": 25,
+        "period": 3,
+    }

--- a/tests/unit/models/test_matchups.py
+++ b/tests/unit/models/test_matchups.py
@@ -1,0 +1,237 @@
+"""Unit tests for matchup models.
+
+Tests the PlayerMatchup, ZoneMatchup, and related models.
+
+Issue: #261 - Wave 3: Matchup Analysis
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nhl_api.models.matchups import (
+    GameMatchupSummary,
+    MatchupResult,
+    MatchupType,
+    PlayerMatchup,
+    Zone,
+    ZoneMatchup,
+)
+
+
+class TestPlayerMatchup:
+    """Tests for PlayerMatchup model."""
+
+    def test_basic_creation(self) -> None:
+        """Should create matchup with basic attributes."""
+        matchup = PlayerMatchup(
+            player1_id=8478402,
+            player2_id=8477934,
+            matchup_type=MatchupType.TEAMMATE,
+            toi_seconds=1250,
+            game_count=15,
+        )
+
+        assert matchup.player1_id == 8477934  # Sorted: lower ID first
+        assert matchup.player2_id == 8478402
+        assert matchup.matchup_type == MatchupType.TEAMMATE
+        assert matchup.toi_seconds == 1250
+        assert matchup.game_count == 15
+
+    def test_player_id_ordering(self) -> None:
+        """Player IDs should be sorted (lower first)."""
+        matchup = PlayerMatchup(
+            player1_id=9999999,  # Higher
+            player2_id=1111111,  # Lower
+            matchup_type=MatchupType.OPPONENT,
+        )
+
+        assert matchup.player1_id == 1111111
+        assert matchup.player2_id == 9999999
+
+    def test_toi_minutes(self) -> None:
+        """Should calculate TOI in minutes."""
+        matchup = PlayerMatchup(
+            player1_id=1,
+            player2_id=2,
+            matchup_type=MatchupType.TEAMMATE,
+            toi_seconds=900,  # 15 minutes
+        )
+
+        assert matchup.toi_minutes == 15.0
+
+    def test_toi_display(self) -> None:
+        """Should format TOI as MM:SS."""
+        matchup = PlayerMatchup(
+            player1_id=1,
+            player2_id=2,
+            matchup_type=MatchupType.TEAMMATE,
+            toi_seconds=905,  # 15:05
+        )
+
+        assert matchup.toi_display == "15:05"
+
+    def test_to_dict(self) -> None:
+        """Should serialize to dictionary."""
+        matchup = PlayerMatchup(
+            player1_id=8478402,
+            player2_id=8477934,
+            matchup_type=MatchupType.TEAMMATE,
+            toi_seconds=1250,
+            game_count=15,
+            situation_breakdown={"5v5": 1000, "5v4": 250},
+        )
+
+        data = matchup.to_dict()
+
+        assert data["player1_id"] == 8477934
+        assert data["player2_id"] == 8478402
+        assert data["matchup_type"] == "teammate"
+        assert data["toi_seconds"] == 1250
+        assert data["toi_minutes"] == 20.83
+        assert data["game_count"] == 15
+        assert data["situation_breakdown"] == {"5v5": 1000, "5v4": 250}
+
+    def test_default_values(self) -> None:
+        """Should have sensible defaults."""
+        matchup = PlayerMatchup(
+            player1_id=1,
+            player2_id=2,
+            matchup_type=MatchupType.OPPONENT,
+        )
+
+        assert matchup.toi_seconds == 0
+        assert matchup.game_count == 0
+        assert matchup.situation_breakdown == {}
+
+
+class TestZoneMatchup:
+    """Tests for ZoneMatchup model."""
+
+    def test_basic_creation(self) -> None:
+        """Should create zone matchup."""
+        matchup = ZoneMatchup(
+            player1_id=8478402,
+            player2_id=8477934,
+            matchup_type=MatchupType.OPPONENT,
+            zone=Zone.DEFENSIVE,
+            toi_seconds=300,
+            event_count=5,
+        )
+
+        assert matchup.zone == Zone.DEFENSIVE
+        assert matchup.toi_seconds == 300
+        assert matchup.event_count == 5
+
+    def test_to_dict(self) -> None:
+        """Should serialize with zone."""
+        matchup = ZoneMatchup(
+            player1_id=1,
+            player2_id=2,
+            matchup_type=MatchupType.OPPONENT,
+            zone=Zone.OFFENSIVE,
+            toi_seconds=600,
+        )
+
+        data = matchup.to_dict()
+
+        assert data["zone"] == "O"
+        assert data["toi_seconds"] == 600
+        assert data["toi_minutes"] == 10.0
+
+
+class TestMatchupResult:
+    """Tests for MatchupResult model."""
+
+    def test_basic_creation(self) -> None:
+        """Should create result with lists."""
+        result = MatchupResult(
+            player_id=8478402,
+            total_games=20,
+        )
+
+        assert result.player_id == 8478402
+        assert result.teammates == []
+        assert result.opponents == []
+        assert result.total_games == 20
+
+    def test_top_teammates(self) -> None:
+        """Should return top 5 teammates by TOI."""
+        teammates = [
+            PlayerMatchup(1, 10, MatchupType.TEAMMATE, toi_seconds=100),
+            PlayerMatchup(1, 20, MatchupType.TEAMMATE, toi_seconds=500),
+            PlayerMatchup(1, 30, MatchupType.TEAMMATE, toi_seconds=300),
+            PlayerMatchup(1, 40, MatchupType.TEAMMATE, toi_seconds=200),
+            PlayerMatchup(1, 50, MatchupType.TEAMMATE, toi_seconds=400),
+            PlayerMatchup(1, 60, MatchupType.TEAMMATE, toi_seconds=600),
+        ]
+
+        result = MatchupResult(player_id=1, teammates=teammates)
+
+        top = result.top_teammates
+        assert len(top) == 5
+        assert top[0].toi_seconds == 600
+        assert top[1].toi_seconds == 500
+        assert top[4].toi_seconds == 200
+
+    def test_top_opponents(self) -> None:
+        """Should return top 5 opponents by TOI."""
+        opponents = [
+            PlayerMatchup(1, 100, MatchupType.OPPONENT, toi_seconds=50),
+            PlayerMatchup(1, 200, MatchupType.OPPONENT, toi_seconds=150),
+        ]
+
+        result = MatchupResult(player_id=1, opponents=opponents)
+
+        top = result.top_opponents
+        assert len(top) == 2
+        assert top[0].toi_seconds == 150
+
+
+class TestMatchupType:
+    """Tests for MatchupType enum."""
+
+    def test_teammate_value(self) -> None:
+        """Teammate value should be 'teammate'."""
+        assert MatchupType.TEAMMATE.value == "teammate"
+
+    def test_opponent_value(self) -> None:
+        """Opponent value should be 'opponent'."""
+        assert MatchupType.OPPONENT.value == "opponent"
+
+
+class TestGameMatchupSummary:
+    """Tests for GameMatchupSummary model."""
+
+    def test_basic_creation(self) -> None:
+        """Should create game summary."""
+        summary = GameMatchupSummary(
+            game_id=2024020500,
+            home_team_id=22,
+            away_team_id=25,
+            matchup_count=100,
+        )
+
+        assert summary.game_id == 2024020500
+        assert summary.home_team_id == 22
+        assert summary.away_team_id == 25
+        assert summary.matchup_count == 100
+        assert summary.top_matchups == []
+
+    def test_to_dict(self) -> None:
+        """Should serialize to dictionary."""
+        summary = GameMatchupSummary(
+            game_id=2024020500,
+            home_team_id=22,
+            away_team_id=25,
+            matchup_count=50,
+            top_matchups=[
+                PlayerMatchup(1, 2, MatchupType.OPPONENT, toi_seconds=300),
+            ],
+        )
+
+        data = summary.to_dict()
+
+        assert data["game_id"] == 2024020500
+        assert data["matchup_count"] == 50
+        assert len(data["top_matchups"]) == 1

--- a/tests/unit/services/analytics/test_zone_detection.py
+++ b/tests/unit/services/analytics/test_zone_detection.py
@@ -1,0 +1,187 @@
+"""Unit tests for zone detection service.
+
+Tests the ZoneDetector's ability to correctly classify ice zones
+based on coordinates and game context.
+
+Issue: #261 - Wave 3: Matchup Analysis (T022)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nhl_api.services.analytics.zone_detection import Zone, ZoneDetector, ZoneResult
+
+
+class TestZoneDetector:
+    """Tests for ZoneDetector zone classification."""
+
+    def test_neutral_zone_center_ice(self) -> None:
+        """Center ice should be neutral zone."""
+        detector = ZoneDetector()
+        zone = detector.get_zone(0.0, 0.0, period=1, is_home_team=True)
+        assert zone == Zone.NEUTRAL
+
+    def test_neutral_zone_near_blue_line(self) -> None:
+        """Just inside blue line should be neutral zone."""
+        detector = ZoneDetector()
+
+        # Just inside left blue line
+        zone = detector.get_zone(-24.0, 0.0, period=1, is_home_team=True)
+        assert zone == Zone.NEUTRAL
+
+        # Just inside right blue line
+        zone = detector.get_zone(24.0, 0.0, period=1, is_home_team=True)
+        assert zone == Zone.NEUTRAL
+
+    def test_offensive_zone_period_1_home(self) -> None:
+        """Home team attacks right in period 1."""
+        detector = ZoneDetector()
+
+        # Positive x past blue line = offensive for home in P1
+        zone = detector.get_zone(75.0, 10.0, period=1, is_home_team=True)
+        assert zone == Zone.OFFENSIVE
+
+    def test_defensive_zone_period_1_home(self) -> None:
+        """Home team defends left in period 1."""
+        detector = ZoneDetector()
+
+        # Negative x past blue line = defensive for home in P1
+        zone = detector.get_zone(-75.0, 10.0, period=1, is_home_team=True)
+        assert zone == Zone.DEFENSIVE
+
+    def test_offensive_zone_period_2_home(self) -> None:
+        """Home team attacks left in period 2 (sides switch)."""
+        detector = ZoneDetector()
+
+        # Negative x past blue line = offensive for home in P2
+        zone = detector.get_zone(-75.0, 10.0, period=2, is_home_team=True)
+        assert zone == Zone.OFFENSIVE
+
+    def test_defensive_zone_period_2_home(self) -> None:
+        """Home team defends right in period 2."""
+        detector = ZoneDetector()
+
+        # Positive x past blue line = defensive for home in P2
+        zone = detector.get_zone(75.0, 10.0, period=2, is_home_team=True)
+        assert zone == Zone.DEFENSIVE
+
+    def test_period_3_same_as_period_1(self) -> None:
+        """Period 3 should have same orientation as period 1."""
+        detector = ZoneDetector()
+
+        zone_p1 = detector.get_zone(75.0, 0.0, period=1, is_home_team=True)
+        zone_p3 = detector.get_zone(75.0, 0.0, period=3, is_home_team=True)
+        assert zone_p1 == zone_p3 == Zone.OFFENSIVE
+
+    def test_away_team_opposite_of_home(self) -> None:
+        """Away team zones are opposite of home team."""
+        detector = ZoneDetector()
+
+        # Same location, different team perspective
+        home_zone = detector.get_zone(75.0, 0.0, period=1, is_home_team=True)
+        away_zone = detector.get_zone(75.0, 0.0, period=1, is_home_team=False)
+
+        assert home_zone == Zone.OFFENSIVE
+        assert away_zone == Zone.DEFENSIVE
+
+    def test_none_coordinate_returns_neutral(self) -> None:
+        """Missing coordinates should return neutral zone."""
+        detector = ZoneDetector()
+        zone = detector.get_zone(None, 0.0, period=1, is_home_team=True)
+        assert zone == Zone.NEUTRAL
+
+    def test_overtime_same_as_period_2(self) -> None:
+        """Overtime (period 4) matches period 2 orientation (even periods)."""
+        detector = ZoneDetector()
+
+        # Period 4 is even (4 % 2 = 0), so it matches period 2
+        zone_p2 = detector.get_zone(75.0, 0.0, period=2, is_home_team=True)
+        zone_ot = detector.get_zone(75.0, 0.0, period=4, is_home_team=True)
+        assert zone_p2 == zone_ot == Zone.DEFENSIVE
+
+
+class TestZoneDetectorResult:
+    """Tests for detailed zone result."""
+
+    def test_get_zone_result_includes_context(self) -> None:
+        """Zone result should include full context."""
+        detector = ZoneDetector()
+        result = detector.get_zone_result(
+            75.0, 10.0, period=2, is_home_team=True
+        )
+
+        assert isinstance(result, ZoneResult)
+        assert result.zone == Zone.DEFENSIVE
+        assert result.x_coord == 75.0
+        assert result.y_coord == 10.0
+        assert result.period == 2
+        assert result.is_home_perspective is True
+
+    def test_zone_result_with_none_y(self) -> None:
+        """Should handle None y_coord."""
+        detector = ZoneDetector()
+        result = detector.get_zone_result(50.0, None, period=1, is_home_team=True)
+
+        assert result.y_coord == 0.0
+        assert result.zone == Zone.OFFENSIVE
+
+
+class TestClassifyEventZone:
+    """Tests for API zone classification."""
+
+    def test_prefers_api_zone(self) -> None:
+        """Should prefer API-provided zone over coordinates."""
+        detector = ZoneDetector()
+
+        # API says defensive, coords would say offensive
+        zone = detector.classify_event_zone(75.0, "D")
+        assert zone == Zone.DEFENSIVE
+
+    def test_falls_back_to_coords(self) -> None:
+        """Should use coords when no API zone."""
+        detector = ZoneDetector()
+
+        zone = detector.classify_event_zone(75.0, None)
+        assert zone == Zone.OFFENSIVE
+
+        zone = detector.classify_event_zone(-75.0, None)
+        assert zone == Zone.DEFENSIVE
+
+    def test_handles_invalid_api_zone(self) -> None:
+        """Should fall back on invalid API zone."""
+        detector = ZoneDetector()
+
+        zone = detector.classify_event_zone(75.0, "X")  # Invalid
+        assert zone == Zone.OFFENSIVE
+
+    def test_neutral_on_missing_coords(self) -> None:
+        """Should return neutral with no valid data."""
+        detector = ZoneDetector()
+
+        zone = detector.classify_event_zone(None, None)
+        assert zone == Zone.NEUTRAL
+
+
+class TestZoneHelpers:
+    """Tests for zone helper methods."""
+
+    def test_is_defensive_zone(self) -> None:
+        """Test defensive zone detection."""
+        assert ZoneDetector.is_defensive_zone(Zone.DEFENSIVE)
+        assert ZoneDetector.is_defensive_zone("D")
+        assert not ZoneDetector.is_defensive_zone(Zone.OFFENSIVE)
+        assert not ZoneDetector.is_defensive_zone("O")
+
+    def test_is_offensive_zone(self) -> None:
+        """Test offensive zone detection."""
+        assert ZoneDetector.is_offensive_zone(Zone.OFFENSIVE)
+        assert ZoneDetector.is_offensive_zone("O")
+        assert not ZoneDetector.is_offensive_zone(Zone.DEFENSIVE)
+        assert not ZoneDetector.is_offensive_zone("D")
+
+    def test_is_neutral_zone(self) -> None:
+        """Test neutral zone detection."""
+        assert ZoneDetector.is_neutral_zone(Zone.NEUTRAL)
+        assert ZoneDetector.is_neutral_zone("N")
+        assert not ZoneDetector.is_neutral_zone(Zone.OFFENSIVE)


### PR DESCRIPTION
## Summary

- **T019**: MatchupService with player matchup queries
- **T020**: Aggregation queries with situation code breakdowns (5v5, 5v4, etc.)
- **T021**: Ice time calculation for player pairs (teammates and opponents)
- **T022**: ZoneDetector for determining offensive/defensive/neutral zones from coordinates
- **T023**: Defensive zone matchup filtering for defensive matchup analysis

## New Files

- `src/nhl_api/models/matchups.py`: PlayerMatchup, ZoneMatchup, MatchupResult models
- `src/nhl_api/services/analytics/matchup_service.py`: MatchupService for querying matchup data
- `src/nhl_api/services/analytics/zone_detection.py`: ZoneDetector for zone classification

## Key Features

- Query matchups by player, season, or game
- Get top teammates and opponents by ice time
- Filter by situation code (5v5, power play, etc.)
- Zone-based matchup filtering (defensive zone matchups)
- NHL rink coordinate to zone conversion

## Test plan

- [x] 44 new tests pass (unit + integration)
- [x] All 284 existing unit tests pass
- [x] Ruff linting passes

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)