### PR TITLE
fix(ci): Use mypy config packages setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv sync --frozen --extra lint --extra test --extra viewer --extra scraping
 
       - name: Run mypy
-        run: uv run mypy .
+        run: uv run mypy
 
   test:
     name: Test (Python ${{ matrix.python-version }})


### PR DESCRIPTION
## Summary

Change `mypy .` to `mypy` in CI so it respects the pyproject.toml `packages = ["nhl_api"]` setting.

## Problem

Running `mypy .` scans all files including integration tests, which have ~200 type errors from untyped fixtures. The pyproject.toml config specifies:

```toml
[tool.mypy]
packages = ["nhl_api"]
```

But `mypy .` ignores this and scans everything.

## Solution

Simply run `mypy` without arguments. This uses the `packages` setting and only type-checks `src/nhl_api/`.

## Test plan

- CI type check should now pass
- `uv run mypy` locally passes (118 source files, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)