### PR TITLE
feat(analytics): Add aggregation service for flexible TOI rollups

### DIFF
--- a/src/nhl_api/services/analytics/__init__.py
+++ b/src/nhl_api/services/analytics/__init__.py
@@ -17,11 +17,25 @@ Example usage:
         matchup_service = MatchupService(db)
         matchups = await matchup_service.get_player_matchups(8478402)
 
+        # Aggregation (Wave 5)
+        agg_service = AggregationService(db)
+        game_stats = await agg_service.aggregate_game(game_id=2024020500)
+
 Issue: #259 - Second-by-Second Analytics
 Issue: #261 - Wave 3: Matchup Analysis
+Issue: #263 - Wave 5: Aggregation Functions
 """
 
 from nhl_api.models.matchups import Zone
+from nhl_api.services.analytics.aggregation import (
+    AggregationFilters,
+    AggregationService,
+    GameAggregation,
+    LineCombinationStats,
+    PeriodAggregation,
+    SeasonAggregation,
+    ShiftAggregation,
+)
 from nhl_api.services.analytics.event_attributor import (
     AttributionResult,
     EventAttribution,
@@ -70,4 +84,12 @@ __all__ = [
     "ZoneDetector",
     "Zone",
     "ZoneResult",
+    # Aggregation (Wave 5)
+    "AggregationService",
+    "AggregationFilters",
+    "ShiftAggregation",
+    "PeriodAggregation",
+    "GameAggregation",
+    "SeasonAggregation",
+    "LineCombinationStats",
 ]

--- a/src/nhl_api/services/analytics/aggregation.py
+++ b/src/nhl_api/services/analytics/aggregation.py
@@ -1,0 +1,863 @@
+"""Aggregation service for flexible TOI rollups at any level.
+
+This module provides aggregation functions for second-by-second analytics
+data at multiple levels: shift, period, game, and season.
+
+Example usage:
+    async with DatabaseService() as db:
+        service = AggregationService(db)
+
+        # Get shift-level aggregation for a game
+        shifts = await service.aggregate_shifts(game_id=2024020500)
+
+        # Get period-level aggregation
+        periods = await service.aggregate_periods(game_id=2024020500)
+
+        # Get game-level aggregation
+        game = await service.aggregate_game(game_id=2024020500)
+
+        # Get season-level line combinations
+        lines = await service.get_line_combinations(
+            season_id=20242025,
+            min_toi=600,
+        )
+
+Issue: #263 - Wave 5: Aggregation Functions (T030-T033)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nhl_api.services.db.connection import DatabaseService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AggregationFilters:
+    """Filters for aggregation queries.
+
+    Attributes:
+        player_ids: Filter to specific players.
+        situation_codes: Filter to specific situations (e.g., ["5v5"]).
+        exclude_empty_net: Exclude empty net situations.
+        exclude_stoppages: Exclude stoppage time (default True).
+    """
+
+    player_ids: list[int] | None = None
+    situation_codes: list[str] | None = None
+    exclude_empty_net: bool = False
+    exclude_stoppages: bool = True
+
+
+@dataclass
+class ShiftAggregation:
+    """Stats at shift level (continuous ice time segment).
+
+    Represents aggregated TOI for a single player shift,
+    defined as continuous seconds on ice without a gap.
+
+    Attributes:
+        player_id: NHL player ID.
+        game_id: NHL game ID.
+        shift_number: Shift ordinal within the game (1-based).
+        period: Period number (1-5).
+        start_second: Game second when shift started.
+        end_second: Game second when shift ended.
+        toi_seconds: Total ice time in seconds.
+        by_situation: Breakdown by situation code.
+    """
+
+    player_id: int
+    game_id: int
+    shift_number: int
+    period: int
+    start_second: int
+    end_second: int
+    toi_seconds: int
+    by_situation: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class PeriodAggregation:
+    """Stats aggregated per period.
+
+    Attributes:
+        player_id: NHL player ID.
+        game_id: NHL game ID.
+        period: Period number (1-5).
+        toi_seconds: Total ice time in seconds.
+        shift_count: Number of shifts in this period.
+        by_situation: Breakdown by situation code.
+    """
+
+    player_id: int
+    game_id: int
+    period: int
+    toi_seconds: int
+    shift_count: int
+    by_situation: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class GameAggregation:
+    """Stats aggregated per game.
+
+    Attributes:
+        player_id: NHL player ID.
+        game_id: NHL game ID.
+        toi_seconds: Total ice time in seconds.
+        period_count: Number of periods with ice time.
+        shift_count: Total number of shifts.
+        by_situation: Breakdown by situation code.
+    """
+
+    player_id: int
+    game_id: int
+    toi_seconds: int
+    period_count: int
+    shift_count: int
+    by_situation: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class SeasonAggregation:
+    """Stats aggregated per season.
+
+    Attributes:
+        player_id: NHL player ID.
+        season_id: Season ID (e.g., 20242025).
+        toi_seconds: Total ice time in seconds.
+        game_count: Number of games played.
+        avg_toi_per_game: Average TOI per game in seconds.
+        by_situation: Breakdown by situation code.
+    """
+
+    player_id: int
+    season_id: int
+    toi_seconds: int
+    game_count: int
+    avg_toi_per_game: float
+    by_situation: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class LineCombinationStats:
+    """Season-level line combination stats.
+
+    Tracks TOI for a group of players together on the ice.
+
+    Attributes:
+        player_ids: Frozenset of player IDs in the combination.
+        season_id: Season ID (e.g., 20242025).
+        toi_together: Total seconds on ice together.
+        game_count: Number of games with shared ice time.
+        by_situation: Breakdown by situation code.
+    """
+
+    player_ids: frozenset[int]
+    season_id: int
+    toi_together: int
+    game_count: int
+    by_situation: dict[str, int] = field(default_factory=dict)
+
+
+class AggregationService:
+    """Service for flexible TOI aggregation at any level.
+
+    Provides methods for aggregating second-by-second snapshot data
+    at shift, period, game, and season levels.
+
+    Attributes:
+        db: Database service for data access.
+
+    Example:
+        >>> service = AggregationService(db)
+        >>> shifts = await service.aggregate_shifts(2024020500)
+        >>> print(f"Total shifts: {len(shifts)}")
+    """
+
+    def __init__(self, db: DatabaseService) -> None:
+        """Initialize the AggregationService.
+
+        Args:
+            db: Database service for data access.
+        """
+        self.db = db
+
+    def _build_where_clause(
+        self,
+        filters: AggregationFilters | None,
+        *,
+        game_id: int | None = None,
+        season_id: int | None = None,
+        table_alias: str = "",
+    ) -> tuple[list[str], list[Any], int]:
+        """Build WHERE clause conditions from filters.
+
+        Args:
+            filters: Aggregation filters.
+            game_id: Optional game ID filter.
+            season_id: Optional season ID filter.
+            table_alias: Table alias prefix (e.g., "s." or "").
+
+        Returns:
+            Tuple of (conditions list, params list, next param index).
+        """
+        prefix = f"{table_alias}." if table_alias else ""
+        conditions: list[str] = []
+        params: list[Any] = []
+        param_idx = 1
+
+        if game_id is not None:
+            conditions.append(f"{prefix}game_id = ${param_idx}")
+            params.append(game_id)
+            param_idx += 1
+
+        if season_id is not None:
+            conditions.append(f"{prefix}season_id = ${param_idx}")
+            params.append(season_id)
+            param_idx += 1
+
+        if filters:
+            if filters.exclude_stoppages:
+                conditions.append(f"{prefix}is_stoppage = false")
+
+            if filters.exclude_empty_net:
+                conditions.append(f"{prefix}is_empty_net = false")
+
+            if filters.situation_codes:
+                placeholders = ", ".join(
+                    f"${param_idx + i}" for i in range(len(filters.situation_codes))
+                )
+                conditions.append(f"{prefix}situation_code IN ({placeholders})")
+                params.extend(filters.situation_codes)
+                param_idx += len(filters.situation_codes)
+
+        # Default to excluding stoppages if no filter provided
+        if not filters:
+            conditions.append(f"{prefix}is_stoppage = false")
+
+        return conditions, params, param_idx
+
+    async def aggregate_shifts(
+        self,
+        game_id: int,
+        filters: AggregationFilters | None = None,
+    ) -> list[ShiftAggregation]:
+        """Aggregate player TOI at shift level (T030).
+
+        A shift is defined as a continuous sequence of seconds on ice,
+        with gaps > 1 second indicating a new shift.
+
+        Args:
+            game_id: NHL game ID.
+            filters: Optional aggregation filters.
+
+        Returns:
+            List of ShiftAggregation for each player shift.
+        """
+        conditions, params, param_idx = self._build_where_clause(
+            filters, game_id=game_id
+        )
+
+        # Handle player filter if specified
+        player_filter = ""
+        if filters and filters.player_ids:
+            player_placeholders = ", ".join(
+                f"${param_idx + i}" for i in range(len(filters.player_ids))
+            )
+            player_filter = f"WHERE player_id IN ({player_placeholders})"
+            params.extend(filters.player_ids)
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        # Use window functions to detect shift boundaries
+        query = f"""
+            WITH player_seconds AS (
+                -- Get all seconds each player is on ice
+                SELECT
+                    game_id,
+                    period,
+                    game_second,
+                    situation_code,
+                    unnest(home_skater_ids) as player_id
+                FROM second_snapshots
+                WHERE {where_clause}
+
+                UNION ALL
+
+                SELECT
+                    game_id,
+                    period,
+                    game_second,
+                    situation_code,
+                    unnest(away_skater_ids) as player_id
+                FROM second_snapshots
+                WHERE {where_clause}
+            ),
+            with_gaps AS (
+                -- Detect gaps in continuous ice time
+                SELECT
+                    *,
+                    game_second - LAG(game_second, 1, game_second)
+                        OVER (PARTITION BY player_id ORDER BY game_second) as gap
+                FROM player_seconds
+                {player_filter}
+            ),
+            with_shift_id AS (
+                -- Assign shift IDs using cumulative sum of new shift markers
+                SELECT
+                    *,
+                    SUM(CASE WHEN gap > 1 THEN 1 ELSE 0 END)
+                        OVER (PARTITION BY player_id ORDER BY game_second) as shift_id
+                FROM with_gaps
+            )
+            SELECT
+                player_id,
+                game_id,
+                shift_id + 1 as shift_number,
+                MIN(period) as period,
+                MIN(game_second) as start_second,
+                MAX(game_second) as end_second,
+                COUNT(*) as toi_seconds,
+                situation_code,
+                COUNT(*) as situation_toi
+            FROM with_shift_id
+            GROUP BY player_id, game_id, shift_id, situation_code
+            ORDER BY player_id, shift_id, situation_code
+        """
+
+        results = await self.db.fetch(query, *params)
+
+        # Aggregate situation breakdowns per shift
+        shift_data: dict[tuple[int, int], dict[str, Any]] = {}
+
+        for row in results:
+            key = (row["player_id"], row["shift_number"])
+
+            if key not in shift_data:
+                shift_data[key] = {
+                    "player_id": row["player_id"],
+                    "game_id": row["game_id"],
+                    "shift_number": row["shift_number"],
+                    "period": row["period"],
+                    "start_second": row["start_second"],
+                    "end_second": row["end_second"],
+                    "toi_seconds": 0,
+                    "by_situation": {},
+                }
+
+            shift_data[key]["toi_seconds"] += row["situation_toi"]
+            situation = row["situation_code"]
+            if situation not in shift_data[key]["by_situation"]:
+                shift_data[key]["by_situation"][situation] = 0
+            shift_data[key]["by_situation"][situation] += row["situation_toi"]
+
+        return [
+            ShiftAggregation(
+                player_id=data["player_id"],
+                game_id=data["game_id"],
+                shift_number=data["shift_number"],
+                period=data["period"],
+                start_second=data["start_second"],
+                end_second=data["end_second"],
+                toi_seconds=data["toi_seconds"],
+                by_situation=data["by_situation"],
+            )
+            for data in sorted(
+                shift_data.values(), key=lambda x: (x["player_id"], x["shift_number"])
+            )
+        ]
+
+    async def aggregate_periods(
+        self,
+        game_id: int,
+        filters: AggregationFilters | None = None,
+    ) -> list[PeriodAggregation]:
+        """Aggregate player TOI at period level (T031).
+
+        Args:
+            game_id: NHL game ID.
+            filters: Optional aggregation filters.
+
+        Returns:
+            List of PeriodAggregation for each player-period.
+        """
+        conditions, params, param_idx = self._build_where_clause(
+            filters, game_id=game_id
+        )
+
+        # Handle player filter
+        player_condition = ""
+        if filters and filters.player_ids:
+            player_placeholders = ", ".join(
+                f"${param_idx + i}" for i in range(len(filters.player_ids))
+            )
+            player_condition = f"AND player_id IN ({player_placeholders})"
+            params.extend(filters.player_ids)
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        query = f"""
+            WITH player_seconds AS (
+                SELECT
+                    game_id,
+                    period,
+                    game_second,
+                    situation_code,
+                    unnest(home_skater_ids) as player_id
+                FROM second_snapshots
+                WHERE {where_clause}
+
+                UNION ALL
+
+                SELECT
+                    game_id,
+                    period,
+                    game_second,
+                    situation_code,
+                    unnest(away_skater_ids) as player_id
+                FROM second_snapshots
+                WHERE {where_clause}
+            ),
+            with_gaps AS (
+                SELECT
+                    *,
+                    game_second - LAG(game_second, 1, game_second)
+                        OVER (PARTITION BY player_id, period ORDER BY game_second) as gap
+                FROM player_seconds
+                WHERE 1=1 {player_condition}
+            ),
+            with_shifts AS (
+                SELECT
+                    *,
+                    SUM(CASE WHEN gap > 1 THEN 1 ELSE 0 END)
+                        OVER (PARTITION BY player_id, period ORDER BY game_second) as shift_id
+                FROM with_gaps
+            )
+            SELECT
+                player_id,
+                game_id,
+                period,
+                situation_code,
+                COUNT(*) as toi_seconds,
+                COUNT(DISTINCT shift_id) as shift_count
+            FROM with_shifts
+            GROUP BY player_id, game_id, period, situation_code
+            ORDER BY player_id, period, situation_code
+        """
+
+        results = await self.db.fetch(query, *params)
+
+        # Aggregate by player-period
+        period_data: dict[tuple[int, int], dict[str, Any]] = {}
+
+        for row in results:
+            key = (row["player_id"], row["period"])
+
+            if key not in period_data:
+                period_data[key] = {
+                    "player_id": row["player_id"],
+                    "game_id": row["game_id"],
+                    "period": row["period"],
+                    "toi_seconds": 0,
+                    "shift_count": 0,
+                    "by_situation": {},
+                }
+
+            period_data[key]["toi_seconds"] += row["toi_seconds"]
+            period_data[key]["shift_count"] = max(
+                period_data[key]["shift_count"], row["shift_count"]
+            )
+
+            situation = row["situation_code"]
+            if situation not in period_data[key]["by_situation"]:
+                period_data[key]["by_situation"][situation] = 0
+            period_data[key]["by_situation"][situation] += row["toi_seconds"]
+
+        return [
+            PeriodAggregation(
+                player_id=data["player_id"],
+                game_id=data["game_id"],
+                period=data["period"],
+                toi_seconds=data["toi_seconds"],
+                shift_count=data["shift_count"],
+                by_situation=data["by_situation"],
+            )
+            for data in sorted(
+                period_data.values(), key=lambda x: (x["player_id"], x["period"])
+            )
+        ]
+
+    async def aggregate_game(
+        self,
+        game_id: int,
+        filters: AggregationFilters | None = None,
+    ) -> list[GameAggregation]:
+        """Aggregate player TOI at game level (T032).
+
+        Args:
+            game_id: NHL game ID.
+            filters: Optional aggregation filters.
+
+        Returns:
+            List of GameAggregation for each player.
+        """
+        conditions, params, param_idx = self._build_where_clause(
+            filters, game_id=game_id
+        )
+
+        # Handle player filter
+        player_condition = ""
+        if filters and filters.player_ids:
+            player_placeholders = ", ".join(
+                f"${param_idx + i}" for i in range(len(filters.player_ids))
+            )
+            player_condition = f"AND player_id IN ({player_placeholders})"
+            params.extend(filters.player_ids)
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        query = f"""
+            WITH player_seconds AS (
+                SELECT
+                    game_id,
+                    period,
+                    game_second,
+                    situation_code,
+                    unnest(home_skater_ids) as player_id
+                FROM second_snapshots
+                WHERE {where_clause}
+
+                UNION ALL
+
+                SELECT
+                    game_id,
+                    period,
+                    game_second,
+                    situation_code,
+                    unnest(away_skater_ids) as player_id
+                FROM second_snapshots
+                WHERE {where_clause}
+            ),
+            with_gaps AS (
+                SELECT
+                    *,
+                    game_second - LAG(game_second, 1, game_second)
+                        OVER (PARTITION BY player_id ORDER BY game_second) as gap
+                FROM player_seconds
+                WHERE 1=1 {player_condition}
+            ),
+            with_shifts AS (
+                SELECT
+                    *,
+                    SUM(CASE WHEN gap > 1 THEN 1 ELSE 0 END)
+                        OVER (PARTITION BY player_id ORDER BY game_second) as shift_id
+                FROM with_gaps
+            )
+            SELECT
+                player_id,
+                game_id,
+                situation_code,
+                COUNT(*) as toi_seconds,
+                COUNT(DISTINCT period) as period_count,
+                COUNT(DISTINCT shift_id) as shift_count
+            FROM with_shifts
+            GROUP BY player_id, game_id, situation_code
+            ORDER BY player_id, situation_code
+        """
+
+        results = await self.db.fetch(query, *params)
+
+        # Aggregate by player
+        game_data: dict[int, dict[str, Any]] = {}
+
+        for row in results:
+            player_id = row["player_id"]
+
+            if player_id not in game_data:
+                game_data[player_id] = {
+                    "player_id": player_id,
+                    "game_id": row["game_id"],
+                    "toi_seconds": 0,
+                    "period_count": 0,
+                    "shift_count": 0,
+                    "by_situation": {},
+                }
+
+            game_data[player_id]["toi_seconds"] += row["toi_seconds"]
+            game_data[player_id]["period_count"] = max(
+                game_data[player_id]["period_count"], row["period_count"]
+            )
+            game_data[player_id]["shift_count"] = max(
+                game_data[player_id]["shift_count"], row["shift_count"]
+            )
+
+            situation = row["situation_code"]
+            if situation not in game_data[player_id]["by_situation"]:
+                game_data[player_id]["by_situation"][situation] = 0
+            game_data[player_id]["by_situation"][situation] += row["toi_seconds"]
+
+        return [
+            GameAggregation(
+                player_id=data["player_id"],
+                game_id=data["game_id"],
+                toi_seconds=data["toi_seconds"],
+                period_count=data["period_count"],
+                shift_count=data["shift_count"],
+                by_situation=data["by_situation"],
+            )
+            for data in sorted(game_data.values(), key=lambda x: -x["toi_seconds"])
+        ]
+
+    async def aggregate_season(
+        self,
+        season_id: int,
+        filters: AggregationFilters | None = None,
+    ) -> list[SeasonAggregation]:
+        """Aggregate player TOI at season level.
+
+        Args:
+            season_id: Season ID (e.g., 20242025).
+            filters: Optional aggregation filters.
+
+        Returns:
+            List of SeasonAggregation for each player.
+        """
+        conditions, params, param_idx = self._build_where_clause(
+            filters, season_id=season_id
+        )
+
+        # Handle player filter
+        player_condition = ""
+        if filters and filters.player_ids:
+            player_placeholders = ", ".join(
+                f"${param_idx + i}" for i in range(len(filters.player_ids))
+            )
+            player_condition = f"AND player_id IN ({player_placeholders})"
+            params.extend(filters.player_ids)
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        query = f"""
+            WITH player_seconds AS (
+                SELECT
+                    game_id,
+                    season_id,
+                    situation_code,
+                    unnest(home_skater_ids) as player_id
+                FROM second_snapshots
+                WHERE {where_clause}
+
+                UNION ALL
+
+                SELECT
+                    game_id,
+                    season_id,
+                    situation_code,
+                    unnest(away_skater_ids) as player_id
+                FROM second_snapshots
+                WHERE {where_clause}
+            )
+            SELECT
+                player_id,
+                season_id,
+                situation_code,
+                COUNT(*) as toi_seconds,
+                COUNT(DISTINCT game_id) as game_count
+            FROM player_seconds
+            WHERE 1=1 {player_condition}
+            GROUP BY player_id, season_id, situation_code
+            ORDER BY player_id, situation_code
+        """
+
+        results = await self.db.fetch(query, *params)
+
+        # Aggregate by player
+        season_data: dict[int, dict[str, Any]] = {}
+
+        for row in results:
+            player_id = row["player_id"]
+
+            if player_id not in season_data:
+                season_data[player_id] = {
+                    "player_id": player_id,
+                    "season_id": row["season_id"],
+                    "toi_seconds": 0,
+                    "game_count": 0,
+                    "by_situation": {},
+                }
+
+            season_data[player_id]["toi_seconds"] += row["toi_seconds"]
+            season_data[player_id]["game_count"] = max(
+                season_data[player_id]["game_count"], row["game_count"]
+            )
+
+            situation = row["situation_code"]
+            if situation not in season_data[player_id]["by_situation"]:
+                season_data[player_id]["by_situation"][situation] = 0
+            season_data[player_id]["by_situation"][situation] += row["toi_seconds"]
+
+        return [
+            SeasonAggregation(
+                player_id=data["player_id"],
+                season_id=data["season_id"],
+                toi_seconds=data["toi_seconds"],
+                game_count=data["game_count"],
+                avg_toi_per_game=(
+                    data["toi_seconds"] / data["game_count"]
+                    if data["game_count"] > 0
+                    else 0.0
+                ),
+                by_situation=data["by_situation"],
+            )
+            for data in sorted(season_data.values(), key=lambda x: -x["toi_seconds"])
+        ]
+
+    async def get_line_combinations(
+        self,
+        season_id: int,
+        *,
+        min_toi: int = 300,
+        min_players: int = 3,
+        max_players: int = 5,
+        filters: AggregationFilters | None = None,
+    ) -> list[LineCombinationStats]:
+        """Get season-level line combination stats (T033).
+
+        Analyzes which player combinations have spent time on ice together.
+
+        Args:
+            season_id: Season ID (e.g., 20242025).
+            min_toi: Minimum TOI in seconds to include (default 300 = 5 min).
+            min_players: Minimum players in combination (default 3).
+            max_players: Maximum players in combination (default 5).
+            filters: Optional aggregation filters.
+
+        Returns:
+            List of LineCombinationStats sorted by TOI together.
+        """
+        conditions, params, param_idx = self._build_where_clause(
+            filters, season_id=season_id
+        )
+
+        # Add array length filters
+        conditions.append(f"array_length(home_skater_ids, 1) >= ${param_idx}")
+        params.append(min_players)
+        param_idx += 1
+
+        conditions.append(f"array_length(home_skater_ids, 1) <= ${param_idx}")
+        params.append(max_players)
+        param_idx += 1
+
+        # Store min_toi param index
+        min_toi_idx = param_idx
+        params.append(min_toi)
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        # Query for line combinations (using sorted array for consistent grouping)
+        query = f"""
+            WITH line_seconds AS (
+                -- Home team line combinations
+                SELECT
+                    game_id,
+                    season_id,
+                    situation_code,
+                    (SELECT array_agg(x ORDER BY x) FROM unnest(home_skater_ids) x) as sorted_players
+                FROM second_snapshots
+                WHERE {where_clause}
+
+                UNION ALL
+
+                -- Away team line combinations
+                SELECT
+                    game_id,
+                    season_id,
+                    situation_code,
+                    (SELECT array_agg(x ORDER BY x) FROM unnest(away_skater_ids) x) as sorted_players
+                FROM second_snapshots
+                WHERE {where_clause.replace("home_skater_ids", "away_skater_ids")}
+            )
+            SELECT
+                sorted_players,
+                season_id,
+                situation_code,
+                COUNT(*) as toi_seconds,
+                COUNT(DISTINCT game_id) as game_count
+            FROM line_seconds
+            WHERE sorted_players IS NOT NULL
+            GROUP BY sorted_players, season_id, situation_code
+            HAVING COUNT(*) >= ${min_toi_idx}
+            ORDER BY COUNT(*) DESC
+        """
+
+        results = await self.db.fetch(query, *params)
+
+        # Aggregate by line combination
+        line_data: dict[tuple[int, ...], dict[str, Any]] = {}
+
+        for row in results:
+            # Convert list to tuple for dict key
+            players = tuple(sorted(row["sorted_players"]))
+
+            if players not in line_data:
+                line_data[players] = {
+                    "player_ids": frozenset(players),
+                    "season_id": row["season_id"],
+                    "toi_together": 0,
+                    "game_count": 0,
+                    "by_situation": {},
+                }
+
+            line_data[players]["toi_together"] += row["toi_seconds"]
+            line_data[players]["game_count"] = max(
+                line_data[players]["game_count"], row["game_count"]
+            )
+
+            situation = row["situation_code"]
+            if situation not in line_data[players]["by_situation"]:
+                line_data[players]["by_situation"][situation] = 0
+            line_data[players]["by_situation"][situation] += row["toi_seconds"]
+
+        return [
+            LineCombinationStats(
+                player_ids=data["player_ids"],
+                season_id=data["season_id"],
+                toi_together=data["toi_together"],
+                game_count=data["game_count"],
+                by_situation=data["by_situation"],
+            )
+            for data in sorted(line_data.values(), key=lambda x: -x["toi_together"])
+        ]
+
+    async def get_player_toi_summary(
+        self,
+        player_id: int,
+        season_id: int,
+        filters: AggregationFilters | None = None,
+    ) -> SeasonAggregation | None:
+        """Get TOI summary for a single player.
+
+        Convenience method for quick player lookups.
+
+        Args:
+            player_id: NHL player ID.
+            season_id: Season ID.
+            filters: Optional aggregation filters.
+
+        Returns:
+            SeasonAggregation for the player, or None if no data.
+        """
+        if filters is None:
+            filters = AggregationFilters(player_ids=[player_id])
+        else:
+            filters.player_ids = [player_id]
+
+        results = await self.aggregate_season(season_id, filters)
+        return results[0] if results else None

--- a/tests/integration/analytics/test_aggregation.py
+++ b/tests/integration/analytics/test_aggregation.py
@@ -1,0 +1,582 @@
+"""Integration tests for aggregation service (T030-T033).
+
+Validates aggregation functionality at all levels:
+- T030: Shift-level aggregation
+- T031: Period-level aggregation
+- T032: Game-level aggregation
+- T033: Season-level line combinations
+
+Issue: #263 - Wave 5: Aggregation Functions
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nhl_api.services.analytics.aggregation import (
+    AggregationFilters,
+    AggregationService,
+    GameAggregation,
+    LineCombinationStats,
+    PeriodAggregation,
+    SeasonAggregation,
+    ShiftAggregation,
+)
+from tests.integration.analytics.conftest import make_records
+
+if TYPE_CHECKING:
+    from nhl_api.services.db.connection import DatabaseService
+
+
+class TestAggregateShiftsIntegration:
+    """Integration tests for shift-level aggregation (T030)."""
+
+    @pytest.mark.asyncio
+    async def test_aggregate_shifts_single_player(self) -> None:
+        """Should aggregate shifts for a single player."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    # First shift
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "shift_number": 1,
+                        "period": 1,
+                        "start_second": 0,
+                        "end_second": 45,
+                        "toi_seconds": 46,
+                        "situation_code": "5v5",
+                        "situation_toi": 46,
+                    },
+                    # Second shift with PP time
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "shift_number": 2,
+                        "period": 1,
+                        "start_second": 120,
+                        "end_second": 165,
+                        "toi_seconds": 35,
+                        "situation_code": "5v5",
+                        "situation_toi": 35,
+                    },
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "shift_number": 2,
+                        "period": 1,
+                        "start_second": 120,
+                        "end_second": 165,
+                        "toi_seconds": 11,
+                        "situation_code": "5v4",
+                        "situation_toi": 11,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        shifts = await service.aggregate_shifts(2024020500)
+
+        assert len(shifts) == 2
+        assert all(isinstance(s, ShiftAggregation) for s in shifts)
+
+        # Check first shift
+        shift1 = shifts[0]
+        assert shift1.player_id == 8478402
+        assert shift1.shift_number == 1
+        assert shift1.toi_seconds == 46
+        assert shift1.by_situation == {"5v5": 46}
+
+        # Check second shift (combined situations)
+        shift2 = shifts[1]
+        assert shift2.shift_number == 2
+        assert shift2.toi_seconds == 46  # 35 + 11
+        assert shift2.by_situation == {"5v5": 35, "5v4": 11}
+
+    @pytest.mark.asyncio
+    async def test_aggregate_shifts_multiple_players(self) -> None:
+        """Should aggregate shifts for multiple players."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "shift_number": 1,
+                        "period": 1,
+                        "start_second": 0,
+                        "end_second": 45,
+                        "toi_seconds": 46,
+                        "situation_code": "5v5",
+                        "situation_toi": 46,
+                    },
+                    {
+                        "player_id": 8477934,
+                        "game_id": 2024020500,
+                        "shift_number": 1,
+                        "period": 1,
+                        "start_second": 0,
+                        "end_second": 42,
+                        "toi_seconds": 43,
+                        "situation_code": "5v5",
+                        "situation_toi": 43,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        shifts = await service.aggregate_shifts(2024020500)
+
+        assert len(shifts) == 2
+        player_ids = {s.player_id for s in shifts}
+        assert player_ids == {8478402, 8477934}
+
+    @pytest.mark.asyncio
+    async def test_aggregate_shifts_with_player_filter(self) -> None:
+        """Should filter to specific players."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(return_value=[])
+
+        service = AggregationService(db)
+        filters = AggregationFilters(player_ids=[8478402])
+        await service.aggregate_shifts(2024020500, filters)
+
+        # Verify fetch was called with player filter
+        call_args = db.fetch.call_args
+        assert 8478402 in call_args[0]
+
+
+class TestAggregatePeriodsIntegration:
+    """Integration tests for period-level aggregation (T031)."""
+
+    @pytest.mark.asyncio
+    async def test_aggregate_periods_all_periods(self) -> None:
+        """Should aggregate across all periods."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "period": 1,
+                        "situation_code": "5v5",
+                        "toi_seconds": 380,
+                        "shift_count": 7,
+                    },
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "period": 1,
+                        "situation_code": "5v4",
+                        "toi_seconds": 40,
+                        "shift_count": 2,
+                    },
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "period": 2,
+                        "situation_code": "5v5",
+                        "toi_seconds": 400,
+                        "shift_count": 8,
+                    },
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "period": 3,
+                        "situation_code": "5v5",
+                        "toi_seconds": 350,
+                        "shift_count": 7,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        periods = await service.aggregate_periods(2024020500)
+
+        assert len(periods) == 3
+        assert all(isinstance(p, PeriodAggregation) for p in periods)
+
+        # Check period 1 (combined situations)
+        p1 = next(p for p in periods if p.period == 1)
+        assert p1.toi_seconds == 420  # 380 + 40
+        assert p1.by_situation == {"5v5": 380, "5v4": 40}
+
+        # Check totals
+        total_toi = sum(p.toi_seconds for p in periods)
+        assert total_toi == 1170  # 420 + 400 + 350
+
+    @pytest.mark.asyncio
+    async def test_aggregate_periods_with_situation_filter(self) -> None:
+        """Should filter to specific situations."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "period": 1,
+                        "situation_code": "5v5",
+                        "toi_seconds": 380,
+                        "shift_count": 7,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        filters = AggregationFilters(situation_codes=["5v5"])
+        periods = await service.aggregate_periods(2024020500, filters)
+
+        assert len(periods) == 1
+        assert periods[0].by_situation == {"5v5": 380}
+
+
+class TestAggregateGameIntegration:
+    """Integration tests for game-level aggregation (T032)."""
+
+    @pytest.mark.asyncio
+    async def test_aggregate_game_all_players(self) -> None:
+        """Should aggregate game stats for all players."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "situation_code": "5v5",
+                        "toi_seconds": 1100,
+                        "period_count": 3,
+                        "shift_count": 20,
+                    },
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "situation_code": "5v4",
+                        "toi_seconds": 150,
+                        "period_count": 3,
+                        "shift_count": 5,
+                    },
+                    {
+                        "player_id": 8477934,
+                        "game_id": 2024020500,
+                        "situation_code": "5v5",
+                        "toi_seconds": 1050,
+                        "period_count": 3,
+                        "shift_count": 18,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        game_stats = await service.aggregate_game(2024020500)
+
+        assert len(game_stats) == 2
+        assert all(isinstance(g, GameAggregation) for g in game_stats)
+
+        # Should be sorted by TOI descending
+        assert game_stats[0].player_id == 8478402
+        assert game_stats[0].toi_seconds == 1250
+        assert game_stats[1].player_id == 8477934
+        assert game_stats[1].toi_seconds == 1050
+
+    @pytest.mark.asyncio
+    async def test_aggregate_game_situation_breakdown(self) -> None:
+        """Should include situation breakdown."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "situation_code": "5v5",
+                        "toi_seconds": 1000,
+                        "period_count": 3,
+                        "shift_count": 18,
+                    },
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "situation_code": "5v4",
+                        "toi_seconds": 120,
+                        "period_count": 2,
+                        "shift_count": 4,
+                    },
+                    {
+                        "player_id": 8478402,
+                        "game_id": 2024020500,
+                        "situation_code": "4v5",
+                        "toi_seconds": 80,
+                        "period_count": 2,
+                        "shift_count": 3,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        game_stats = await service.aggregate_game(2024020500)
+
+        assert len(game_stats) == 1
+        assert game_stats[0].by_situation == {
+            "5v5": 1000,
+            "5v4": 120,
+            "4v5": 80,
+        }
+
+
+class TestAggregateSeasonIntegration:
+    """Integration tests for season-level aggregation."""
+
+    @pytest.mark.asyncio
+    async def test_aggregate_season_all_players(self) -> None:
+        """Should aggregate season stats for all players."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    {
+                        "player_id": 8478402,
+                        "season_id": 20242025,
+                        "situation_code": "5v5",
+                        "toi_seconds": 45000,
+                        "game_count": 40,
+                    },
+                    {
+                        "player_id": 8478402,
+                        "season_id": 20242025,
+                        "situation_code": "5v4",
+                        "toi_seconds": 4000,
+                        "game_count": 40,
+                    },
+                    {
+                        "player_id": 8477934,
+                        "season_id": 20242025,
+                        "situation_code": "5v5",
+                        "toi_seconds": 42000,
+                        "game_count": 38,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        season_stats = await service.aggregate_season(20242025)
+
+        assert len(season_stats) == 2
+        assert all(isinstance(s, SeasonAggregation) for s in season_stats)
+
+        # Should be sorted by TOI descending
+        mcdavid = season_stats[0]
+        assert mcdavid.player_id == 8478402
+        assert mcdavid.toi_seconds == 49000  # 45000 + 4000
+        assert mcdavid.game_count == 40
+        assert mcdavid.avg_toi_per_game == 1225.0
+
+    @pytest.mark.asyncio
+    async def test_aggregate_season_with_filters(self) -> None:
+        """Should apply filters to season aggregation."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(return_value=[])
+
+        service = AggregationService(db)
+        filters = AggregationFilters(
+            situation_codes=["5v5"],
+            exclude_empty_net=True,
+        )
+        await service.aggregate_season(20242025, filters)
+
+        # Verify filters applied
+        call_args = db.fetch.call_args
+        assert "5v5" in call_args[0]
+
+
+class TestLineCombinationsIntegration:
+    """Integration tests for line combinations (T033)."""
+
+    @pytest.mark.asyncio
+    async def test_get_line_combinations_basic(self) -> None:
+        """Should return line combination stats."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    {
+                        "sorted_players": [8477934, 8478402, 8478421],
+                        "season_id": 20242025,
+                        "situation_code": "5v5",
+                        "toi_seconds": 5000,
+                        "game_count": 30,
+                    },
+                    {
+                        "sorted_players": [8477934, 8478402, 8478421],
+                        "season_id": 20242025,
+                        "situation_code": "5v4",
+                        "toi_seconds": 500,
+                        "game_count": 25,
+                    },
+                    {
+                        "sorted_players": [8477846, 8477904, 8478042],
+                        "season_id": 20242025,
+                        "situation_code": "5v5",
+                        "toi_seconds": 3000,
+                        "game_count": 20,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        lines = await service.get_line_combinations(20242025, min_toi=300)
+
+        assert len(lines) == 2
+        assert all(isinstance(line, LineCombinationStats) for line in lines)
+
+        # Should be sorted by TOI
+        assert lines[0].toi_together == 5500  # Combined 5v5 + 5v4
+        assert lines[0].player_ids == frozenset({8477934, 8478402, 8478421})
+        assert lines[0].by_situation == {"5v5": 5000, "5v4": 500}
+
+    @pytest.mark.asyncio
+    async def test_get_line_combinations_with_player_count(self) -> None:
+        """Should filter by player count."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(return_value=[])
+
+        service = AggregationService(db)
+        await service.get_line_combinations(
+            20242025,
+            min_players=5,  # Full 5-player lines only
+            max_players=5,
+        )
+
+        # Verify player count params passed
+        call_args = db.fetch.call_args
+        assert 5 in call_args[0]
+
+    @pytest.mark.asyncio
+    async def test_get_line_combinations_empty_result(self) -> None:
+        """Should handle no line combinations found."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(return_value=[])
+
+        service = AggregationService(db)
+        lines = await service.get_line_combinations(20242025, min_toi=10000)
+
+        assert lines == []
+
+
+class TestPlayerTOISummaryIntegration:
+    """Integration tests for player TOI summary."""
+
+    @pytest.mark.asyncio
+    async def test_get_player_toi_summary_found(self) -> None:
+        """Should return player summary when found."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(
+            return_value=make_records(
+                [
+                    {
+                        "player_id": 8478402,
+                        "season_id": 20242025,
+                        "situation_code": "5v5",
+                        "toi_seconds": 50000,
+                        "game_count": 41,
+                    },
+                ]
+            )
+        )
+
+        service = AggregationService(db)
+        summary = await service.get_player_toi_summary(8478402, 20242025)
+
+        assert summary is not None
+        assert summary.player_id == 8478402
+        assert summary.toi_seconds == 50000
+        assert summary.game_count == 41
+        assert summary.avg_toi_per_game == pytest.approx(1219.51, rel=0.01)
+
+    @pytest.mark.asyncio
+    async def test_get_player_toi_summary_not_found(self) -> None:
+        """Should return None when player not found."""
+        db = AsyncMock()
+        db.fetch = AsyncMock(return_value=[])
+
+        service = AggregationService(db)
+        summary = await service.get_player_toi_summary(9999999, 20242025)
+
+        assert summary is None
+
+
+class TestAggregationWithLiveDatabase:
+    """Tests with live database connection (skipped if unavailable)."""
+
+    @pytest.fixture
+    def db_available(self, live_db_service: DatabaseService | None) -> bool:
+        """Check if database is available."""
+        return live_db_service is not None
+
+    @pytest.mark.asyncio
+    async def test_aggregate_game_live(
+        self, live_db_service: DatabaseService | None
+    ) -> None:
+        """Aggregate game with live database."""
+        if live_db_service is None:
+            pytest.skip("Database not available")
+
+        service = AggregationService(live_db_service)
+
+        # Query for any game with data
+        game_id = await live_db_service.fetchval(
+            "SELECT game_id FROM second_snapshots LIMIT 1"
+        )
+
+        if game_id is None:
+            pytest.skip("No second_snapshots data available")
+
+        game_stats = await service.aggregate_game(game_id)
+
+        assert isinstance(game_stats, list)
+        if game_stats:
+            assert all(isinstance(g, GameAggregation) for g in game_stats)
+            # At least one player should have data
+            assert any(g.toi_seconds > 0 for g in game_stats)
+
+    @pytest.mark.asyncio
+    async def test_line_combinations_live(
+        self, live_db_service: DatabaseService | None
+    ) -> None:
+        """Get line combinations with live database."""
+        if live_db_service is None:
+            pytest.skip("Database not available")
+
+        service = AggregationService(live_db_service)
+
+        # Get a season with data
+        season_id = await live_db_service.fetchval(
+            "SELECT DISTINCT season_id FROM second_snapshots LIMIT 1"
+        )
+
+        if season_id is None:
+            pytest.skip("No second_snapshots data available")
+
+        lines = await service.get_line_combinations(
+            season_id,
+            min_toi=60,  # Low threshold for testing
+        )
+
+        assert isinstance(lines, list)
+        # May or may not have data depending on season

--- a/tests/unit/services/analytics/test_aggregation.py
+++ b/tests/unit/services/analytics/test_aggregation.py
@@ -1,0 +1,706 @@
+"""Unit tests for AggregationService.
+
+Tests the aggregation logic for shift, period, game, and season levels.
+
+Issue: #263 - Wave 5: Aggregation Functions (T030-T033)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nhl_api.services.analytics.aggregation import (
+    AggregationFilters,
+    AggregationService,
+    GameAggregation,
+    LineCombinationStats,
+    PeriodAggregation,
+    SeasonAggregation,
+    ShiftAggregation,
+)
+
+
+class DictLikeRecord:
+    """A dict-like object that mimics asyncpg Record behavior."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __getattr__(self, key: str) -> Any:
+        try:
+            return self._data[key]
+        except KeyError as err:
+            raise AttributeError(
+                f"'{type(self).__name__}' has no attribute '{key}'"
+            ) from err
+
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        return self._data.values()
+
+    def items(self):
+        return self._data.items()
+
+
+def make_records(data_list: list[dict[str, Any]]) -> list[DictLikeRecord]:
+    """Helper to create a list of DictLikeRecords from a list of dicts."""
+    return [DictLikeRecord(d) for d in data_list]
+
+
+class TestAggregationFilters:
+    """Tests for AggregationFilters dataclass."""
+
+    def test_default_values(self) -> None:
+        """Default filters have sensible values."""
+        filters = AggregationFilters()
+        assert filters.player_ids is None
+        assert filters.situation_codes is None
+        assert filters.exclude_empty_net is False
+        assert filters.exclude_stoppages is True
+
+    def test_custom_values(self) -> None:
+        """Custom filter values are stored."""
+        filters = AggregationFilters(
+            player_ids=[8478402, 8477934],
+            situation_codes=["5v5", "5v4"],
+            exclude_empty_net=True,
+            exclude_stoppages=False,
+        )
+        assert filters.player_ids == [8478402, 8477934]
+        assert filters.situation_codes == ["5v5", "5v4"]
+        assert filters.exclude_empty_net is True
+        assert filters.exclude_stoppages is False
+
+
+class TestShiftAggregation:
+    """Tests for ShiftAggregation dataclass."""
+
+    def test_creation(self) -> None:
+        """ShiftAggregation stores all values."""
+        shift = ShiftAggregation(
+            player_id=8478402,
+            game_id=2024020500,
+            shift_number=1,
+            period=1,
+            start_second=0,
+            end_second=45,
+            toi_seconds=46,
+            by_situation={"5v5": 40, "5v4": 6},
+        )
+        assert shift.player_id == 8478402
+        assert shift.game_id == 2024020500
+        assert shift.shift_number == 1
+        assert shift.period == 1
+        assert shift.start_second == 0
+        assert shift.end_second == 45
+        assert shift.toi_seconds == 46
+        assert shift.by_situation == {"5v5": 40, "5v4": 6}
+
+    def test_default_by_situation(self) -> None:
+        """by_situation defaults to empty dict."""
+        shift = ShiftAggregation(
+            player_id=8478402,
+            game_id=2024020500,
+            shift_number=1,
+            period=1,
+            start_second=0,
+            end_second=45,
+            toi_seconds=46,
+        )
+        assert shift.by_situation == {}
+
+
+class TestPeriodAggregation:
+    """Tests for PeriodAggregation dataclass."""
+
+    def test_creation(self) -> None:
+        """PeriodAggregation stores all values."""
+        period = PeriodAggregation(
+            player_id=8478402,
+            game_id=2024020500,
+            period=1,
+            toi_seconds=420,
+            shift_count=8,
+            by_situation={"5v5": 380, "5v4": 40},
+        )
+        assert period.player_id == 8478402
+        assert period.period == 1
+        assert period.toi_seconds == 420
+        assert period.shift_count == 8
+
+
+class TestGameAggregation:
+    """Tests for GameAggregation dataclass."""
+
+    def test_creation(self) -> None:
+        """GameAggregation stores all values."""
+        game = GameAggregation(
+            player_id=8478402,
+            game_id=2024020500,
+            toi_seconds=1250,
+            period_count=3,
+            shift_count=25,
+            by_situation={"5v5": 1100, "5v4": 100, "4v5": 50},
+        )
+        assert game.player_id == 8478402
+        assert game.game_id == 2024020500
+        assert game.toi_seconds == 1250
+        assert game.period_count == 3
+        assert game.shift_count == 25
+
+
+class TestSeasonAggregation:
+    """Tests for SeasonAggregation dataclass."""
+
+    def test_creation(self) -> None:
+        """SeasonAggregation stores all values."""
+        season = SeasonAggregation(
+            player_id=8478402,
+            season_id=20242025,
+            toi_seconds=50000,
+            game_count=40,
+            avg_toi_per_game=1250.0,
+            by_situation={"5v5": 45000, "5v4": 4000, "4v5": 1000},
+        )
+        assert season.player_id == 8478402
+        assert season.season_id == 20242025
+        assert season.toi_seconds == 50000
+        assert season.game_count == 40
+        assert season.avg_toi_per_game == 1250.0
+
+
+class TestLineCombinationStats:
+    """Tests for LineCombinationStats dataclass."""
+
+    def test_creation(self) -> None:
+        """LineCombinationStats stores all values."""
+        line = LineCombinationStats(
+            player_ids=frozenset({8478402, 8477934, 8478421}),
+            season_id=20242025,
+            toi_together=5000,
+            game_count=30,
+            by_situation={"5v5": 4500, "5v4": 500},
+        )
+        assert 8478402 in line.player_ids
+        assert 8477934 in line.player_ids
+        assert 8478421 in line.player_ids
+        assert line.season_id == 20242025
+        assert line.toi_together == 5000
+        assert line.game_count == 30
+
+
+class TestAggregationServiceBuildWhereClause:
+    """Tests for _build_where_clause method."""
+
+    @pytest.fixture
+    def service(self) -> AggregationService:
+        """Create AggregationService with mock db."""
+        db = AsyncMock()
+        return AggregationService(db)
+
+    def test_no_filters(self, service: AggregationService) -> None:
+        """No filters adds is_stoppage filter by default."""
+        conditions, params, next_idx = service._build_where_clause(None)
+        assert "is_stoppage = false" in conditions
+        assert params == []
+        assert next_idx == 1
+
+    def test_with_game_id(self, service: AggregationService) -> None:
+        """game_id filter is added."""
+        conditions, params, next_idx = service._build_where_clause(
+            None, game_id=2024020500
+        )
+        assert "game_id = $1" in conditions
+        assert params == [2024020500]
+        assert next_idx == 2
+
+    def test_with_season_id(self, service: AggregationService) -> None:
+        """season_id filter is added."""
+        conditions, params, next_idx = service._build_where_clause(
+            None, season_id=20242025
+        )
+        assert "season_id = $1" in conditions
+        assert params == [20242025]
+        assert next_idx == 2
+
+    def test_with_situation_codes(self, service: AggregationService) -> None:
+        """situation_codes filter is added."""
+        filters = AggregationFilters(situation_codes=["5v5", "5v4"])
+        conditions, params, next_idx = service._build_where_clause(filters)
+        assert "situation_code IN ($1, $2)" in conditions
+        assert params == ["5v5", "5v4"]
+
+    def test_with_exclude_empty_net(self, service: AggregationService) -> None:
+        """exclude_empty_net filter is added."""
+        filters = AggregationFilters(exclude_empty_net=True)
+        conditions, params, next_idx = service._build_where_clause(filters)
+        assert "is_empty_net = false" in conditions
+
+    def test_with_exclude_stoppages_false(self, service: AggregationService) -> None:
+        """exclude_stoppages=False removes is_stoppage filter."""
+        filters = AggregationFilters(exclude_stoppages=False)
+        conditions, params, next_idx = service._build_where_clause(filters)
+        assert "is_stoppage = false" not in conditions
+
+    def test_with_table_alias(self, service: AggregationService) -> None:
+        """Table alias is applied to conditions."""
+        conditions, params, next_idx = service._build_where_clause(
+            None, game_id=2024020500, table_alias="s"
+        )
+        assert "s.game_id = $1" in conditions
+
+
+class TestAggregationServiceAggregateShifts:
+    """Tests for aggregate_shifts method."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create mock database service."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_db: AsyncMock) -> AggregationService:
+        """Create AggregationService with mock db."""
+        return AggregationService(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_aggregate_shifts_returns_list(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """aggregate_shifts returns list of ShiftAggregation."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "player_id": 8478402,
+                    "game_id": 2024020500,
+                    "shift_number": 1,
+                    "period": 1,
+                    "start_second": 0,
+                    "end_second": 45,
+                    "toi_seconds": 46,
+                    "situation_code": "5v5",
+                    "situation_toi": 46,
+                },
+                {
+                    "player_id": 8478402,
+                    "game_id": 2024020500,
+                    "shift_number": 2,
+                    "period": 1,
+                    "start_second": 120,
+                    "end_second": 165,
+                    "toi_seconds": 46,
+                    "situation_code": "5v5",
+                    "situation_toi": 46,
+                },
+            ]
+        )
+
+        result = await service.aggregate_shifts(2024020500)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(r, ShiftAggregation) for r in result)
+        assert result[0].player_id == 8478402
+        assert result[0].shift_number == 1
+
+    @pytest.mark.asyncio
+    async def test_aggregate_shifts_with_filters(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """aggregate_shifts applies filters."""
+        mock_db.fetch.return_value = []
+
+        filters = AggregationFilters(
+            situation_codes=["5v5"],
+            player_ids=[8478402],
+        )
+        await service.aggregate_shifts(2024020500, filters)
+
+        # Verify fetch was called with parameters
+        mock_db.fetch.assert_called_once()
+        call_args = mock_db.fetch.call_args
+        assert "5v5" in call_args[0]  # situation code in params
+
+    @pytest.mark.asyncio
+    async def test_aggregate_shifts_combines_situations(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """Multiple situations in same shift are combined."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "player_id": 8478402,
+                    "game_id": 2024020500,
+                    "shift_number": 1,
+                    "period": 1,
+                    "start_second": 0,
+                    "end_second": 60,
+                    "toi_seconds": 40,
+                    "situation_code": "5v5",
+                    "situation_toi": 40,
+                },
+                {
+                    "player_id": 8478402,
+                    "game_id": 2024020500,
+                    "shift_number": 1,
+                    "period": 1,
+                    "start_second": 0,
+                    "end_second": 60,
+                    "toi_seconds": 21,
+                    "situation_code": "5v4",
+                    "situation_toi": 21,
+                },
+            ]
+        )
+
+        result = await service.aggregate_shifts(2024020500)
+
+        assert len(result) == 1  # Single shift
+        assert result[0].toi_seconds == 61  # Combined TOI
+        assert result[0].by_situation == {"5v5": 40, "5v4": 21}
+
+
+class TestAggregationServiceAggregatePeriods:
+    """Tests for aggregate_periods method."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create mock database service."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_db: AsyncMock) -> AggregationService:
+        """Create AggregationService with mock db."""
+        return AggregationService(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_aggregate_periods_returns_list(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """aggregate_periods returns list of PeriodAggregation."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "player_id": 8478402,
+                    "game_id": 2024020500,
+                    "period": 1,
+                    "situation_code": "5v5",
+                    "toi_seconds": 380,
+                    "shift_count": 7,
+                },
+                {
+                    "player_id": 8478402,
+                    "game_id": 2024020500,
+                    "period": 1,
+                    "situation_code": "5v4",
+                    "toi_seconds": 40,
+                    "shift_count": 2,
+                },
+            ]
+        )
+
+        result = await service.aggregate_periods(2024020500)
+
+        assert isinstance(result, list)
+        assert len(result) == 1  # Combined into one period
+        assert isinstance(result[0], PeriodAggregation)
+        assert result[0].player_id == 8478402
+        assert result[0].period == 1
+        assert result[0].toi_seconds == 420  # Combined
+        assert result[0].by_situation == {"5v5": 380, "5v4": 40}
+
+
+class TestAggregationServiceAggregateGame:
+    """Tests for aggregate_game method."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create mock database service."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_db: AsyncMock) -> AggregationService:
+        """Create AggregationService with mock db."""
+        return AggregationService(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_aggregate_game_returns_list(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """aggregate_game returns list of GameAggregation."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "player_id": 8478402,
+                    "game_id": 2024020500,
+                    "situation_code": "5v5",
+                    "toi_seconds": 1100,
+                    "period_count": 3,
+                    "shift_count": 20,
+                },
+                {
+                    "player_id": 8478402,
+                    "game_id": 2024020500,
+                    "situation_code": "5v4",
+                    "toi_seconds": 150,
+                    "period_count": 3,
+                    "shift_count": 5,
+                },
+                {
+                    "player_id": 8477934,
+                    "game_id": 2024020500,
+                    "situation_code": "5v5",
+                    "toi_seconds": 1050,
+                    "period_count": 3,
+                    "shift_count": 18,
+                },
+            ]
+        )
+
+        result = await service.aggregate_game(2024020500)
+
+        assert isinstance(result, list)
+        assert len(result) == 2  # Two players
+        assert all(isinstance(r, GameAggregation) for r in result)
+
+        # Results should be sorted by TOI descending
+        assert result[0].player_id == 8478402
+        assert result[0].toi_seconds == 1250
+        assert result[1].player_id == 8477934
+        assert result[1].toi_seconds == 1050
+
+
+class TestAggregationServiceAggregateSeason:
+    """Tests for aggregate_season method."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create mock database service."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_db: AsyncMock) -> AggregationService:
+        """Create AggregationService with mock db."""
+        return AggregationService(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_aggregate_season_returns_list(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """aggregate_season returns list of SeasonAggregation."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "player_id": 8478402,
+                    "season_id": 20242025,
+                    "situation_code": "5v5",
+                    "toi_seconds": 45000,
+                    "game_count": 40,
+                },
+                {
+                    "player_id": 8478402,
+                    "season_id": 20242025,
+                    "situation_code": "5v4",
+                    "toi_seconds": 4000,
+                    "game_count": 40,
+                },
+                {
+                    "player_id": 8478402,
+                    "season_id": 20242025,
+                    "situation_code": "4v5",
+                    "toi_seconds": 1000,
+                    "game_count": 38,
+                },
+            ]
+        )
+
+        result = await service.aggregate_season(20242025)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], SeasonAggregation)
+        assert result[0].player_id == 8478402
+        assert result[0].season_id == 20242025
+        assert result[0].toi_seconds == 50000  # Combined
+        assert result[0].game_count == 40  # Max
+        assert result[0].avg_toi_per_game == 1250.0  # 50000 / 40
+
+    @pytest.mark.asyncio
+    async def test_aggregate_season_handles_zero_games(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """aggregate_season handles zero games (avoids division by zero)."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "player_id": 8478402,
+                    "season_id": 20242025,
+                    "situation_code": "5v5",
+                    "toi_seconds": 0,
+                    "game_count": 0,
+                },
+            ]
+        )
+
+        result = await service.aggregate_season(20242025)
+
+        assert len(result) == 1
+        assert result[0].avg_toi_per_game == 0.0
+
+
+class TestAggregationServiceLineCombinations:
+    """Tests for get_line_combinations method."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create mock database service."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_db: AsyncMock) -> AggregationService:
+        """Create AggregationService with mock db."""
+        return AggregationService(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_get_line_combinations_returns_list(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """get_line_combinations returns list of LineCombinationStats."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "sorted_players": [8477934, 8478402, 8478421],
+                    "season_id": 20242025,
+                    "situation_code": "5v5",
+                    "toi_seconds": 5000,
+                    "game_count": 30,
+                },
+                {
+                    "sorted_players": [8477934, 8478402, 8478421],
+                    "season_id": 20242025,
+                    "situation_code": "5v4",
+                    "toi_seconds": 500,
+                    "game_count": 25,
+                },
+            ]
+        )
+
+        result = await service.get_line_combinations(20242025, min_toi=300)
+
+        assert isinstance(result, list)
+        assert len(result) == 1  # Combined into one line
+        assert isinstance(result[0], LineCombinationStats)
+        assert result[0].player_ids == frozenset({8477934, 8478402, 8478421})
+        assert result[0].toi_together == 5500
+        assert result[0].game_count == 30
+        assert result[0].by_situation == {"5v5": 5000, "5v4": 500}
+
+    @pytest.mark.asyncio
+    async def test_get_line_combinations_sorted_by_toi(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """Line combinations are sorted by TOI descending."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "sorted_players": [8477934, 8478402, 8478421],
+                    "season_id": 20242025,
+                    "situation_code": "5v5",
+                    "toi_seconds": 3000,
+                    "game_count": 30,
+                },
+                {
+                    "sorted_players": [8477846, 8477904, 8478042],
+                    "season_id": 20242025,
+                    "situation_code": "5v5",
+                    "toi_seconds": 5000,
+                    "game_count": 25,
+                },
+            ]
+        )
+
+        result = await service.get_line_combinations(20242025)
+
+        assert len(result) == 2
+        assert result[0].toi_together == 5000  # Higher TOI first
+        assert result[1].toi_together == 3000
+
+
+class TestAggregationServicePlayerTOISummary:
+    """Tests for get_player_toi_summary method."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create mock database service."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_db: AsyncMock) -> AggregationService:
+        """Create AggregationService with mock db."""
+        return AggregationService(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_get_player_toi_summary_returns_aggregation(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """get_player_toi_summary returns SeasonAggregation."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "player_id": 8478402,
+                    "season_id": 20242025,
+                    "situation_code": "5v5",
+                    "toi_seconds": 50000,
+                    "game_count": 40,
+                },
+            ]
+        )
+
+        result = await service.get_player_toi_summary(8478402, 20242025)
+
+        assert result is not None
+        assert isinstance(result, SeasonAggregation)
+        assert result.player_id == 8478402
+
+    @pytest.mark.asyncio
+    async def test_get_player_toi_summary_returns_none_when_no_data(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """get_player_toi_summary returns None when player not found."""
+        mock_db.fetch.return_value = []
+
+        result = await service.get_player_toi_summary(9999999, 20242025)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_player_toi_summary_uses_provided_filters(
+        self, service: AggregationService, mock_db: AsyncMock
+    ) -> None:
+        """get_player_toi_summary applies provided filters."""
+        mock_db.fetch.return_value = make_records(
+            [
+                {
+                    "player_id": 8478402,
+                    "season_id": 20242025,
+                    "situation_code": "5v5",
+                    "toi_seconds": 45000,
+                    "game_count": 40,
+                },
+            ]
+        )
+
+        filters = AggregationFilters(situation_codes=["5v5"])
+        result = await service.get_player_toi_summary(8478402, 20242025, filters)
+
+        assert result is not None
+        # Filters should override player_ids with the specified player
+        assert result.player_id == 8478402


### PR DESCRIPTION
## Summary
- Implements Wave 5 aggregation functions for second-by-second analytics (#263)
- Adds `AggregationService` with flexible TOI rollups at shift, period, game, and season levels
- Includes `LineCombinationStats` for tracking line combination ice time

### Tasks Completed
- **T030**: Shift-level aggregation (continuous ice time segments)
- **T031**: Period-level aggregation
- **T032**: Game-level aggregation  
- **T033**: Season-level line combination stats

## Test plan
- [x] Unit tests pass (27 tests)
- [x] Integration tests pass (14 tests, 2 skipped for live DB)
- [x] Type checking passes (mypy)
- [x] Module imports verified

## Files Changed
| File | Description |
|------|-------------|
| `src/nhl_api/services/analytics/aggregation.py` | New aggregation service |
| `src/nhl_api/services/analytics/__init__.py` | Export new classes |
| `tests/unit/services/analytics/test_aggregation.py` | Unit tests |
| `tests/integration/analytics/test_aggregation.py` | Integration tests |

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)